### PR TITLE
Fixed typo

### DIFF
--- a/syntax_and_semantics/c_bindings/union.md
+++ b/syntax_and_semantics/c_bindings/union.md
@@ -30,7 +30,7 @@ A C union starts with all its fields set to "zero": integers and floats start at
 To avoid this initialization you can use `uninitialized`:
 
 ```crystal
-value = uninitialized U::IntOrFlaot
+value = uninitialized U::IntOrFloat
 value.some_int #=> some garbage value
 ```
 


### PR DESCRIPTION
Just fixed a typo on the union type name.