### PR TITLE
change camelcased to PascalCased

### DIFF
--- a/conventions/coding_style.md
+++ b/conventions/coding_style.md
@@ -4,7 +4,7 @@ This style is used in the standard library. You can use it in your own project t
 
 ## Naming
 
-__Type names__ are camelcased. For example:
+__Type names__ are PascalCased. For example:
 
 ```crystal
 class ParseError < Exception


### PR DESCRIPTION
The only online reference that I found for this was from Microsoft's own [naming conventions](https://msdn.microsoft.com/en-us/library/x2dbyw72(v=vs.71).aspx).

I always have to remember to camelCase for JavaScript as I am so used to PascalCase for classes and modules in Ruby and underscore-case for methods. So, when I read this I got confused. Maybe no one else would notice or they skip over it.

If this doesn't fit with the goals, feel free to close, just thought I'd submit it anyway.