### PR TITLE
add clone/cd instructions for building the book

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Crystal is a programming language with the following goals:
 ## Build
 
 ```
+$ git clone git@github.com:crystal-lang/crystal-book.git
+$ cd crystal-book
 $ npm install -g gitbook-cli
 $ gitbook build --gitbook=2.3.2
 ```


### PR DESCRIPTION
As of now the [Crystal docs](https://crystal-lang.org/docs/index.html) make no reference of this repo. It took me a bit of googling to figure out what I was supposed to build the book from. Adding instructions that point back to this repo would've been helpful, so here's a PR :smile:
