### PR TITLE
Recursive C structs do not need a forward declaration

### DIFF
--- a/syntax_and_semantics/c_bindings/struct.md
+++ b/syntax_and_semantics/c_bindings/struct.md
@@ -27,16 +27,16 @@ lib C
 end
 ```
 
-To declare recursive structs you can forward-declare them:
+Recursive structs work just like you expect them to:
 
 ```crystal
 lib C
-  # This is a forward declaration
-  struct Node
+  struct LinkedListNode
+    prev, _next : LinkedListNode*
   end
-
-  struct Node
-    node : Node*
+  
+  struct LinkedList
+    head : LinkedListNode*
   end
 end
 ```


### PR DESCRIPTION
As a matter of fact, the current code will error with a double declaration of `Node`. I have also updated the example to something a bit more relevant.