### PR TITLE
Various typo and grammar fixes

### DIFF
--- a/syntax_and_semantics/assignment.md
+++ b/syntax_and_semantics/assignment.md
@@ -1,6 +1,6 @@
 # Assignment
 
-Assignment is done with the equal (`=`) character.
+Assignment is done with the equals (`=`) character.
 
 ```crystal
 # Assigns to a local variable

--- a/syntax_and_semantics/attributes.md
+++ b/syntax_and_semantics/attributes.md
@@ -55,7 +55,7 @@ needed or used outside it.
 
 ## Packed
 
-Allows marking a [C struct](c_bindings/struct.html) as packed, which makes the alignment of the struct to be one byte, and that there is no padding between the elements. In non-packed structs, padding between field types is inserted according to the target system.
+Marks a [C struct](c_bindings/struct.html) as packed, which prevents the automatic insertion of padding bytes between fields in order to align the fields. This is typically only needed if the C library explicitly uses packed structs.
 
 ## AlwaysInline
 
@@ -70,7 +70,7 @@ end
 
 ## NoInline
 
-Tells the compiler to never inline a method call. This has no effect if the method yields.
+Tells the compiler to never inline a method call. This has no effect if the method yields, since functions with yield are always inlined.
 
 ```crystal
 @[NoInline]

--- a/syntax_and_semantics/attributes.md
+++ b/syntax_and_semantics/attributes.md
@@ -55,7 +55,7 @@ needed or used outside it.
 
 ## Packed
 
-Marks a [C struct](c_bindings/struct.html) as packed, which prevents the automatic insertion of padding bytes between fields in order to align the fields. This is typically only needed if the C library explicitly uses packed structs.
+Marks a [C struct](c_bindings/struct.html) as packed, which prevents the automatic insertion of padding bytes between fields. This is typically only needed if the C library explicitly uses packed structs.
 
 ## AlwaysInline
 
@@ -70,7 +70,7 @@ end
 
 ## NoInline
 
-Tells the compiler to never inline a method call. This has no effect if the method yields, since functions with yield are always inlined.
+Tells the compiler to never inline a method call. This has no effect if the method yields, since functions which yield are always inlined.
 
 ```crystal
 @[NoInline]

--- a/syntax_and_semantics/c_bindings/fun.md
+++ b/syntax_and_semantics/c_bindings/fun.md
@@ -63,7 +63,7 @@ lib LLVMIntrinsics
 end
 ```
 
-This can also be used to give shorter, nicer names to C functions, as these tend to be long and usually prefixed with the library name.
+This can also be used to give shorter, nicer names to C functions, as these tend to be long and are usually prefixed with the library name.
 
 The valid types to use in C bindings are:
 * Primitive types (`Int8`, ..., `Int64`, `UInt8`, ..., `UInt64`, `Float32`, `Float64`)

--- a/syntax_and_semantics/c_bindings/fun.md
+++ b/syntax_and_semantics/c_bindings/fun.md
@@ -45,7 +45,7 @@ end
 X.variadic(1, 2, 3, 4)
 ```
 
-Note that there are no implicit conversions (except `to_unsafe`, explained later) when invoking a C function: you must pass the exact type that is expected. For integers and floats you can use the various `to_...` methods.
+Note that there are no implicit conversions (except `to_unsafe`, which is explained later) when invoking a C function: you must pass the exact type that is expected. For integers and floats you can use the various `to_...` methods.
 
 Because method names in Crystal must start with a lowercase letter, `fun` names must also start with a lowercase letter. If you need to bind to a C function that starts with a capital letter you can give the function another name for Crystal:
 
@@ -63,7 +63,7 @@ lib LLVMIntrinsics
 end
 ```
 
-This can also be used to give shorter, nicer names to C functions, as these tend to be long and usually be prefixed with the library name.
+This can also be used to give shorter, nicer names to C functions, as these tend to be long and usually prefixed with the library name.
 
 The valid types to use in C bindings are:
 * Primitive types (`Int8`, ..., `Int64`, `UInt8`, ..., `UInt64`, `Float32`, `Float64`)
@@ -75,7 +75,7 @@ The valid types to use in C bindings are:
 * `NoReturn`: similar to `Void`, but the compiler understands that no code can be executed after that invocation.
 * Crystal structs marked with the `@[Extern]` attribute
 
-Refer to the [type gammar](../type_grammar.html) for the notation used in fun types.
+Refer to the [type grammar](../type_grammar.html) for the notation used in fun types.
 
 The standard library defines the [LibC](https://github.com/crystal-lang/crystal/blob/master/src/lib_c.cr) lib with aliases for common C types, like `int`, `short`, `size_t`. Use them in bindings like this:
 

--- a/syntax_and_semantics/case.md
+++ b/syntax_and_semantics/case.md
@@ -1,6 +1,6 @@
 # case
 
-A `case` is a control expression, which functions a bit like pattern matching. It allows writing a chain of if-else-if with a small change in semantic and some more powerful constructs.
+A `case` is a control expression which functions a bit like pattern matching. It allows writing a chain of if-else-if with a small change in semantic and some more powerful constructs.
 
 In its basic form, it allows matching a value against other values:
 

--- a/syntax_and_semantics/case.md
+++ b/syntax_and_semantics/case.md
@@ -1,6 +1,6 @@
 # case
 
-A `case` is a control expression that allows a sort of pattern matching. It allows writing a chain of if-else-if with a small change in semantic and some more powerful constructs.
+A `case` is a control expression, which functions a bit like pattern matching. It allows writing a chain of if-else-if with a small change in semantic and some more powerful constructs.
 
 In its basic form, it allows matching a value against other values:
 

--- a/syntax_and_semantics/default_values_named_arguments_splats_tuples_and_overloading.md
+++ b/syntax_and_semantics/default_values_named_arguments_splats_tuples_and_overloading.md
@@ -4,7 +4,7 @@ This is the formal specification of method and call arguments.
 
 ## Components a method definition
 
-A method definition consist of:
+A method definition consists of:
 
 * required and optional positional arguments
 * an optional splat argument, whose name can be empty

--- a/syntax_and_semantics/enum.md
+++ b/syntax_and_semantics/enum.md
@@ -148,6 +148,6 @@ end
 paint :red
 ```
 
-However, if the programmer makes a typo, say `:reed`, the error will only be caught at runtime, but writing `Color::Reed` will result in a compile-time error.
+However, if the programmer makes a typo, say `:reed`, the error will only be caught at runtime, while attempting to use `Color::Reed` will result in a compile-time error.
 
 The recommended thing to do is to use enums whenever possible, only use symbols for the internal implementation of an API, and avoid symbols for public APIs. But you are free to do what you want.

--- a/syntax_and_semantics/exception_handling.md
+++ b/syntax_and_semantics/exception_handling.md
@@ -238,4 +238,4 @@ array[4]  # raises because of IndexError
 array[4]? # returns nil because of index out of bounds
 ```
 
-The usual convention is to provide an alternative "question" method to signal that this variant of the method returns `nil` instead of raising. This lets the user choose whether she wants to deal with exceptions or with `nil`. Note, however, that this is not avaialble for every method out there, as exceptions are still the preferred way because they don't pollute the code with error handling logic.
+The usual convention is to provide an alternative "question" method to signal that this variant of the method returns `nil` instead of raising. This lets the user choose whether she wants to deal with exceptions or with `nil`. Note, however, that this is not available for every method out there, as exceptions are still the preferred way because they don't pollute the code with error handling logic.

--- a/syntax_and_semantics/literals/bool.md
+++ b/syntax_and_semantics/literals/bool.md
@@ -1,6 +1,6 @@
 # Bool
 
-[Bool](http://crystal-lang.org/api/Bool.html) has only two possible values: `true` and `false`. They are constructed using these literals:
+[Bool](http://crystal-lang.org/api/Bool.html) has only two possible values: `true` and `false`. They are constructed using the following literals:
 
 
 ```crystal

--- a/syntax_and_semantics/literals/char.md
+++ b/syntax_and_semantics/literals/char.md
@@ -13,7 +13,7 @@ It is created by enclosing an UTF-8 character in single quotes.
 'あ'
 ```
 
-You can use a backslash to denote some characters:
+You can use a backslash to denote some special characters:
 
 ```crystal
 '\'' # single quote

--- a/syntax_and_semantics/literals/floats.md
+++ b/syntax_and_semantics/literals/floats.md
@@ -28,5 +28,5 @@ The underscore `_` before the suffix is optional.
 Underscores can be used to make some numbers more readable:
 
 ```crystal
-1_000_000.111_111 # better than 1000000.111111
+1_000_000.111_111 # a lot more readable than 1000000.111111, yet functionally the same
 ```

--- a/syntax_and_semantics/literals/hash.md
+++ b/syntax_and_semantics/literals/hash.md
@@ -7,7 +7,7 @@ A [Hash](http://crystal-lang.org/api/Hash.html) representing a mapping of keys o
 {1 => 2, 'a' => 3}   # Hash(Int32 | Char, Int32)
 ```
 
-A Hash can have mixed types, both for the keys and values, meaning `K`/`V` will be union types, but these are determined when the hash is created, either by specifying `K` and `V` or by using a hash literal. In the latter case, `K` will be set to the union of the hash literal keys, and `V` will be set to the union of the hash literal values.
+A Hash can have mixed types, both for the keys and values, meaning `K`/`V` will be union types. These types are determined when the hash is created, either by specifying `K` and `V` or by using a hash literal. In the latter case, `K` will be set to the union of the hash literal keys, and `V` will be set to the union of the hash literal values.
 
 When creating an empty hash you must always specify `K` and `V`:
 

--- a/syntax_and_semantics/literals/named_tuple.md
+++ b/syntax_and_semantics/literals/named_tuple.md
@@ -15,7 +15,7 @@ To denote a named tuple type you can write:
 NamedTuple(x: Int32, y: String)
 ```
 
-In type restrictions, generic type arguments and other places where a type is expected, you can use a shorter syntax, as explained in the [type](../type_grammar.html):
+In type restrictions, generic type arguments and other places where a type is expected, you can use a shorter syntax, as explained in the [type grammar](../type_grammar.html):
 
 ```crystal
 # An array of named tuples of x: Int32, y: String

--- a/syntax_and_semantics/literals/nil.md
+++ b/syntax_and_semantics/literals/nil.md
@@ -1,6 +1,6 @@
 # Nil
 
-The [Nil](http://crystal-lang.org/api/Nil.html) type has only one possible value:
+The [Nil](http://crystal-lang.org/api/Nil.html) type is used to represent the absence of a value, not unlike `null` in other languages. It only has a single value:
 
 ```crystal
 nil

--- a/syntax_and_semantics/literals/string.md
+++ b/syntax_and_semantics/literals/string.md
@@ -8,7 +8,7 @@ A String is typically created with a string literal, enclosing UTF-8 characters 
 "hello world"
 ```
 
-A backslash can be used to denote some characters inside the string:
+A backslash can be used to denote various special characters inside the string:
 
 ```crystal
 "\"" # double quote
@@ -30,7 +30,7 @@ You can use a backslash followed by at most three digits to denote a code point 
 "\1"   # string with one character with code point 1
 ```
 
-You can use a backslash followed by an *u* and four hexadecimal characters to denote a unicode codepoint written:
+You can use a backslash followed by an *u* and four hexadecimal characters to denote a unicode codepoint:
 
 ```crystal
 "\u0041" # == "A"

--- a/syntax_and_semantics/literals/tuple.md
+++ b/syntax_and_semantics/literals/tuple.md
@@ -18,7 +18,7 @@ To denote a tuple type you can write:
 Tuple(Int32, String, Char)
 ```
 
-In type restrictions, generic type arguments and other places where a type is expected, you can use a shorter syntax, as explained in the [type](../type_grammar.html):
+In type restrictions, generic type arguments and other places where a type is expected, you can use a shorter syntax, as explained in the [type grammar](../type_grammar.html):
 
 ```crystal
 # An array of tuples of Int32, String and Char

--- a/syntax_and_semantics/not.md
+++ b/syntax_and_semantics/not.md
@@ -2,7 +2,7 @@
 
 The `!` operator returns a `Bool` that results from negating the [truthyness](truthy_and_falsey_values.html) of a value.
 
-When used in an `if` in conjuntion with a variable, `is_a?`, `responds_to?` or `nil?` the compiler will restrict the types accordingly:
+When used in an `if` in conjunction with a variable, `is_a?`, `responds_to?` or `nil?` the compiler will restrict the types accordingly:
 
 ```crystal
 a = some_condition ? nil : 3

--- a/syntax_and_semantics/requiring_files.md
+++ b/syntax_and_semantics/requiring_files.md
@@ -10,7 +10,7 @@ Once a file is required, the compiler remembers its absolute path and later `req
 
 This looks up "filename" in the require path.
 
-By default the require path is the location of the standard library that comes with the compiler, and the "libs" directory relative to the current working directory (given by `pwd` in a unix shell). These are the only places that are looked up.
+By default the require path is the location of the standard library that comes with the compiler, and the "libs" directory relative to the current working directory (given by `pwd` in a Unix shell). These are the only places that are looked up.
 
 The lookup goes like this:
 

--- a/syntax_and_semantics/visibility.md
+++ b/syntax_and_semantics/visibility.md
@@ -154,7 +154,7 @@ This allows you to define helper methods in a file that will only be known in th
 
 ## Private top-level types
 
-A `private` top-level type is only visibile in the current file.
+A `private` top-level type is only visible in the current file.
 
 ```crystal
 # In file one.cr


### PR DESCRIPTION
Although there are probably a few typos left, most of the ones in `syntax_and_schemantics` have been fixed. I've also taken the liberty to reword a few sentences, but no major other changes.
