### PR TITLE
Update HTTP server example to show it listens on 127.0.0.1 by default

### DIFF
--- a/overview/http_server.md
+++ b/overview/http_server.md
@@ -10,7 +10,7 @@ server = HTTP::Server.new(8080) do |context|
   context.response.print "Hello world! The time is #{Time.now}"
 end
 
-puts "Listening on http://0.0.0.0:8080"
+puts "Listening on http://127.0.0.1:8080"
 server.listen
 ```
 
@@ -34,7 +34,7 @@ The above code will make sense once you read the whole documentation, but we can
     ...
     Time.now
     ...
-    puts "Listening on http://0.0.0.0:8080"
+    puts "Listening on http://127.0.0.1:8080"
     ...
     server.listen
     ```


### PR DESCRIPTION
Triggered by discussion on: https://github.com/crystal-lang/crystal/issues/3382
