### PR TITLE
Fix contributing link on source installation page.

### DIFF
--- a/installation/from_source_repository.md
+++ b/installation/from_source_repository.md
@@ -14,6 +14,6 @@ and you're ready to start hacking.
 
 To build your own version of the compiler, run `make`. The new compiler will be placed at `.build/crystal`.
 
-Make sure to install [all the required libraries](https://github.com/crystal-lang/crystal/wiki/All-required-libraries). You might also want to read the [contributing guide](https://github.com/crystal-lang/crystal/blob/master/Contributing.md).
+Make sure to install [all the required libraries](https://github.com/crystal-lang/crystal/wiki/All-required-libraries). You might also want to read the [contributing guide](https://github.com/crystal-lang/crystal/blob/master/CONTRIBUTING.md).
 
 Inside the repository you will also find a wrapper script at `bin/crystal`. This script will execute the global installed compiler or the one that you just compiled (if present).


### PR DESCRIPTION
The `contributing` link on the installation from sources page was broken, this PR just fixes it.