### PR TITLE
Change wording about what we can do with a Person

### DIFF
--- a/syntax_and_semantics/methods_and_instance_variables.md
+++ b/syntax_and_semantics/methods_and_instance_variables.md
@@ -10,7 +10,7 @@ class Person
 end
 ```
 
-Right now, we can't do much with a person: create it with a name, ask for its name and for its age, which will always be zero. So lets add a method that makes a person become older:
+Right now, we can't do much with a person aside from create it with a name. Its age will always be zero. So lets add a method that makes a person become older:
 
 ```crystal
 class Person


### PR DESCRIPTION
This is a PR that represents something discussed in https://github.com/crystal-lang/crystal-book/issues/47...

The [methods_and_instance_variables.md](https://github.com/crystal-lang/crystal-book/blob/master/syntax_and_semantics/methods_and_instance_variables.md) there's a code snippet:

```crystal
class Person
  def initialize(@name : String)
    @age = 0
  end
end
```

Followed by:

> Right now, we can't do much with a person: create it with a name, ask for its name and for its age, which will always be zero. So lets add a method that makes a person become older:

But - really - we can't query the state of `@age` or `@name` without using `getter :age, :name`.

If you feel like this is big enough to address I can send a PR...perhaps...

> Right now, we can't do much with a person aside from create it with a name. Its age will always be zero. So lets add a method that makes a person become older.