### PR TITLE
Add 'Install required libraries' on Ubuntu install

### DIFF
--- a/installation/on_debian_and_ubuntu.md
+++ b/installation/on_debian_and_ubuntu.md
@@ -25,6 +25,30 @@ Once the repository is configured you're ready to install Crystal:
 sudo apt-get install crystal
 ```
 
+## Install required libraries
+Before you can use Crystal you'll need to install some required libraries:
+
+```
+sudo apt-get install \
+  libbsd-dev \
+  libedit-dev \
+  libevent-core-2.0-5 \
+  libevent-dev \
+  libevent-extra-2.0-5 \
+  libevent-openssl-2.0-5 \
+  libevent-pthreads-2.0-5 \
+  libgmp-dev \
+  libgmpxx4ldbl \
+  libssl-dev \
+  libxml2-dev \
+  libyaml-dev \
+  libreadline-dev \
+  automake \
+  libtool \
+  git \
+  llvm
+```
+
 ## Upgrade
 
 When a new Crystal version is released you can upgrade your system using:


### PR DESCRIPTION
I got frustrated that the required libraries weren't referenced here when I installed Crystal.

I copied from the wiki at https://github.com/crystal-lang/crystal/wiki/All-required-libraries

It would be great if this was also added to the other install pages, but since this is my first rodeo with pull-requests I'd like to keep it simple (for me).