### PR TITLE
Improve "white space" pages + minor edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,20 @@ Crystal is a programming language with the following goals:
 * Have compile-time evaluation and generation of code, to avoid boilerplate code.
 * Compile to efficient native code.
 
-## Build
+If you are new to Crystal, welcome! We recommend you get started by [installing the compiler](../installation/README.md) and learning [how to use it](../using_the_compiler/README.md).
+
+If you have any questions, please find us through our [Community](https://crystal-lang.org/community/) page.
+
+## Contribute
+
+Do you consider yourself a helpful person? If you find bugs or sections
+which need more clarification you're welcome to contribute to this
+documentation. You can submit a pull request to this repository:
+https://github.com/crystal-lang/crystal-book
+
+Thank you very much!
+
+## Building docs
 
 ```
 $ npm install -g gitbook-cli@2.3.0
@@ -40,11 +53,3 @@ gitbook_1  | Restart after change in file node_modules/.bin
 ```
 
 
-## Contribute
-
-Do you consider yourself a helpful person? If you find bugs or sections
-which need more clarification you're welcome to contribute to this
-documentation. You can submit a pull request to this repository:
-https://github.com/crystal-lang/crystal-book
-
-Thank you very much!

--- a/guides/README.md
+++ b/guides/README.md
@@ -1,3 +1,6 @@
 # Guides
 
-Read these guides to get the best out of Crystal.
+The Crystal community has written guides on key parts of the Crystal language. We expect more to come as the language and community both develop. In the mean time, check them out below:
+
+* [Performance](performance.html)
+* [Concurrency](concurrency.html)

--- a/installation/README.md
+++ b/installation/README.md
@@ -9,4 +9,4 @@ Once you install the compiler using one of the following methods, make sure to r
 * [From a tar.gz](from_a_targz.html)
 * [From sources](from_source_repository.html)
 
-
+If you need help installing the compiler, please find us through our [Community](https://crystal-lang.org/community/) page.

--- a/installation/on_mac_osx_using_homebrew.md
+++ b/installation/on_mac_osx_using_homebrew.md
@@ -7,7 +7,7 @@ brew update
 brew install crystal-lang
 ```
 
-If you're planning to contribute to the project you might find useful to install LLVM as well. So replace the last line with:
+If you're planning to contribute to the project you might find useful to install LLVM as well. To do so, replace the last line with:
 
 ```
 brew install crystal-lang --with-llvm

--- a/overview/README.md
+++ b/overview/README.md
@@ -16,4 +16,7 @@ s = "hello"
 # s : String
 ```
 
-Let's start with two examples to familiarize ourselves with the language.
+Let's start with two examples to familiarize ourselves with the language:
+
+* [Hello World!](hello_world.html)
+* [HTTP Server](http_server.html)

--- a/overview/hello_world.md
+++ b/overview/hello_world.md
@@ -3,8 +3,8 @@
 The classic "hello world" program looks like this in Crystal:
 
 ```crystal
-puts "Hello world!"
+puts "Hello world!" #=> Hello world!
 ```
 
-From this you can see that the main routine is simply the program itself: there's no need to define a "main" function or something similar.
+From this you can see that the main routine is simply the program itself; there's no need to define a "main" function or something similar.
 

--- a/syntax_and_semantics/README.md
+++ b/syntax_and_semantics/README.md
@@ -16,4 +16,4 @@ The program’s source code must be encoded in UTF-8.
 * [Exception handling](exception_handling.html)
 * [Compile-time flags](compile_time_flags.html)
 * [Macros](macros.html)
-* [C bindings](c_bindings.html)
+* [C bindings](../c_bindings/README.md)

--- a/syntax_and_semantics/README.md
+++ b/syntax_and_semantics/README.md
@@ -1,3 +1,19 @@
 # Syntax and Semantics
 
 The program’s source code must be encoded in UTF-8.
+
+* [Comments](comments.html)
+* [Literals](literals.html)
+* [Assignment](assignment.html)
+* [Local variables](local_variables.html)
+* [Union types](union_types.html)
+* [Control expressions](control_expressions.html)
+* [Types and methods](types_and_methods.html)
+* [Type reflection](type_reflection.html)
+* [Attributes](attributes.html)
+* [Requiring files](requiring_files.html)
+* [Low-level primitives](low_level_primitives.html)
+* [Exception handling](exception_handling.html)
+* [Compile-time flags](compile_time_flags.html)
+* [Macros](macros.html)
+* [C bindings](c_bindings.html)

--- a/syntax_and_semantics/assignment.md
+++ b/syntax_and_semantics/assignment.md
@@ -13,7 +13,7 @@ local = 1
 @@class = 3
 ```
 
-Each of the above kinds of variables will be explained later on.
+Each of the above kinds of variables will be explained in the [Local variables](local_variables.html), [Methods and instance variables](methods_and_instance_variables.html) and [Class variables](class_variables.html) pages.
 
 Some syntax sugar that contains the `=` character is available:
 
@@ -49,7 +49,7 @@ objects.[](2, 3)
 objects[2, 3]
 ```
 
-The `=` operator syntax sugar is also available to setters and indexers. Note that `||` and `&&` use the `[]?` method to check for key prescence.
+The `=` operator syntax sugar is also available to setters and indexers. Note that `||` and `&&` use the `[]?` method to check for key presence.
 
 ```crystal
 person.age += 1        # same as: person.age = person.age + 1

--- a/syntax_and_semantics/c_bindings/README.md
+++ b/syntax_and_semantics/c_bindings/README.md
@@ -3,3 +3,15 @@
 Crystal allows you to bind to existing C libraries without writing a single line in C.
 
 Additionally, it provides some conveniences like `out` and `to_unsafe` so writing bindings is as painless as possible.
+
+* [lib](lib.html)
+* [fun](fun.html)
+* [struct](struct.html)
+* [union](union.html)
+* [enum](enum.html)
+* [Variables](variables.html)
+* [Constants](constants.html)
+* [type](type.html)
+* [alias](alias.html)
+* [Callbacks](callbacks.html)
+

--- a/syntax_and_semantics/classes_and_methods.md
+++ b/syntax_and_semantics/classes_and_methods.md
@@ -8,3 +8,18 @@ end
 ```
 
 Class names, and every type name, begin with a capital letter in Crystal.
+
+* [new, initialize and allocate](new,_initialize_and_allocate.html)
+* [Methods and instance variables](methods_and_instance_variables.html)
+* [Type inference](type_inference.html)
+* [Overloading](overloading.html)
+* [Default values and named arguments](default_and_named_arguments.html)
+* [Splats and tuples](splats_and_tuples.html)
+* [Type restrictions](type_restrictions.html)
+* [Return types](return_types.html)
+* [Method arguments](method_arguments.html)
+* [Operators](operators.html)
+* [Visibility](visibility.html)
+* [Inheritance](inheritance.html)
+* [Class variables](class_variables.html)
+* [finalize](finalize.html)

--- a/syntax_and_semantics/control_expressions.md
+++ b/syntax_and_semantics/control_expressions.md
@@ -1,3 +1,14 @@
 # Control expressions
 
-Before talking about control expressions we need to know what *truthy* and *falsey* values are.
+Before exploring control expressions, you may want to learn about Crystal's [truthy and falsey values](truthy_and_falsey_values.html).
+
+Crystal has a variety of ways to control execution. The following control expressions are available:
+
+* [if / else / elsif](if_else_elsif.html)
+* [unless](unless.html)
+* [case](case.html)
+* [while](while.html)
+    - [break](break.html)
+    - [next](next.html)
+* [&& (and)](and.html)
+* [|| (or)](or.html)

--- a/syntax_and_semantics/if_else_elsif.md
+++ b/syntax_and_semantics/if_else_elsif.md
@@ -1,4 +1,4 @@
-# if
+# if / else / elsif
 
 An `if` evaluates the `then` branch if its condition is *truthy*, and evaluates the `else` branch, if there’s any, otherwise.
 

--- a/syntax_and_semantics/literals.md
+++ b/syntax_and_semantics/literals.md
@@ -14,5 +14,5 @@ Several literals are available for creating many basic types in the language:
 * [Range](../literals/range.md)
 * [Regex](../literals/regex.md)
 * [Tuple](../literals/tuple.md)
-* [NamedTuple](../literals/namedtuple.md)
+* [NamedTuple](../literals/named_tuple.md)
 * [Proc](../literals/proc.md)

--- a/syntax_and_semantics/literals.md
+++ b/syntax_and_semantics/literals.md
@@ -1,3 +1,18 @@
 # Literals
 
-Several literals are available for creating many basic types in the language.
+Several literals are available for creating many basic types in the language:
+
+* [Nil](../literals/nil.md)
+* [Bool](../literals/bool.md)
+* [Integers](../literals/integers.md)
+* [Floats](../literals/floats.md)
+* [Char](../literals/char.md)
+* [String](../literals/string.md)
+* [Symbol](../literals/symbol.md)
+* [Array](../literals/array.md)
+* [Hash](../literals/hash.md)
+* [Range](../literals/range.md)
+* [Regex](../literals/regex.md)
+* [Tuple](../literals/tuple.md)
+* [NamedTuple](../literals/namedtuple.md)
+* [Proc](../literals/proc.md)

--- a/syntax_and_semantics/literals/array.md
+++ b/syntax_and_semantics/literals/array.md
@@ -7,7 +7,7 @@ An [Array](http://crystal-lang.org/api/Array.html) is a generic type containing 
 [1, "hello", 'x'] # Array(Int32 | String | Char)
 ```
 
-An Array can have mixed types, meaning `T` will be a union of types, but these are determined when the array is created, either by specifying T or by using an array literal. In the latter case, T will be set to the union of the array literal elements.
+An Array can have mixed types, meaning `T` will be a [union of types](../syntax_and_semantics/union_types.html), but these are determined when the array is created, either by specifying T or by using an array literal. In the latter case, T will be set to the union of the array literal elements.
 
 When creating an empty array you must always specify T:
 
@@ -34,7 +34,7 @@ Arrays of symbols can be created with a special syntax:
 
 ## Array-like types
 
-You can use a special array literal syntax with other types too, as long as they define an argless `new` method and a `<<` method:
+You can use a special array literal syntax with other types too, as long as they define an argument-less `new` method and a `<<` method:
 
 ```crystal
 MyType{1, 2, 3}

--- a/syntax_and_semantics/literals/hash.md
+++ b/syntax_and_semantics/literals/hash.md
@@ -7,7 +7,7 @@ A [Hash](http://crystal-lang.org/api/Hash.html) representing a mapping of keys o
 {1 => 2, 'a' => 3}   # Hash(Int32 | Char, Int32)
 ```
 
-A Hash can have mixed types, both for the keys and values, meaning `K`/`V` will be union types. These types are determined when the hash is created, either by specifying `K` and `V` or by using a hash literal. In the latter case, `K` will be set to the union of the hash literal keys, and `V` will be set to the union of the hash literal values.
+A Hash can have mixed types, both for the keys and values, meaning `K`/`V` will be [union types](../syntax_and_semantics/union_types.html). These types are determined when the hash is created, either by specifying `K` and `V` or by using a hash literal. In the latter case, `K` will be set to the union of the hash literal keys, and `V` will be set to the union of the hash literal values.
 
 When creating an empty hash you must always specify `K` and `V`:
 
@@ -18,7 +18,7 @@ When creating an empty hash you must always specify `K` and `V`:
 
 ## Hash-like types
 
-You can use a special hash literal syntax with other types too, as long as they define an argless `new` method and a `[]=` method:
+You can use a special hash literal syntax with other types too, as long as they define an argument-less `new` method and a `[]=` method:
 
 ```crystal
 MyType{"foo" => "bar"}

--- a/syntax_and_semantics/literals/range.md
+++ b/syntax_and_semantics/literals/range.md
@@ -3,8 +3,8 @@
 A [Range](http://crystal-lang.org/api/Range.html) is typically constructed with a range literal:
 
 ```crystal
-x..y  # an inclusive range, in mathematics: [x, y]
-x...y # an exclusive range, in mathematics: [x, y)
+x..y  # an inclusive range, in mathematics: [x, y], from x to y, including both x and y
+x...y # an exclusive range, in mathematics: [x, y), from x to y, including x but not y
 ```
 
 An easy way to remember which one is inclusive and which one is exclusive it to think of the extra dot as if it pushes *y* further away, thus leaving it outside of the range.

--- a/syntax_and_semantics/low_level_primitives.md
+++ b/syntax_and_semantics/low_level_primitives.md
@@ -1,3 +1,8 @@
 # Low-level primitives
 
 Some low-level primitives are provided. They are mostly useful for interfacing with C libraries and for low-level code.
+
+* [pointerof](pointerof.html)
+* [sizeof](sizeof.html)
+* [instance_sizeof](instance_sizeof.html)
+* [Uninitialized variable declaration](declare_var.html)

--- a/syntax_and_semantics/type_reflection.md
+++ b/syntax_and_semantics/type_reflection.md
@@ -1,3 +1,10 @@
 # Type reflection
 
-Crystal provides basic methods to do type reflection, casting and introspection.
+Crystal provides basic methods to do type reflection, casting and introspection:
+
+* [is_a?](is_a.html)
+* [nil?](nil_question.html)
+* [responds_to?](responds_to.html)
+* [as](as.html)
+* [as?](as_question.html)
+* [typeof](typeof.html)

--- a/syntax_and_semantics/types_and_methods.md
+++ b/syntax_and_semantics/types_and_methods.md
@@ -1,3 +1,14 @@
 # Types and methods
 
 The next sections will assume you know what [object oriented programming](http://en.wikipedia.org/wiki/Object-oriented_programming) is, as well as the concepts of [classes](http://en.wikipedia.org/wiki/Class_%28computer_programming%29) and [methods](http://en.wikipedia.org/wiki/Method_%28computer_programming%29).
+
+* [Everything is an object](everything_is_an_object.html)
+* [The Program](the_program.html)
+* [Classes and methods](classes_and_methods.html)
+* [Modules](modules.html)
+* [Generics](generics.html)
+* [Structs](structs.html)
+* [Constants](constants.html)
+* [Enums](enums.html)
+* [Blocks and Procs](blocks_and_procs.html)
+* [alias](alias.html)


### PR DESCRIPTION
This PR:

1. Repurposes some section opener pages as tables of contents for their sections. A few of the section opener pages were very empty, sometimes consisting of a single line. For hygiene, I added the list of pages that follow for each section. E.g., syntax and semantics, control expressions

2. Renames the `if` page to `if / else / elsif`. I think it's clearer but I concede that other docs will also leave it as just `if`.

3. Makes minor changes in wording and linking