### PR TITLE
added note to centos install about installing readline too

### DIFF
--- a/installation/on_redhat_and_centos.md
+++ b/installation/on_redhat_and_centos.md
@@ -29,6 +29,13 @@ Once the repository is configured you're ready to install Crystal:
 sudo yum install crystal
 ```
 
+### Note
+If you see `/usr/bin/ld: cannot find -lreadline` when compiling you will want to install the readline development libraries:
+
+```
+sudo yum install -y readline-devel
+```
+
 ## Upgrade
 
 When a new Crystal version is released you can upgrade your system using:


### PR DESCRIPTION
added the following note to the CentOS install instructions because it's exactly what I had to do on our ancient version of CentOS. After that it worked fine.

----

### Note
If you see `/usr/bin/ld: cannot find -lreadline` when compiling you will want to install the readline development libraries:

```
sudo yum install -y readline-devel
```
