### PR TITLE
Add more real world usage of Object's finalizer

### DIFF
--- a/syntax_and_semantics/finalize.md
+++ b/syntax_and_semantics/finalize.md
@@ -1,19 +1,30 @@
 # finalize
 
-If a class defines a `finalize` method, when an instance of that class is garbage-collected that method will be invoked:
+If a class defines a `finalize` method, when an instance of that class is
+garbage-collected that method will be invoked:
 
 ```crystal
 class Foo
   def finalize
     # Invoked when Foo is garbage-collected
-    puts "Bye bye from #{self}!"
+    # Use to release non-managed resources (ie. C libraries, structs)
   end
-end
-
-# Prints "Bye bye ...!" for ever
-loop do
-  Foo.new
 end
 ```
 
-**Note:** the `finalize` method will only be invoked once the object has been fully initialized via the `initialize` method. If an exception is raised inside the `initialize` method, `finalize` won't be invoked. If your class defines a finalizer, be sure to catch any exceptions that might be raised in the `initialize` methods and free resources.
+Use this method to release resources allocated by external libraries that are
+not directly managed by Crystal garbage collector.
+
+Examples of this can be found in [`IO::FileDescriptor#finalize`](https://crystal-lang.org/api/IO/FileDescriptor.html#finalize-instance-method)
+or [`OpenSSL::Digest#finalize`](https://crystal-lang.org/api/OpenSSL/Digest.html#finalize-instance-method).
+
+**Notes**:
+
+- The `finalize` method will only be invoked once the object has been
+fully initialized via the `initialize` method. If an exception is raised
+inside the `initialize` method, `finalize` won't be invoked. If your class
+defines a `finalize` method, be sure to catch any exceptions that might be
+raised in the `initialize` methods and free resources.
+
+- Allocating any new object instances during garbage-collection might result
+in undefined behavior and most likely crashing your program.


### PR DESCRIPTION
Current documentation suggest `finalizer` might be used for regular code that developers might write.

The changes suggested here aims to indicate real world usage of `finalize` and include references from the standard library that showcase it's usage.

Also warn about possible undefined behavior when attempting to allocate memory during the garbage-collection phase.

Ref crystal-lang/crystal#4013

Thank you. :heart: :heart: :heart: 