### PR TITLE
Remove `then` branch in `if` documentation

### DIFF
--- a/syntax_and_semantics/if.md
+++ b/syntax_and_semantics/if.md
@@ -1,6 +1,7 @@
 # if
 
-An `if` evaluates the `then` branch if its condition is *truthy*, and evaluates the `else` branch, if there’s any, otherwise.
+An `if` evaluates the given branch if its condition is *truthy*, otherwise, it
+evaluates the `else` branch, if present.
 
 ```crystal
 a = 1


### PR DESCRIPTION
Clear out confusion caused by `then` being used as branch name of `if` documentation.

Fixes crystal-lang/crystal#4117

Thank you. :heart: :heart: :heart: 