### PR TITLE
Removes octal escape from Char literal doc

### DIFF
--- a/syntax_and_semantics/literals/char.md
+++ b/syntax_and_semantics/literals/char.md
@@ -26,15 +26,6 @@ You can use a backslash to denote some special characters:
 '\v' # vertical tab
 ```
 
-You can use a backslash followed by at most three digits to denote a code point written in octal:
-
-```crystal
-'\101' # == 'A'
-'\123' # == 'S'
-'\12'  # == '\n'
-'\1'   # code point 1
-```
-
 You can use a backslash followed by an *u* and four hexadecimal characters to denote a unicode codepoint written:
 
 ```crystal


### PR DESCRIPTION
Removed descriptions about octal escape from document of the Char literal.
It has already been removed at [v0.21.0](https://github.com/crystal-lang/crystal/releases/tag/0.21.0).