### PR TITLE
adds a short explanation for *case equality*

### DIFF
--- a/syntax_and_semantics/case.md
+++ b/syntax_and_semantics/case.md
@@ -25,9 +25,7 @@ else
 end
 ```
 
-For comparing an expression against a `cause`'s value the *case equality operator* `===`. It is defined as a method on [`Object#===`](https://crystal-lang.org/api/Object.html#%3D%3D%3D%28other%29-instance-method) and can be overriden by subclasses to provide meaningful semantics in case statements.
-
-So the exact meaning of the `===` operator is defined by each type. For example, [`Class#===`](https://crystal-lang.org/api/Class.html#%3D%3D%3D%28other%29-instance-method) means an object is an instance of that class, [`Regex#===`](https://crystal-lang.org/api/Regex.html#%3D%3D%3D%28other%3AString%29-instance-method) that a string matches and [`Range#===`](https://crystal-lang.org/api/Range.html#%3D%3D%3D%28value%29-instance-method) that a number is included in that range.
+For comparing an expression against a `cause`'s value the *case equality operator* `===` is used. It is defined as a method on [`Object`](https://crystal-lang.org/api/Object.html#%3D%3D%3D%28other%29-instance-method) and can be overriden by subclasses to provide meaningful semantics in case statements. For example, [`Class`](https://crystal-lang.org/api/Class.html#%3D%3D%3D%28other%29-instance-method) defines case equality as when an object is an instance of that class, [`Regex`](https://crystal-lang.org/api/Regex.html#%3D%3D%3D%28other%3AString%29-instance-method) as when the value matches the regular expression and [`Range`](https://crystal-lang.org/api/Range.html#%3D%3D%3D%28value%29-instance-method) as when the value is included in that range.
 
 If a `when`'s expression is a type, `is_a?` is used. Additionally, if the case expression is a variable or a variable assignment the type of the variable is restricted:
 

--- a/syntax_and_semantics/case.md
+++ b/syntax_and_semantics/case.md
@@ -25,7 +25,9 @@ else
 end
 ```
 
-Note that `===` is used for comparing an expression against a `case`'s value.
+For comparing an expression against a `cause`'s value the *case equality operator* `===`. It is defined as a method on [`Object#===`](https://crystal-lang.org/api/Object.html#%3D%3D%3D%28other%29-instance-method) and can be overriden by subclasses to provide meaningful semantics in case statements.
+
+So the exact meaning of the `===` operator is defined by each type. For example, [`Class#===`](https://crystal-lang.org/api/Class.html#%3D%3D%3D%28other%29-instance-method) means an object is an instance of that class, [`Regex#===`](https://crystal-lang.org/api/Regex.html#%3D%3D%3D%28other%3AString%29-instance-method) that a string matches and [`Range#===`](https://crystal-lang.org/api/Range.html#%3D%3D%3D%28value%29-instance-method) that a number is included in that range.
 
 If a `when`'s expression is a type, `is_a?` is used. Additionally, if the case expression is a variable or a variable assignment the type of the variable is restricted:
 

--- a/syntax_and_semantics/case.md
+++ b/syntax_and_semantics/case.md
@@ -25,7 +25,7 @@ else
 end
 ```
 
-For comparing an expression against a `cause`'s value the *case equality operator* `===` is used. It is defined as a method on [`Object`](https://crystal-lang.org/api/Object.html#%3D%3D%3D%28other%29-instance-method) and can be overriden by subclasses to provide meaningful semantics in case statements. For example, [`Class`](https://crystal-lang.org/api/Class.html#%3D%3D%3D%28other%29-instance-method) defines case equality as when an object is an instance of that class, [`Regex`](https://crystal-lang.org/api/Regex.html#%3D%3D%3D%28other%3AString%29-instance-method) as when the value matches the regular expression and [`Range`](https://crystal-lang.org/api/Range.html#%3D%3D%3D%28value%29-instance-method) as when the value is included in that range.
+For comparing an expression against a `case`'s value the *case equality operator* `===` is used. It is defined as a method on [`Object`](https://crystal-lang.org/api/Object.html#%3D%3D%3D%28other%29-instance-method) and can be overriden by subclasses to provide meaningful semantics in case statements. For example, [`Class`](https://crystal-lang.org/api/Class.html#%3D%3D%3D%28other%29-instance-method) defines case equality as when an object is an instance of that class, [`Regex`](https://crystal-lang.org/api/Regex.html#%3D%3D%3D%28other%3AString%29-instance-method) as when the value matches the regular expression and [`Range`](https://crystal-lang.org/api/Range.html#%3D%3D%3D%28value%29-instance-method) as when the value is included in that range.
 
 If a `when`'s expression is a type, `is_a?` is used. Additionally, if the case expression is a variable or a variable assignment the type of the variable is restricted:
 

--- a/syntax_and_semantics/operators.md
+++ b/syntax_and_semantics/operators.md
@@ -59,27 +59,25 @@ v1 = Vector2.new(1, 2)
 
 ## Binary operators
 
-```crystal
-+   # addition
--   # subtraction
-*   # multiplication
-/   # division
-%   # modulo
-&   # bitwise and
-|   # bitwise or
-^   # bitwise xor
-**  # exponentiation
-<<  # shift left, append
->>  # shift right
-==  # equals
-!=  # not equals
-<   # less
-<=  # less or equal
->   # greater
->=  # greater or equal
-<=> # comparison
-=== # case equality
-```
+* `+` – addition
+* `-` – subtraction
+* `*` – multiplication
+* `/` – division
+* `%` – modulo
+* `&` – bitwise and
+* `|` – bitwise or
+* `^` – bitwise xor
+* `**` – exponentiation
+* `<<` – shift left, append
+* `>>` – shift right
+* `==` – equals
+* `!=` – not equals
+* `<` – less
+* `<=` – less or equal
+* `>` – greater
+* `>=` – greater or equal
+* `<=>` – comparison
+* `===` – [case equality](case.html)
 
 ## Indexing
 


### PR DESCRIPTION
As discussed in crystal-lang/crystal#4295 there is no explanation for case equality in the docs. This tries to provide at least a simple understanding of this concept.