### PR TITLE
Change curl comamnd in Bash on Ubuntu on Windows installation to include -sSL flags

### DIFF
--- a/installation/on_bash_on_ubuntu_on_windows.md
+++ b/installation/on_bash_on_ubuntu_on_windows.md
@@ -9,7 +9,7 @@ Don't forget - **this is highly experimental**.
 First you have to add the repository to your APT configuration. For easy setup just run in your command line:
 
 ```
-curl https://dist.crystal-lang.org/apt/setup.sh | sudo bash
+curl -sSL https://dist.crystal-lang.org/apt/setup.sh | sudo bash
 ```
 
 That will add the signing key and the repository configuration. If you prefer to do it manually, execute the following commands:


### PR DESCRIPTION
In my installation using the subsystem, the progress display from curl was getting in the way of the sudo prompt, adding these flags fixed that issue.