### PR TITLE
Change wrong wording in documenting_code.md

### DIFF
--- a/conventions/documenting_code.md
+++ b/conventions/documenting_code.md
@@ -35,7 +35,7 @@ def horns
 end
 ``````
 
-* Use the third person: `Returns the number of horns this unicorn has` instead of `Return the number of horns this unicorn has`.
+* Use the third person: `Returns the number of horns a unicorn has` instead of `Return the number of horns this unicorn has`.
 
 * Parameter names should be *italicized* (surrounded with single asterisks `*` or underscores `_`):
 


### PR DESCRIPTION
Change from two first person statements to one (correcting the other to third person)