### PR TITLE
Add recommentation about string interpolation

### DIFF
--- a/guides/performance.md
+++ b/guides/performance.md
@@ -98,6 +98,13 @@ without to_s  77.11M ( 12.97ns) (± 1.05%)       fastest
 
 Always remember that it's not just the time that has improved: memory usage is also decreased.
 
+### Use string interpolation instead of concatenation
+
+Sometimes you need to work directly with strings built from combining string literals with other values. You shouldn't just concatenate these strings with `String#+(String)` but rather use [string interpolation](syntax_and_semantics/literals/string.html) which allows to embed expressions into a string literal: `"Hello, #{name}"` is better than `"Hello, " +  name.to_s`.
+
+Interpolated strings are transformed by the compiler to append to a string IO so that it automatically avoids intermediate strings. The example above translates to: `(StringBuilder.new << "Hello, " << name).to_s`.
+
+
 ### Avoid creating temporary objects over and over
 
 Consider this program:

--- a/guides/performance.md
+++ b/guides/performance.md
@@ -65,7 +65,7 @@ class MyClass
 end
 ```
 
-This philosophy of appending to an IO instead of returning an intermediate string is present in other APIs, such as in the JSON and YAML APIs, where one needs to define `to_json(io)` and `to_yaml(io)` methods to write this data directly to an IO. You should use this strategy in your API definitions too.
+This philosophy of appending to an IO instead of returning an intermediate string provides better performance than handling intermediate strings. You should use this strategy in your API definitions too.
 
 Let's compare the times:
 

--- a/guides/performance.md
+++ b/guides/performance.md
@@ -65,7 +65,7 @@ class MyClass
 end
 ```
 
-This philosophy of appending to an IO instead of returning an intermediate string provides better performance than handling intermediate strings. You should use this strategy in your API definitions too.
+This philosophy of appending to an IO instead of returning an intermediate string results in better performance than handling intermediate strings. You should use this strategy in your API definitions too.
 
 Let's compare the times:
 


### PR DESCRIPTION
Adds a paragraph about string interpolation on the performance guide

I don't think this needs to mention that concatenation can in some cases be more performant (see crystal-lang/crystal#4964) but rather recommend to use interpolation in any case.

I also removed a reference about JSON and YAML APIs `to_json(io)`/`to_yaml(io)` which have been replaced with builders.