### PR TITLE
Workaround for corrupt search index

### DIFF
--- a/syntax_and_semantics/literals/char.md
+++ b/syntax_and_semantics/literals/char.md
@@ -34,7 +34,4 @@ You can use a backslash followed by an *u* and four hexadecimal characters to de
 
 Or you can use curly braces and specify up to six hexadecimal numbers (0 to 10FFFF):
 
-```crystal
-'\u{41}'    # == 'A'
-'\u{1F52E}' # == '🔮'
-```
+`'\u{41}'` equals `A` and `'\u{1F52E}'` equals &#x1F52E;.

--- a/syntax_and_semantics/literals/string.md
+++ b/syntax_and_semantics/literals/string.md
@@ -38,10 +38,7 @@ You can use a backslash followed by an *u* and four hexadecimal characters to de
 
 Or you can use curly braces and specify up to six hexadecimal numbers (0 to 10FFFF):
 
-```crystal
-"\u{41}"    # == "A"
-"\u{1F52E}" # == "🔮"
-```
+For example, `"\u{41}"` euqals `A` and `"\u{1F52E}"` equals &#x1F52E;.
 
 A string can span multiple lines:
 


### PR DESCRIPTION
Lunr.js can't handle emojis in the search index, this workaround encodes the emoji as html numerical character reference.
Unfortunately this woni't work inside fenced code blocks.

See #127 for details.