### PR TITLE
Document getter, setter, and property macros

### DIFF
--- a/syntax_and_semantics/methods_and_instance_variables.md
+++ b/syntax_and_semantics/methods_and_instance_variables.md
@@ -50,8 +50,8 @@ The Crystal [Standard Library](https://crystal-lang.org/api) provides macros whi
 
 ```crystal
 class Person
-  getter :age
-  property :name : String
+  getter age
+  property name : String
 
   def initialize(@name)
     @age = 0

--- a/syntax_and_semantics/methods_and_instance_variables.md
+++ b/syntax_and_semantics/methods_and_instance_variables.md
@@ -46,12 +46,12 @@ Method names begin with a lowercase letter and, as a convention, only use lowerc
 
 ## Getters and setters
 
-The Crystal [Standard Library](https://crystal-lang.org/api) provides macros which ease the definition of getter and setter methods:
+The Crystal [Standard Library](https://crystal-lang.org/api) provides macros which simplify the definition of getter and setter methods:
 
 ```crystal
 class Person
-  getter age
-  property name : String
+  property age
+  getter name : String
 
   def initialize(@name)
     @age = 0
@@ -59,10 +59,11 @@ class Person
 end
 
 john = Person.new "John"
-john.age #=> 0
+john.age = 32
+john.age #=> 32
 ```
 
-For more on getter and setter macros, reference the standard library documentation for [Object#getter](https://crystal-lang.org/api/latest/Object.html#getter%28%2Anames%29-macro), [Object#setter](https://crystal-lang.org/api/latest/Object.html#setter%28%2Anames%29-macro), and [Object#property](https://crystal-lang.org/api/latest/Object.html#property%28%2Anames%29-macro).
+For more information on getter and setter macros, see the standard library documentation for [Object#getter](https://crystal-lang.org/api/latest/Object.html#getter%28%2Anames%29-macro), [Object#setter](https://crystal-lang.org/api/latest/Object.html#setter%28%2Anames%29-macro), and [Object#property](https://crystal-lang.org/api/latest/Object.html#property%28%2Anames%29-macro).
 
 As a side note, we can define `become_older` inside the original `Person` definition, or in a separate definition: Crystal combines all definitions into a single class. The following works just fine:
 

--- a/syntax_and_semantics/methods_and_instance_variables.md
+++ b/syntax_and_semantics/methods_and_instance_variables.md
@@ -62,7 +62,7 @@ john = Person.new "John"
 john.age #=> 0
 ```
 
-For more on getter and setter macros, reference the standard library documentation for [Object#getter](https://crystal-lang.org/api/0.23.1/Object.html#getter%28%2Anames%29-macro), [Object#setter](https://crystal-lang.org/api/0.23.1/Object.html#setter%28%2Anames%29-macro), and [Object#property](https://crystal-lang.org/api/0.23.1/Object.html#property%28%2Anames%29-macro).
+For more on getter and setter macros, reference the standard library documentation for [Object#getter](https://crystal-lang.org/api/latest/Object.html#getter%28%2Anames%29-macro), [Object#setter](https://crystal-lang.org/api/latest/Object.html#setter%28%2Anames%29-macro), and [Object#property](https://crystal-lang.org/api/latest/Object.html#property%28%2Anames%29-macro).
 
 As a side note, we can define `become_older` inside the original `Person` definition, or in a separate definition: Crystal combines all definitions into a single class. The following works just fine:
 

--- a/syntax_and_semantics/methods_and_instance_variables.md
+++ b/syntax_and_semantics/methods_and_instance_variables.md
@@ -44,6 +44,26 @@ peter.age #=> 0
 
 Method names begin with a lowercase letter and, as a convention, only use lowercase letters, underscores and numbers.
 
+## Getters and setters
+
+The Crystal [Standard Library](https://crystal-lang.org/api) provides macros which ease the definition of getter and setter methods:
+
+```crystal
+class Person
+  getter :age
+  property :name : String
+
+  def initialize(@name)
+    @age = 0
+  end
+end
+
+john = Person.new "John"
+john.age #=> 0
+```
+
+For more on getter and setter macros, reference the standard library documentation for [Object#getter](https://crystal-lang.org/api/0.23.1/Object.html#getter%28%2Anames%29-macro), [Object#setter](https://crystal-lang.org/api/0.23.1/Object.html#setter%28%2Anames%29-macro), and [Object#property](https://crystal-lang.org/api/0.23.1/Object.html#property%28%2Anames%29-macro).
+
 As a side note, we can define `become_older` inside the original `Person` definition, or in a separate definition: Crystal combines all definitions into a single class. The following works just fine:
 
 ```crystal


### PR DESCRIPTION
Relevant to #130, here is an initial stab at documenting the getters and setters macros and referencing the standard library. 

I see a couple problems with this I'd like to better approach before this gets merged, but I'm not sure what the documentation standards are around this type of thing. Hopefully a few minutes writing down concrete text will provide a place for concrete discussion on how to make it better. 

- Hard links to the standard library documentation at the current version are not forward compatible
- The placement of this section within the document is completely arbitrary. I couldn't find a place that felt natural to put it in. I'm open for suggestions.

