### PR TITLE
Clarify Comment Page

### DIFF
--- a/syntax_and_semantics/comments.md
+++ b/syntax_and_semantics/comments.md
@@ -1,6 +1,6 @@
 # Comments
 
-Comments start with the number (`#`) sign. Only one-line comments are supported for now.
+Comments start with the (`#`) character. Only one-line comments are supported for now.
 
 ```crystal
 # This is a comment

--- a/syntax_and_semantics/comments.md
+++ b/syntax_and_semantics/comments.md
@@ -1,6 +1,6 @@
 # Comments
 
-Comments start with the sharp (`#`) character. Only one-line comments are supported for now.
+Comments start with the number (`#`) sign. Only one-line comments are supported for now.
 
 ```crystal
 # This is a comment

--- a/syntax_and_semantics/comments.md
+++ b/syntax_and_semantics/comments.md
@@ -1,6 +1,6 @@
 # Comments
 
-Comments start with the (`#`) character. Only one-line comments are supported for now.
+Comments start with the `#` character. Only one-line comments are supported for now.
 
 ```crystal
 # This is a comment


### PR DESCRIPTION
The character used for comments is commonly referred to as the 'number sign,' not the 'sharp character' as was previously written.