### PR TITLE
better document rescue/else/ensure ordering

### DIFF
--- a/syntax_and_semantics/exception_handling.md
+++ b/syntax_and_semantics/exception_handling.md
@@ -105,6 +105,22 @@ rescue
 end
 ```
 
+## else
+
+An `else` clause is executed only if no exceptions were rescued:
+
+```crystal
+begin
+  something_dangerous
+rescue
+  # execute this if an exception is raised
+else
+  # execute this if an exception isn't raised
+end
+```
+
+An `else` clause can only be specified if at least one `rescue` clause is specified.
+
 ## ensure
 
 An `ensure` clause is executed at the end of a `begin ... end` or `begin ... rescue ... end` expression regardless of whether an exception was raised or not:
@@ -127,6 +143,8 @@ begin
   something_dangerous
 rescue
   # ...
+else
+  # ...
 ensure
   # this will always be executed
 end
@@ -134,25 +152,9 @@ end
 
 `ensure` clauses are usually used for clean up, freeing resources, etc.
 
-## else
-
-An `else` clause is executed only if no exceptions were rescued:
-
-```crystal
-begin
-  something_dangerous
-rescue
-  # execute this if an exception is raised
-else
-  # execute this if an exception isn't raised
-end
-```
-
-An `else` clause can only be specified if at least one `rescue` clause is specified.
-
 ## Short syntax form
 
-Exception handling has a short syntax form: assume a method definition is an implicit `begin ... end` expression, then specify `rescue`, `ensure` and `else` clauses:
+Exception handling has a short syntax form: assume a method definition is an implicit `begin ... end` expression, then specify `rescue`, `else`, and `ensure` clauses:
 
 ```crystal
 def some_method

--- a/syntax_and_semantics/exception_handling.md
+++ b/syntax_and_semantics/exception_handling.md
@@ -154,7 +154,7 @@ end
 
 ## Short syntax form
 
-Exception handling has a short syntax form: assume a method definition is an implicit `begin ... end` expression, then specify `rescue`, `else`, and `ensure` clauses:
+Exception handling has a short syntax form: assume a method or block definition is an implicit `begin ... end` expression, then specify `rescue`, `else`, and `ensure` clauses:
 
 ```crystal
 def some_method
@@ -173,7 +173,7 @@ def some_method
 end
 ```
 
-An example with `ensure`:
+With `ensure`:
 
 ```crystal
 def some_method
@@ -189,6 +189,17 @@ def some_method
   ensure
     # always execute this
   end
+end
+
+# Similarly, the shorthand also works with blocks:
+(1..10).each do |n|
+  # potentially dangerous operation
+rescue
+  #..
+else
+  #..
+ensure
+  #..
 end
 ```
 


### PR DESCRIPTION
relevant to #103 

I also toyed with the idea of explicitly stating that the `else` must come before the `ensure` but didn't find anything that pleased me, so I pulled it. 

Comments and suggestions welcome.