### PR TITLE
Fix Typo in Char Description

### DIFF
--- a/syntax_and_semantics/literals/char.md
+++ b/syntax_and_semantics/literals/char.md
@@ -26,7 +26,7 @@ You can use a backslash to denote some special characters:
 '\v' # vertical tab
 ```
 
-You can use a backslash followed by an *u* and four hexadecimal characters to denote a unicode codepoint written:
+You can use a backslash followed by a *u* and four hexadecimal characters to denote a unicode codepoint written:
 
 ```crystal
 '\u0041' # == 'A'


### PR DESCRIPTION
Found a small typo in the Char file. It had "an" instead of "a" for the letter *u*.