### PR TITLE
Suggest perf/callgrind for profiling on Linux

### DIFF
--- a/guides/performance.md
+++ b/guides/performance.md
@@ -10,7 +10,7 @@ Donald Knuth once said:
 
 However, if you are writing a program and you realize that writing a semantically equivalent, faster version involves just minor changes, you shouldn't miss that opportunity.
 
-And always be sure to profile your program to learn what its bottlenecks are. For profiling, on Mac OSX you can use [Instruments Time Profiler](https://developer.apple.com/library/prerelease/content/documentation/DeveloperTools/Conceptual/InstrumentsUserGuide/Instrument-TimeProfiler.html), which comes with XCode. On Linux, a program that can profile C/C++ programs, like [gprof](https://sourceware.org/binutils/docs/gprof/), should work.
+And always be sure to profile your program to learn what its bottlenecks are. For profiling, on Mac OSX you can use [Instruments Time Profiler](https://developer.apple.com/library/prerelease/content/documentation/DeveloperTools/Conceptual/InstrumentsUserGuide/Instrument-TimeProfiler.html), which comes with XCode. On Linux, any program that can profile C/C++ programs, like [perf](https://perf.wiki.kernel.org/index.php/Main_Page) or [Callgrind](http://valgrind.org/docs/manual/cl-manual.html), should work.
 
 Make sure to always profile programs by compiling or running them with the `--release` flag, which turns on optimizations.
 


### PR DESCRIPTION
gprof requires compiling code with an extra flag, which is only indirectly supported by crystal. Also, the gmon.out file produced sometimes ends up being empty. perf and callgrind are usually both more straightforward to use for new users and more powerful.

This PR is intended as an alternative to #147 (see discussion there for background).