### PR TITLE
Clarify require docs and change libs to lib, fixes #151

### DIFF
--- a/syntax_and_semantics/requiring_files.md
+++ b/syntax_and_semantics/requiring_files.md
@@ -10,7 +10,7 @@ Once a file is required, the compiler remembers its absolute path and later `req
 
 This looks up "filename" in the require path.
 
-By default the require path is the location of the standard library that comes with the compiler, and the "libs" directory relative to the current working directory (given by `pwd` in a Unix shell). These are the only places that are looked up.
+By default the require path is the location of the standard library that comes with the compiler, and the "lib" directory relative to the current working directory (given by `pwd` in a Unix shell). These are the only places that are looked up.
 
 The lookup goes like this:
 
@@ -22,7 +22,7 @@ The second rule is very convenient because of the typical directory structure of
 
 ```
 - project
-  - libs
+  - lib
     - foo
       foo.cr
     - bar
@@ -32,6 +32,8 @@ The second rule is very convenient because of the typical directory structure of
   - spec
     - project_spec.cr
 ```
+
+For example, if you want to `require "foo"` in "project.cr", then you should run crystal in the `project` directory with `crystal src/project.cr`. This ensures that the `lib` folder is one of the require paths.
 
 ## require "./filename"
 

--- a/syntax_and_semantics/requiring_files.md
+++ b/syntax_and_semantics/requiring_files.md
@@ -33,7 +33,9 @@ The second rule is very convenient because of the typical directory structure of
     - project_spec.cr
 ```
 
-For example, if you want to `require "foo"` in "project.cr", then you should run crystal in the `project` directory with `crystal src/project.cr`. This ensures that the `lib` folder is one of the require paths.
+For example, if you put `require "foo"` in `project.cr` and run `crystal src/project.cr` in the project's root directory, it will find `foo` in `lib/foo/foo.cr`.
+
+If you run the compiler from somewhere else, say the `src` folder, `lib` will not be in the path and `require "foo"` can't be resolved.
 
 ## require "./filename"
 


### PR DESCRIPTION
This fixes #151 and clarifies the importance of the working directory when requiring files.