### PR TITLE
Add more examples of macro hooks & @type

### DIFF
--- a/syntax_and_semantics/macros.md
+++ b/syntax_and_semantics/macros.md
@@ -235,6 +235,27 @@ When a macro is invoked you can access the current scope, or type, with a specia
 
 Note that `@type` is always the *instance* type, even when the macro is invoked in a class method.
 
+For example:
+
+```crystal
+macro add_describe_methods
+  def describe
+    "Class is: " + {{ @type.stringify }}
+  end
+  
+  def self.describe
+    "Class is: " + {{ @type.stringify }}
+  end
+end
+
+class Foo
+  add_describe_methods
+end
+
+Foo.new.describe #=> "Class is Foo"
+Foo.describe #=> "Class is Foo"
+```
+
 ## Constants
 
 Macros can access constants. For example:


### PR DESCRIPTION
This adds examples of how the `method_missing` and `method_added` hooks work, especially which scopes they apply to.

I also added an example of `@type` being the same for instance and class methods.