### PR TITLE
Improve subtitle phrasing

### DIFF
--- a/syntax_and_semantics/type_inference.md
+++ b/syntax_and_semantics/type_inference.md
@@ -23,7 +23,7 @@ For this reason, Crystal needs to know, in an obvious way (as obvious as to a hu
 
 There are several ways to let Crystal know this.
 
-## Using an explicit type annotation
+## With type annotations
 
 The easiest, but probably most tedious, way is to use explicit type annotations.
 
@@ -38,7 +38,7 @@ class Person
 end
 ```
 
-## Not using an explicit type annotation
+## Without type annotations
 
 If you omit an explicit type annotation the compiler will try to infer the type of instance and class variables using a bunch of syntactic rules.
 

--- a/syntax_and_semantics/type_inference.md
+++ b/syntax_and_semantics/type_inference.md
@@ -23,7 +23,7 @@ For this reason, Crystal needs to know, in an obvious way (as obvious as to a hu
 
 There are several ways to let Crystal know this.
 
-## Use an explicit type annotation
+## Using an explicit type annotation
 
 The easiest, but probably most tedious, way is to use explicit type annotations.
 
@@ -38,7 +38,7 @@ class Person
 end
 ```
 
-## Don't use an explicit type annotation
+## Not using an explicit type annotation
 
 If you omit an explicit type annotation the compiler will try to infer the type of instance and class variables using a bunch of syntactic rules.
 


### PR DESCRIPTION
The 2 subtitles in their original form seem like declarative instructive statements that contradict each other, rather than being just 2 different ways of doing something.