### PR TITLE
Add gitbook plugin edit-link

### DIFF
--- a/book.json
+++ b/book.json
@@ -3,10 +3,14 @@
     "links": {
         "contributePrefix": "https://github.com/crystal-lang/crystal-book/"
     },
-    "plugins": ["ga"],
+    "plugins": ["ga", "edit-link"],
     "pluginsConfig": {
         "ga": {
             "token": "UA-42353458-1"
+        },
+        "edit-link": {
+            "base": "https://github.com/crystal-lang/crystal-book/edit/master",
+            "label": "Edit This Page"
         }
     }
 }


### PR DESCRIPTION
Adds edit links to each page using [edit-link](https://plugins.gitbook.com/plugin/edit-link) plugin.

Closes #89