### PR TITLE
Fix GFM table syntax

### DIFF
--- a/syntax_and_semantics/literals/integers.md
+++ b/syntax_and_semantics/literals/integers.md
@@ -3,15 +3,15 @@
 There are four signed integer types, and four unsigned integer types:
 
 Type | Length  | Minimum Value | Maximum Value
- ---------- | -----------: | -----------: |-----------: |
-[Int8](http://crystal-lang.org/api/Int8.html)  | 8       | -128 | 127 |
-[Int16](http://crystal-lang.org/api/Int16.html)  | 16 | −32,768 | 32,767|
-[Int32](http://crystal-lang.org/api/Int32.html) | 32  | −2,147,483,648 | 2,147,483,647|
-[Int64](http://crystal-lang.org/api/Int64.html)   |  64 | −2<sup>63</sup> | 2<sup>63</sup> - 1 |
+ ---------- | -----------: | -----------: |-----------:
+[Int8](http://crystal-lang.org/api/Int8.html)  | 8       | -128 | 127
+[Int16](http://crystal-lang.org/api/Int16.html)  | 16 | −32,768 | 32,767
+[Int32](http://crystal-lang.org/api/Int32.html) | 32  | −2,147,483,648 | 2,147,483,647
+[Int64](http://crystal-lang.org/api/Int64.html)   |  64 | −2<sup>63</sup> | 2<sup>63</sup> - 1
 [UInt8](http://crystal-lang.org/api/UInt8.html) | 8 |  0 | 255
 [UInt16](http://crystal-lang.org/api/UInt16.html) | 16 | 0 | 65,535
 [UInt32](http://crystal-lang.org/api/UInt32.html) | 32 |  0 | 4,294,967,295
-[UInt64](http://crystal-lang.org/api/UInt64.html) | 64 | 0 | 2<sup>64</sup> - 1 |
+[UInt64](http://crystal-lang.org/api/UInt64.html) | 64 | 0 | 2<sup>64</sup> - 1
 
 An integer literal is an optional `+` or `-` sign, followed by
 a sequence of digits and underscores, optionally followed by a suffix.


### PR DESCRIPTION
#141 introduced incoherent table syntax which created an additional empty column. This PR removes the unneeded pipes at the end of line.