### PR TITLE
Improve wording of Nil explaination

### DIFF
--- a/syntax_and_semantics/literals/nil.md
+++ b/syntax_and_semantics/literals/nil.md
@@ -1,6 +1,6 @@
 # Nil
 
-The [Nil](http://crystal-lang.org/api/Nil.html) type is used to represent the absence of a value, not unlike `null` in other languages. It only has a single value:
+The [Nil](http://crystal-lang.org/api/Nil.html) type is used to represent the absence of a value, similar to `null` in other languages. It only has a single value:
 
 ```crystal
 nil


### PR DESCRIPTION
"not unlike" (a double negative) is harder for my brain to process than simply "similar to"