### PR TITLE
Add space to expression return value indicator

### DIFF
--- a/conventions/documenting_code.md
+++ b/conventions/documenting_code.md
@@ -87,7 +87,7 @@ For example:
 # See what a unicorn would say with `Unicorn#speak`.
 ```
 
-* To show the value of an expression inside code blocks, use `#=>`.
+* To show the value of an expression inside code blocks, use `# =>`.
 
 ```crystal
 1 + 2             # => 3


### PR DESCRIPTION
Change the expression return value indicator to include a space between `#` and `=>`, as per the examples that follow.