### PR TITLE
Remove pipe from regex example

### DIFF
--- a/syntax_and_semantics/literals.md
+++ b/syntax_and_semantics/literals.md
@@ -16,7 +16,7 @@ Crystal provides several literals for creating values of some basic types.
 | [Hash](./literals/hash.html)              | `{"foo" => 2}`, `{} of String => Int32`     |
 | [Hash-like](./literals/hash.html#hash-like-type-literal) | `MyType{"foo" => "bar"}`                    |
 | [Range](./literals/range.html)            | `1..9`, `1...10`, `0..var`                  |
-| [Regex](./literals/regex.html)            | `/foo\|bar/`, `/foo #{foo}/imx`, `%r(foo/)` |
+| [Regex](./literals/regex.html)            | `/(foo)?bar/`, `/foo #{foo}/imx`, `%r(foo/)` |
 | [Tuple](./literals/tuple.html)            | `{1, "hello", 'x'}`                         |
 | [NamedTuple](./literals/named_tuple.html) | `{name: "Crystal", year: 2011}`, `{"this is a key": 1}`|
 | [Proc](./literals/proc.html)              | `->(x : Int32, y : Int32) { x + y }`        |


### PR DESCRIPTION
Avoids misinterpretation as Markdown table.

Fixes #192