### PR TITLE
Clarify the type restrictions documentation

### DIFF
--- a/syntax_and_semantics/type_restrictions.md
+++ b/syntax_and_semantics/type_restrictions.md
@@ -69,6 +69,15 @@ restricted_add Six.new, 10
 
 Refer to the [type grammar](type_grammar.html) for the notation used in type restrictions.
 
+Note that type restrictions do not apply to the variables inside the actual methods.
+
+```crystal
+def handle_path(path : String)
+  path = Path.new(path) # *path* is now of the type Path
+  # Do something with *path*
+end
+```
+
 ## self restriction
 
 A special type restriction is `self`:


### PR DESCRIPTION
This pull request adds a section demonstrating how Crystal handles type restricted variables inside the actual methods.

I want this section to be added, but the example could be much better than it is now. I'm not sure what to put there.