### PR TITLE
Fix String::Builder example

### DIFF
--- a/syntax_and_semantics/literals/string.md
+++ b/syntax_and_semantics/literals/string.md
@@ -76,7 +76,7 @@ Interpolation can be disabled by escaping the `#` character with a backslash or 
 Interpolation is implemented using a [`String::Builder`](http://crystal-lang.org/api/String/Builder.html) and invoking `Object#to_s(IO)` on each expression enclosed by `#{...}`. The expression `"sum: #{a} + #{b} = #{a + b}"` is equivalent to:
 
 ```crystal
-String::Builder.new do |io|
+String::Builder.build do |io|
   io << "sum: "
   io << a
   io << " + "


### PR DESCRIPTION
The former one gave me the error: `String::Builder.new' is not expected to be invoked with a block, but a block was given`