### PR TITLE
Adding libxml2 and libxml2-dev dependencies

### DIFF
--- a/installation/on_debian_and_ubuntu.md
+++ b/installation/on_debian_and_ubuntu.md
@@ -25,10 +25,10 @@ Once the repository is configured you're ready to install Crystal:
 sudo apt-get install crystal
 ```
 
-Sometimes [you will need](https://github.com/crystal-lang/crystal/issues/4342) to install the package `build-essential` in order to run/build Crystal programs. You can install it with the command:
+Sometimes [you will need](https://github.com/crystal-lang/crystal/issues/4342) to install the packages `build-essential`, `libxml2` and `libxml2-dev` in order to run/build Crystal programs. You can install them with the following command:
 
 ```
-sudo apt-get install build-essential
+sudo apt-get install build-essential libxml2 libxml2-dev
 ```
 
 


### PR DESCRIPTION
Ubuntu often throws errors when trying to running Crystal before installing `libxml2` and `libxml2-dev` dependencies. Its wise to document the need to install those dependencies them in the docs.

Related to: https://github.com/crystal-lang/crystal/issues/4342