### PR TITLE
Docker for crystal-book fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Html output will be in `_book` folder (some links won't work if opening the file
 There is also a docker environment to avoid installing dependencies globally:
 
 ```
-$ docker-compose up
+$ sudo docker-compose up
 ...
 gitbook_1  | Starting server ...
 gitbook_1  | Serving book on http://localhost:4000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
     ports:
       - "4000:4000"
       - "35729:35729"
-    command: /bin/sh -c "npm install && gitbook serve"
+    command: /bin/sh -c "npm install && gitbook install && gitbook serve"


### PR DESCRIPTION
Hi, I tried to use docker environment to install crystal-book locally, however I ran into 2 problems:
(I was using Ubuntu 16.04 with Docker version 1.13.1, build 092cba3)

1. typing `$ docker-compose up` created first problem: 

> ERROR: Couldn't connect to Docker daemon at http+docker://localunixsocket - is it running?

Which was pretty strange, because when I ran `$ systemctl is-active docker` everything looked okay.
Adding `sudo` fixed the problem and then I had second problem: 

> Error: Couldn't locate plugins "edit-link, offline", Run 'gitbook install' to install plugins from registry.

I added this command to _docker-compose.yml_ and tried to run it again. Missing plugins were successfully installed and everything started to work.

That's why I propose to change documentation describing use of docker along with _docker-compose.yml_.