### PR TITLE
Fix wrong example in pointerof.md

### DIFF
--- a/syntax_and_semantics/pointerof.md
+++ b/syntax_and_semantics/pointerof.md
@@ -17,7 +17,7 @@ An example with an instance variable:
 
 ```crystal
 class Point
-  def initialize(@x, @y)
+  def initialize(@x : Int32, @y : Int32)
   end
 
   def x


### PR DESCRIPTION
Right now this example gives you
```Crystal
Can't infer the type of instance variable '@x' of Point

  def initialize(@x, @y)
                 ^~
```