### PR TITLE
Update HTTP Server example

### DIFF
--- a/overview/http_server.md
+++ b/overview/http_server.md
@@ -3,15 +3,16 @@
 A slightly more interesting example is an HTTP Server:
 
 ```crystal
+
 require "http/server"
 
-server = HTTP::Server.new(8080) do |context|
-  context.response.content_type = "text/plain"
-  context.response.print "Hello world! The time is #{Time.now}"
+server = HTTP::Server.new do |context|
+  context.response.headers["Content-Type"] = "text/plain"
+  context.response.print("Hello world! The time is #{Time.now}")
 end
 
-puts "Listening on http://127.0.0.1:8080"
-server.listen
+puts "Listening on http://0.0.0.0:8080"
+server.listen "0.0.0.0", 8080
 ```
 
 The above code will make sense once you read the whole language reference, but we can already learn some things.
@@ -30,19 +31,19 @@ The above code will make sense once you read the whole language reference, but w
 * You program by invoking [methods](../syntax_and_semantics/classes_and_methods.html) (or sending messages) to objects.
 
     ```crystal
-    HTTP::Server.new(8080) ...
+    HTTP::Server.new ...
     ...
     Time.now
     ...
-    puts "Listening on http://127.0.0.1:8080"
+    puts "Listening on http://0.0.0.0:8080"
     ...
-    server.listen
+    server.listen "0.0.0.0", 8080
     ```
 
 * You can use code blocks, or simply [blocks](../syntax_and_semantics/blocks_and_procs.html), which are a very convenient way to reuse code and get some features from the functional world:
 
     ```crystal
-    HTTP::Server.new(8080) do |context|
+    HTTP::Server.new do |context|
       ...
     end
     ```


### PR DESCRIPTION
Current HTTP Server example code breaks on `HTTP::Server.new(8080)` as it is no longer a valid overload.

New example code is based on [crystal-lang/crystal/blob/master/samples/http_server.cr](https://github.com/crystal-lang/crystal/blob/master/samples/http_server.cr)