### PR TITLE
Fix HTTP::Server example

### DIFF
--- a/overview/http_server.md
+++ b/overview/http_server.md
@@ -5,11 +5,12 @@ A slightly more interesting example is an HTTP Server:
 ```crystal
 require "http/server"
 
-server = HTTP::Server.new(8080) do |context|
+server = HTTP::Server.new do |context|
   context.response.content_type = "text/plain"
   context.response.print "Hello world! The time is #{Time.now}"
 end
 
+server.bind_tcp "127.0.0.1", 8080
 puts "Listening on http://127.0.0.1:8080"
 server.listen
 ```


### PR DESCRIPTION
Previous example didn't work on crystal 0.25.0.