### PR TITLE
Homebrew formula was renamed from crystal-lang to crystal

### DIFF
--- a/installation/on_mac_osx_using_homebrew.md
+++ b/installation/on_mac_osx_using_homebrew.md
@@ -4,13 +4,13 @@ To easily install Crystal on Mac you can use [Homebrew](http://brew.sh/).
 
 ```
 brew update
-brew install crystal-lang
+brew install crystal
 ```
 
 If you're planning to contribute to the language itself you might find useful to install LLVM as well. So replace the last line with:
 
 ```
-brew install crystal-lang --with-llvm
+brew install crystal --with-llvm
 ```
 
 ## Troubleshooting on OSX 10.11 (El Capitan)


### PR DESCRIPTION
We [finally](https://github.com/Homebrew/homebrew-core/pull/29574#issuecomment-401548780) managed to rename the homebrew formula from `crystal-lang` to `crystal` 🎉

(whoever manages Linuxbrew, maybe they should rename the formula there too)