### PR TITLE
Replace apt-key adv with apt-key add for WSL

### DIFF
--- a/installation/on_bash_on_ubuntu_on_windows.md
+++ b/installation/on_bash_on_ubuntu_on_windows.md
@@ -15,7 +15,7 @@ curl -sSL https://dist.crystal-lang.org/apt/setup.sh | sudo bash
 That will add the signing key and the repository configuration. If you prefer to do it manually, execute the following commands:
 
 ```
-sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 09617FD37CC06B54
+curl -sL "https://keybase.io/crystal/pgp_keys.asc" | sudo apt-key add
 echo "deb https://dist.crystal-lang.org/apt crystal main" | sudo tee /etc/apt/sources.list.d/crystal.list
 sudo apt-get update
 ```


### PR DESCRIPTION
There is an issue with `apt-key adv` on Ubuntu 18.04 on WSL (https://github.com/Microsoft/WSL/issues/3286). I figured it is easier to simply substitute the entire command instead of showing several alternatives. This should work on all versions.

Original issue discription: https://www.reddit.com/r/crystal_programming/comments/8yktb1/installing_crystal_on_windows_right_now/