### PR TITLE
Remove redundancy in WSL instructions and improve for Debian/Ubuntu

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -8,7 +8,7 @@
    * [On Gentoo Linux](installation/on_gentoo_linux.md)
    * [On Mac OSX using Homebrew](installation/on_mac_osx_using_homebrew.md)
    * [On Linux using Linuxbrew](installation/on_linux_using_linuxbrew.md)
-   * [On Bash on Ubuntu on Windows](installation/on_bash_on_ubuntu_on_windows.md)
+   * [On Windows Subsystem for Linux](installation/on_bash_on_ubuntu_on_windows.md)
    * [From a tar.gz](installation/from_a_targz.md)
    * [From sources](installation/from_source_repository.md)
 * [Using the compiler](using_the_compiler/README.md)

--- a/installation/on_bash_on_ubuntu_on_windows.md
+++ b/installation/on_bash_on_ubuntu_on_windows.md
@@ -1,44 +1,5 @@
-# On Bash on Ubuntu on Windows
+# Windows Subsystem for Linux
 
-Crystal doesn't support Windows _yet_, but if you're using Windows 10 you can (experimentally) try Crystal using [Bash on Ubuntu on Windows](https://msdn.microsoft.com/en-us/commandline/wsl/about), an experimental Bash environment running on Windows. The installation instructions are the same as for [Debian/Ubuntu](on_debian_and_ubuntu.md), but there are a few rough edges to be aware of.
+The Crystal compiler doesn't run on Windows _yet_. But Crystal can be used with the [Windows Subsystem for Linux](https://msdn.microsoft.com/en-us/commandline/wsl/about), a compatibility-layer for Linux executables running natively on Windows 10.
 
-Don't forget - **this is highly experimental**.
-
-## Setup repository
-
-First you have to add the repository to your APT configuration. For easy setup just run in your command line:
-
-```
-curl -sSL https://dist.crystal-lang.org/apt/setup.sh | sudo bash
-```
-
-That will add the signing key and the repository configuration. If you prefer to do it manually, execute the following commands:
-
-```
-sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 09617FD37CC06B54
-echo "deb https://dist.crystal-lang.org/apt crystal main" | sudo tee /etc/apt/sources.list.d/crystal.list
-sudo apt-get update
-```
-
-## Dependencies
-Crystal needs a C compiler (`cc`) and linker (`ld`) to be able to compile Crystal programs - so you should install them:
-
-```
-sudo apt-get install clang binutils
-```
-
-## Install
-Once the repository is configured and you have the dependencies, you're ready to install Crystal:
-
-```
-sudo apt-get install crystal
-```
-
-## Upgrade
-
-When a new Crystal version is released you can upgrade your system using:
-
-```
-sudo apt-get update
-sudo apt-get install crystal
-```
+Several Linux distribution are supported by WSL and the installation instructions for Crystal are equal to that of the respective Linux distribution, most commonly [Debian/Ubuntu](on_debian_and_ubuntu.md).

--- a/installation/on_debian_and_ubuntu.md
+++ b/installation/on_debian_and_ubuntu.md
@@ -13,13 +13,10 @@ curl -sSL https://dist.crystal-lang.org/apt/setup.sh | sudo bash
 That will add the signing key and the repository configuration. If you prefer to do it manually, execute the following commands:
 
 ```bash
-sudo sh -c 'apt-key adv --keyserver keys.gnupg.net --recv-keys 09617FD37CC06B54 && \
-            echo "deb https://dist.crystal-lang.org/apt crystal main" > /etc/apt/sources.list.d/crystal.list && \
-            apt-get update'
+curl -sL "https://keybase.io/crystal/pgp_keys.asc" | sudo apt-key add
+echo "deb https://dist.crystal-lang.org/apt crystal main" | sudo tee /etc/apt/sources.list.d/crystal.list
+sudo apt-get update
 ```
-
-**NOTE:** There is a bug in Ubuntu 18.04 running on Windows Subystem for Linux, making `apt-key adv` fail.
-As a workaround, the first command can be replaced by `curl -sL "https://keybase.io/crystal/pgp_keys.asc" | sudo apt-key add`.
 
 ## Install
 Once the repository is configured you're ready to install Crystal:
@@ -28,13 +25,7 @@ Once the repository is configured you're ready to install Crystal:
 sudo apt install crystal
 ```
 
-Sometimes the package `build-essential` needs to be installed in order to run/build Crystal programs (see [issue #4342](https://github.com/crystal-lang/crystal/issues/4342)):
-
-```bash
-sudo apt install build-essential
-```
-
-The following packages are not required, but recommended for using the respective stlib features:
+The following packages are not required, but recommended for using the respective features in the standard library:
 
 ```bash
 sudo apt install libssl-dev      # for using OpenSSL

--- a/installation/on_debian_and_ubuntu.md
+++ b/installation/on_debian_and_ubuntu.md
@@ -6,37 +6,51 @@ In Debian derived distributions, you can use the official Crystal repository.
 
 First you have to add the repository to your APT configuration. For easy setup just run in your command line:
 
-```
-curl https://dist.crystal-lang.org/apt/setup.sh | sudo bash
+```bash
+curl -sSL https://dist.crystal-lang.org/apt/setup.sh | sudo bash
 ```
 
-That will add the signing key and the repository configuration. If you prefer to do it manually, execute the following commands as *root*:
+That will add the signing key and the repository configuration. If you prefer to do it manually, execute the following commands:
 
+```bash
+sudo sh -c 'apt-key adv --keyserver keys.gnupg.net --recv-keys 09617FD37CC06B54 && \
+            echo "deb https://dist.crystal-lang.org/apt crystal main" > /etc/apt/sources.list.d/crystal.list && \
+            apt-get update'
 ```
-apt-key adv --keyserver keys.gnupg.net --recv-keys 09617FD37CC06B54
-echo "deb https://dist.crystal-lang.org/apt crystal main" > /etc/apt/sources.list.d/crystal.list
-apt-get update
-```
+
+**NOTE:** There is a bug in Ubuntu 18.04 running on Windows Subystem for Linux, making `apt-key adv` fail.
+As a workaround, the first command can be replaced by `curl -sL "https://keybase.io/crystal/pgp_keys.asc" | sudo apt-key add`.
 
 ## Install
 Once the repository is configured you're ready to install Crystal:
 
-```
-sudo apt-get install crystal
-```
-
-Sometimes [you will need](https://github.com/crystal-lang/crystal/issues/4342) to install the package `build-essential` in order to run/build Crystal programs. You can install it with the command:
-
-```
-sudo apt-get install build-essential
+```bash
+sudo apt install crystal
 ```
 
+Sometimes the package `build-essential` needs to be installed in order to run/build Crystal programs (see [issue #4342](https://github.com/crystal-lang/crystal/issues/4342)):
+
+```bash
+sudo apt install build-essential
+```
+
+The following packages are not required, but recommended for using the respective stlib features:
+
+```bash
+sudo apt install libssl-dev      # for using OpenSSL
+sudo apt install libxml2-dev     # for using XML
+sudo apt install libyaml-dev     # for using YAML
+sudo apt install libgmp-dev      # for using Big numbers
+sudo apt install libreadline-dev # for using Readline
+```
+
+For building the Crystal compiler itself, a few other dependencies are needed, see [wiki page](https://github.com/crystal-lang/crystal/wiki/All-required-libraries#ubuntu). They are not required for regular compiler use.
 
 ## Upgrade
 
 When a new Crystal version is released you can upgrade your system using:
 
-```
-sudo apt-get update
-sudo apt-get install crystal
+```bash
+sudo apt update
+sudo apt install crystal
 ```


### PR DESCRIPTION
Installing Crystal on Windows Subsystem for Linux typically doesn't differ from installing on the respective native Linux platform. The only notable exception to that is only recently with Ubuntu 18.04, but not a big deal (see #259).
And WSL easily supports different Linux distributions, not just Ubuntu.

That's why I figure it doesn't make much sense to have detailed instructions for WSL but instead point to the respective Linux distribution's installation instructions.

Renamed `Bash on Ubuntu on Windows` to `Windows Subsystem for Linux` which is the proper and more general name. I left the path at `installation/on_bash_on_ubuntu_on_windows.md` to not break links. It could be moved and redirect, but I don't think it hurts much.

The assessment of *highly experimental*, is certainly not adequate anymore. Crystal on WSL works as good and stable as on any native platform.

I also extended the installation instructions for Debian/Ubuntu, adding a few things from the WSL page and recommended packages. It also incorporates #259.

Closes #259