### PR TITLE
The key is missing from keys.gnupg.net

### DIFF
--- a/installation/on_debian_and_ubuntu.md
+++ b/installation/on_debian_and_ubuntu.md
@@ -13,7 +13,7 @@ curl https://dist.crystal-lang.org/apt/setup.sh | sudo bash
 That will add the signing key and the repository configuration. If you prefer to do it manually, execute the following commands as *root*:
 
 ```
-apt-key adv --keyserver keys.gnupg.net --recv-keys 09617FD37CC06B54
+curl -L https://keybase.io/crystal/pgp_keys.asc|sudo apt-key add -
 echo "deb https://dist.crystal-lang.org/apt crystal main" > /etc/apt/sources.list.d/crystal.list
 apt-get update
 ```


### PR DESCRIPTION
The key is available from keybase.io instead.