### PR TITLE
Update spelling of “macOS”

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -6,7 +6,7 @@
    * [On RedHat and CentOS](installation/on_redhat_and_centos.md)
    * [On Arch Linux](installation/on_arch_linux.md)
    * [On Gentoo Linux](installation/on_gentoo_linux.md)
-   * [On Mac OSX using Homebrew](installation/on_mac_osx_using_homebrew.md)
+   * [On macOS using Homebrew](installation/on_mac_osx_using_homebrew.md)
    * [On Linux using Linuxbrew](installation/on_linux_using_linuxbrew.md)
    * [On Windows Subsystem for Linux](installation/on_bash_on_ubuntu_on_windows.md)
    * [From a tar.gz](installation/from_a_targz.md)

--- a/guides/performance.md
+++ b/guides/performance.md
@@ -10,7 +10,7 @@ Donald Knuth once said:
 
 However, if you are writing a program and you realize that writing a semantically equivalent, faster version involves just minor changes, you shouldn't miss that opportunity.
 
-And always be sure to profile your program to learn what its bottlenecks are. For profiling, on Mac OSX you can use [Instruments Time Profiler](https://developer.apple.com/library/prerelease/content/documentation/DeveloperTools/Conceptual/InstrumentsUserGuide/Instrument-TimeProfiler.html), which comes with XCode. On Linux, any program that can profile C/C++ programs, like [perf](https://perf.wiki.kernel.org/index.php/Main_Page) or [Callgrind](http://valgrind.org/docs/manual/cl-manual.html), should work.
+And always be sure to profile your program to learn what its bottlenecks are. For profiling, on macOS you can use [Instruments Time Profiler](https://developer.apple.com/library/prerelease/content/documentation/DeveloperTools/Conceptual/InstrumentsUserGuide/Instrument-TimeProfiler.html), which comes with XCode. On Linux, any program that can profile C/C++ programs, like [perf](https://perf.wiki.kernel.org/index.php/Main_Page) or [Callgrind](http://valgrind.org/docs/manual/cl-manual.html), should work.
 
 Make sure to always profile programs by compiling or running them with the `--release` flag, which turns on optimizations.
 

--- a/installation/README.md
+++ b/installation/README.md
@@ -6,7 +6,7 @@ Once you install the compiler using one of the following methods, make sure to r
 * [On RedHat And CentOS](on_redhat_and_centos.html)
 * [On Arch Linux](on_arch_linux.html)
 * [On Gentoo Linux](on_gentoo_linux.html)
-* [On Mac OSX using Homebrew](on_mac_osx_using_homebrew.html)
+* [On macOS using Homebrew](on_mac_osx_using_homebrew.html)
 * [On Linux using Linuxbrew](on_linux_using_linuxbrew.html)
 * [On Bash on Ubuntu on Windows](on_bash_on_ubuntu_on_windows.html)
 * [From a tar.gz](from_a_targz.html)

--- a/installation/on_mac_osx_using_homebrew.md
+++ b/installation/on_mac_osx_using_homebrew.md
@@ -1,4 +1,4 @@
-# On Mac OSX using Homebrew
+# On macOS using Homebrew
 
 To easily install Crystal on Mac you can use [Homebrew](http://brew.sh/).
 

--- a/syntax_and_semantics/c_bindings/lib.md
+++ b/syntax_and_semantics/c_bindings/lib.md
@@ -14,6 +14,6 @@ Attributes are used to pass flags to the linker to find external libraries:
 
 * `@[Link("pcre")]` will pass `-lpcre` to the linker, but the compiler will first try to use [pkg-config](http://en.wikipedia.org/wiki/Pkg-config).
 * `@[Link(ldflags: "...")]` will pass those flags directly to the linker, without modification. For example: `@[Link(ldflags: "-lpcre")]`. A common technique is to use backticks to execute commands: ``@[Link(ldflags: "`pkg-config libpcre --libs`")]``.
-* `@[Link(framework: "Cocoa")]` will pass `-framework Cocoa` to the linker (only useful in Mac OS X).
+* `@[Link(framework: "Cocoa")]` will pass `-framework Cocoa` to the linker (only useful in macOS).
 
 Attributes can be omitted if the library is implicitly linked, as in the case of libc.


### PR DESCRIPTION
I intentionally haven’t updated the filename `on_mac_osx_using_homebrew.html` to keep existing links intact.