### PR TITLE
Remove --with-llvm option from Homebrew instructions

### DIFF
--- a/installation/from_source_repository.md
+++ b/installation/from_source_repository.md
@@ -4,7 +4,7 @@ If you want to contribute then you might want to install Crystal from sources.
 
 1. [Install the latest Crystal release](https://crystal-lang.org/docs/installation). To compile Crystal, you need Crystal :).
 
-2. Make sure a supported LLVM version is present in the path. Currently, Crystal supports LLVM 3.8, 3.9, 4.0, and 5.0. When possible, use the latest one. If you are using Mac and the Homebrew formula, this will be automatically configured for you if you install Crystal adding `--with-llvm` flag.
+2. Make sure a supported LLVM version is present in the path. Currently, Crystal supports LLVM 3.8, 3.9, 4.0, and 5.0. When possible, use the latest one.
 
 3. Make sure to install [all the required libraries](https://github.com/crystal-lang/crystal/wiki/All-required-libraries). You might also want to read the [contributing guide](https://github.com/crystal-lang/crystal/blob/master/CONTRIBUTING.md).
 

--- a/installation/on_mac_osx_using_homebrew.md
+++ b/installation/on_mac_osx_using_homebrew.md
@@ -7,12 +7,6 @@ brew update
 brew install crystal
 ```
 
-If you're planning to contribute to the language itself you might find useful to install LLVM as well. So replace the last line with:
-
-```
-brew install crystal --with-llvm
-```
-
 ## Troubleshooting on OSX 10.11 (El Capitan)
 
 If you get an error like:


### PR DESCRIPTION
The [Homebrew formula](https://github.com/Homebrew/homebrew-core/blob/71838be7661e2d48da00acb9d684b0eebea6e61f/Formula/crystal.rb) no longer supports the `--with-llvm` option.