### PR TITLE
Remove out-of-date mention of "deps"

### DIFF
--- a/using_the_compiler/README.md
+++ b/using_the_compiler/README.md
@@ -88,7 +88,6 @@ Usage: crystal [command] [switches] [program file] [--] [arguments]
 Command:
     init                     generate a new project
     build                    build an executable
-    deps                     install project dependencies
     docs                     generate documentation
     env                      print Crystal environment information
     eval                     eval code from args or standard input


### PR DESCRIPTION
Removed mention of crystal's "deps" command since this has been replaced by "shards".