### PR TITLE
Fix "crystal-lang" homebrew package name

### DIFF
--- a/installation/on_mac_osx_using_homebrew.md
+++ b/installation/on_mac_osx_using_homebrew.md
@@ -4,7 +4,7 @@ To easily install Crystal on Mac you can use [Homebrew](http://brew.sh/).
 
 ```
 brew update
-brew install crystal
+brew install crystal-lang
 ```
 
 ## Troubleshooting on OSX 10.11 (El Capitan)


### PR DESCRIPTION
The `brew install crystal` command will install something called "autocode".