### PR TITLE
Add more documentation on the docs command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ $ git clone https://github.com/crystal-lang/crystal-book.git
 $ cd crystal-book
 $ npm install -g gitbook-cli@2.3.0
 $ npm install
+$ gitbook install
 $ gitbook serve
 Live reload server started on port: 35729
 Press CTRL+C to quit ...

--- a/conventions/README.md
+++ b/conventions/README.md
@@ -3,4 +3,4 @@
 Follow these conventions so your code will be more accessible to other developers.
 
 * Use [standard coding style](coding_style.md) so your project will be navigable and readable to others.
-* Write [documentation](documenting_code.md) to express the purpose of your code and support the `crystal doc` generator.
+* Write [documentation](documenting_code.md) to express the purpose of your code and support the `crystal docs` generator.

--- a/conventions/documenting_code.md
+++ b/conventions/documenting_code.md
@@ -1,6 +1,8 @@
 # Documenting code
 
-Crystal documentation comments use a subset of [Markdown](https://daringfireball.net/projects/markdown/).
+Crystal can generate documentation from comments using a subset of [Markdown](https://daringfireball.net/projects/markdown/).
+
+To generate documentation for a project, invoke `crystal docs`. By default this will create a `docs` directory, with a `docs/index.html` entry point. For more details see [Using the compiler - Creating documentation](../using_the_compiler/#creating-documentation).
 
 * Documentation should be positioned right above definitions of classes, modules, and methods. Leave no blanks between them.
 
@@ -225,7 +227,3 @@ class Unicorn
   end
 end
 ``````
-
-### Generate Documentation
-
-To generate documentation for a project, invoke `crystal docs`. This will create a `docs` directory, with a `docs/index.html` entry point. All files inside the root `src` directory will be considered.

--- a/using_the_compiler/README.md
+++ b/using_the_compiler/README.md
@@ -79,15 +79,13 @@ Initialized empty Git repository in ~/my_cool_lib/.git/
 
 ## Creating documentation
 
-Use the `docs` command to create documentation for your library (see [documentation code](../conventions/documenting_code.html)). By default, this command will create a docs directory, with a docs/index.html entry point. All files inside the root src directory will be considered (`src/**`). Now you can just open that index.html file with your web browser and start browsing your docs.
+Use the `docs` command to create documentation for your library (see [documentation code](../conventions/documenting_code.html)). By default, this command will create a docs directory, with a `docs/index.html` entry point. All files inside the root `src` directory will be considered (`src/**`). Now you can just open that `index.html` file with your web browser and start browsing your docs.
 
-If your library has any load-order dependence, you can instead specify which file or files should be used as arguments to the `docs command`:
+If your library has any load-order dependence, you can instead specify which file or files should be used as arguments to the `docs` command will create docs for the crystal program resulting from only reading `src/my_app.cr`.
 
 ```
 $ crystal docs src/my_app.cr
 ```
-
-will create docs for the crystal program resulting from only reading `src/my_app.cr`.
 
 There are also two options (which you will see by invoking `crystal docs -h`)
 

--- a/using_the_compiler/README.md
+++ b/using_the_compiler/README.md
@@ -77,6 +77,31 @@ $ crystal init lib my_cool_lib
 Initialized empty Git repository in ~/my_cool_lib/.git/
 ```
 
+## Creating documentation
+
+Use the `docs` command to create documentation for your library (see [documentation code](../conventions/documenting_code.html)). By default, this command will create a docs directory, with a docs/index.html entry point. All files inside the root src directory will be considered (`src/**`). Now you can just open that index.html file with your web browser and start browsing your docs.
+
+If your library has any load-order dependence, you can instead specify which file or files should be used as arguments to the `docs command`:
+
+```
+$ crystal docs src/my_app.cr
+```
+
+will create docs for the crystal program resulting from only reading `src/my_app.cr`.
+
+There are also two options (which you will see by invoking `crystal docs -h`)
+
+```
+--output=DIR, -o DIR             Set the output directory (default: ./docs)
+--canonical-base-url=URL, -b URL Set the canonical base url
+```
+
+Thus, for the above program, if you need to output the docs at `public` and would like to customize your [canonical base url](https://en.wikipedia.org/wiki/Canonical_link_element) then you could do so like this
+
+```
+$ crystal docs -o public -b http://example.com/ src/my_app.cr
+```
+
 ## Other commands and options
 
 To see the full set of commands, invoke `crystal` without arguments.

--- a/using_the_compiler/README.md
+++ b/using_the_compiler/README.md
@@ -64,22 +64,21 @@ Use the `init` command to create a Crystal project with the standard directory s
 
 ```
 $ crystal init lib my_cool_lib
-      create  my_cool_lib/.gitignore
-      create  my_cool_lib/.editorconfig
-      create  my_cool_lib/LICENSE
-      create  my_cool_lib/README.md
-      create  my_cool_lib/.travis.yml
-      create  my_cool_lib/shard.yml
-      create  my_cool_lib/src/my_cool_lib.cr
-      create  my_cool_lib/src/my_cool_lib/version.cr
-      create  my_cool_lib/spec/spec_helper.cr
-      create  my_cool_lib/spec/my_cool_lib_spec.cr
+    create  my_cool_lib/.gitignore
+    create  my_cool_lib/.editorconfig
+    create  my_cool_lib/LICENSE
+    create  my_cool_lib/README.md
+    create  my_cool_lib/.travis.yml
+    create  my_cool_lib/shard.yml
+    create  my_cool_lib/src/my_cool_lib.cr
+    create  my_cool_lib/spec/spec_helper.cr
+    create  my_cool_lib/spec/my_cool_lib_spec.cr
 Initialized empty Git repository in ~/my_cool_lib/.git/
 ```
 
 ## Creating documentation
 
-Use the `docs` command to create documentation for your library (see [documentation code](../conventions/documenting_code.html)). By default, this command will create a docs directory, with a `docs/index.html` entry point. All files inside the root `src` directory will be considered (`src/**`). Now you can just open that `index.html` file with your web browser and start browsing your docs.
+Use the `docs` command to create documentation for your library (see [documenting code](../conventions/documenting_code.html)). By default, this command will create a docs directory, with a `docs/index.html` entry point. All files inside the root `src` directory will be considered (`src/**`). Now you can just open that `index.html` file with your web browser and start browsing your docs.
 
 If your library has any load-order dependence, you can instead specify which file or files should be used as arguments to the `docs` command will create docs for the crystal program resulting from only reading `src/my_app.cr`.
 


### PR DESCRIPTION
I think the `crystal docs` command could use a bit more documentation. Additionally, I noticed that the startup process for gitbook includes a `gitbook install` step so I threw that in here as well.