### PR TITLE
Fixed a variable name in the if-var concurrent clojure example

### DIFF
--- a/syntax_and_semantics/if_var.md
+++ b/syntax_and_semantics/if_var.md
@@ -47,7 +47,7 @@ if @@a
 end
 
 a = nil
-closure = ->(){ foo = "foo" }
+closure = ->(){ a = "foo" }
 
 if a
   # here `a` can be nil


### PR DESCRIPTION
The example demonstrates a concurrent variable update case, which causes a non-deterministic runtime behavior. This commit changes the variable name defined in the upper scope and alternated in this clojure.