### PR TITLE
Reporting inconsistency in String docs

### DIFF
--- a/syntax_and_semantics/literals/string.md
+++ b/syntax_and_semantics/literals/string.md
@@ -190,5 +190,5 @@ To denote a heredoc without interpolation or escapes, the opening heredoc identi
 ```crystal
 <<-'HERE'
   hello \n #{world}
-  HERE # => "hello \n #{world}"
+  HERE # => "hello \\n \#{world}"
 ```


### PR DESCRIPTION
The docs for this page are inconsistent in how they use the "result" expression comment
```crystal
# => "result"
```

In use is both the actual "representation" of the string, and how the string would be printed to the terminal.

### This example uses the "representation" of the string:
A literal denoted by `%q` does not apply interpolation nor escapes while `%Q` has the same meaning as `%`.
```crystal
name = "world"
%q(hello \n #{name}) # => "hello \\n \#{name}"
%Q(hello \n #{name}) # => "hello \n world"
```
```crystal
# Actually printed to terminal:
Hello \n #{name}
Hello
 world
```
### However this heredoc example uses the result expression to display what is actually printed to the terminal and not the "representation":
To denote a heredoc without interpolation or escapes, the opening heredoc identifier is enclosed in single quotes:
```crystal
<<-'HERE'
  hello \n #{world}
  HERE # => "hello \n #{world}"
```
```crystal
# Actually printed to terminal:
hello \n #{world}
```

### To maintain consistency, this example should actually read
```crystal
<<-'HERE'
  hello \n #{world}
  HERE # => "hello \\n \#{world}"
```

However I think this is confusing for new readers to grasp that this means the uninterpolated text "`hello \n #{world}`"