### PR TITLE
Find missing "Percent string array literal"

### DIFF
--- a/syntax_and_semantics/literals/string.md
+++ b/syntax_and_semantics/literals/string.md
@@ -111,6 +111,22 @@ name = "world"
 %Q(hello \n #{name}) # => "hello \n world"
 ```
 
+## Percent string array literal
+
+Besides the single string literal, there is also a percent literal to create an [Array](https://crystal-lang.org/api/Array.html) of strings. It is indicated by `%w` and a pair of delimiters. Valid delimiters are as same as [percent string literals](#Percent string literals).
+
+```crystal
+%w(foo bar baz) # => ["foo", "bar", "baz"]
+%w(foo\nbar baz) # => ["foo\\nbar", "baz"]
+%w(foo(bar) baz) # => ["foo(bar)", "baz"]
+```
+
+Note that literal denoted by `%w` does not apply interpolation nor escapes expect spaces. Since strings are separated by a single space character (` `) which must be escaped to use it as a part of a string.
+
+```crystal
+%w(foo\ bar baz) # => ["foo bar", "baz"]
+```
+
 ## Multiline strings
 
 Any string literal can span multiple lines:


### PR DESCRIPTION
On "Percent Array Literals" section on Array page, there's a link to "Percent String Array Literal", but this section is not available in String page now.

So, here is that missing section.