### PR TITLE
Fix regex literal docs incorrectly listing \uNNNN syntax

### DIFF
--- a/syntax_and_semantics/literals/regex.md
+++ b/syntax_and_semantics/literals/regex.md
@@ -27,8 +27,7 @@ Regular expressions support the same [escape sequences as String literals](./str
 /\v/ # vertical tab
 /\NNN/ # octal ASCII character
 /\xNN/ # hexadecimal ASCII character
-/\uNNNN/ # hexadecimal unicode character
-/\u{NNNN...}/ # hexadecimal unicode character
+/\x{NNNN...}/ # hexadecimal unicode character
 ```
 
 The delimiter character `/` must be escaped inside slash-delimited regular expression literals.


### PR DESCRIPTION
For some reason, this syntax is listed in the docs despite leading to an error like
```
Syntax error in regex-test.cr:12: invalid regex: PCRE does not support \L, \l, \N{name}, \U, or \u at 1

/\u1234/ # hexadecimal unicode character
^

```

The `\x{NNNN}` syntax seems to work fine however, so I've replaced the `\u` syntax with that.