### PR TITLE
Update passing a closure as callback example

### DIFF
--- a/syntax_and_semantics/c_bindings/callbacks.md
+++ b/syntax_and_semantics/c_bindings/callbacks.md
@@ -57,9 +57,9 @@ To properly define a wrapper for this function we must send the Proc as the call
 
 ```crystal
 module Ticker
-  @@box : Box(Int32 ->)
-
   # The callback for the user doesn't have a Void*
+  @@box : Pointer(Void)?
+
   def self.on_tick(&callback : Int32 ->)
     # Since Proc is a {Void*, Void*}, we can't turn that into a Void*, so we
     # "box" it: we allocate memory and store the Proc there


### PR DESCRIPTION
This change updates the passing a closure as callback example to the one listed in the API docs for [Proc](https://crystal-lang.org/api/0.27.0/Proc.html).

Basically... the type of `@@box` `Box(Int32 ->)` is actually a `Pointer(Void)?` now (or maybe it has always been that way?)