### PR TITLE
Fix directory name for init example

### DIFF
--- a/using_the_compiler/README.md
+++ b/using_the_compiler/README.md
@@ -213,7 +213,7 @@ in its repository and no build target in `shard.yml`, but instructions for using
 
 Example:
 ```shell-session
-$ crystal init lib mylib
+$ crystal init lib my_cool_lib
     create  my_cool_lib/.gitignore
     create  my_cool_lib/.editorconfig
     create  my_cool_lib/LICENSE


### PR DESCRIPTION
Hello, I noticed that the docs provide the following example, in which the directory name in the command should actually be `my_cool_lib` (based on the output):

```
$ crystal init lib mylib
    create  my_cool_lib/.gitignore
    create  my_cool_lib/.editorconfig
    create  my_cool_lib/LICENSE
    create  my_cool_lib/README.md
    create  my_cool_lib/.travis.yml
    create  my_cool_lib/shard.yml
    create  my_cool_lib/src/my_cool_lib.cr
    create  my_cool_lib/spec/spec_helper.cr
    create  my_cool_lib/spec/my_cool_lib_spec.cr
Initialized empty Git repository in ~/my_cool_lib/.git
```