### PR TITLE
Extend next's documentation

### DIFF
--- a/syntax_and_semantics/next.md
+++ b/syntax_and_semantics/next.md
@@ -15,7 +15,7 @@ end
 # The above prints the numbers 2, 4 and 5
 ```
 
-But `next` can also be used to exit from blocks, for example:
+`next` can also be used to exit from a block, for example:
 
 ```crystal
 def block
@@ -31,7 +31,7 @@ end
 # The above prints the numbers 1 and 2
 ```
 
-Similar to [`break`](break.md), `next` can also take a parameter which will then be the value that gets returned:
+Similar to [`break`](break.md), `next` can also take a parameter which will then be returned by `yield`.
 
 ```crystal
 def block

--- a/syntax_and_semantics/next.md
+++ b/syntax_and_semantics/next.md
@@ -39,9 +39,8 @@ def block
 end
 
 block do
-  puts 1, 2
-  next 3
+  next "hello"
 end
 
-# The above prints the numbers 1, 2 and 3
+# The above prints "hello"
 ```

--- a/syntax_and_semantics/next.md
+++ b/syntax_and_semantics/next.md
@@ -23,12 +23,12 @@ def block
 end
 
 block do
-  puts 1, 2
+  puts "hello"
   next
-  puts 3
+  puts "world"
 end
 
-# The above prints the numbers 1 and 2
+# The above prints "hello"
 ```
 
 Similar to [`break`](break.md), `next` can also take a parameter which will then be returned by `yield`.

--- a/syntax_and_semantics/next.md
+++ b/syntax_and_semantics/next.md
@@ -15,7 +15,7 @@ end
 # The above prints the numbers 2, 4 and 5
 ```
 
-But `next` can also be used to exit from captured blocks, for example:
+But `next` can also be used to exit from blocks, for example:
 
 ```crystal
 def block

--- a/syntax_and_semantics/next.md
+++ b/syntax_and_semantics/next.md
@@ -35,15 +35,13 @@ Similar to [`break`](break.md), `next` can also take a parameter which will then
 
 ```crystal
 def block
-  yield
+  puts yield
 end
 
-three = block do
+block do
   puts 1, 2
   next 3
 end
-
-puts three
 
 # The above prints the numbers 1, 2 and 3
 ```

--- a/syntax_and_semantics/next.md
+++ b/syntax_and_semantics/next.md
@@ -11,5 +11,39 @@ while a < 5
   end
   puts a
 end
+
 # The above prints the numbers 2, 4 and 5
+```
+
+But `next` can also be used to exit from captured blocks, for example:
+
+```crystal
+def block
+  yield
+end
+
+block do
+  puts 1, 2
+  next
+  puts 3
+end
+
+# The above prints the numbers 1 and 2
+```
+
+Similar to [`break`](syntax_and_semantics/break.md), `next` can also take a parameter which will then be the value that gets returned:
+
+```crystal
+def block
+  yield
+end
+
+three = block do
+  puts 1, 2
+  next 3
+end
+
+puts three
+
+# The above prints the numbers 1, 2 and 3
 ```

--- a/syntax_and_semantics/next.md
+++ b/syntax_and_semantics/next.md
@@ -31,7 +31,7 @@ end
 # The above prints the numbers 1 and 2
 ```
 
-Similar to [`break`](syntax_and_semantics/break.md), `next` can also take a parameter which will then be the value that gets returned:
+Similar to [`break`](break.md), `next` can also take a parameter which will then be the value that gets returned:
 
 ```crystal
 def block


### PR DESCRIPTION
Fixes #97 and documents that `next` can be used to exit from blocks.