### PR TITLE
add libz-dev to recommended Debian/Ubuntu packages

### DIFF
--- a/installation/on_debian_and_ubuntu.md
+++ b/installation/on_debian_and_ubuntu.md
@@ -33,6 +33,7 @@ sudo apt install libxml2-dev     # for using XML
 sudo apt install libyaml-dev     # for using YAML
 sudo apt install libgmp-dev      # for using Big numbers
 sudo apt install libreadline-dev # for using Readline
+sudo apt install libz-dev        # for using crystal play
 ```
 
 For building the Crystal compiler itself, a few other dependencies are needed, see [wiki page](https://github.com/crystal-lang/crystal/wiki/All-required-libraries#ubuntu). They are not required for regular compiler use.


### PR DESCRIPTION
Without libz-dev, `crystal play` (later in the file) crashes with the error: 

/usr/bin/ld: cannot find -lz (this usually means you need to install the development package for libz)
collect2: error: ld returned 1 exit status