### PR TITLE
Update instructions for homebrew on Macs with Mojave

### DIFF
--- a/installation/on_mac_osx_using_homebrew.md
+++ b/installation/on_mac_osx_using_homebrew.md
@@ -21,3 +21,18 @@ you need to reinstall the command line tools and then select the default active 
 $ xcode-select --install
 $ xcode-select --switch /Library/Developer/CommandLineTools
 ```
+
+## Troubleshooting on OSX 10.14 (Mojave)
+
+If you get an error like:
+
+```
+ld: library not found for -lssl
+```
+
+you need to ensure openssl is installed and then export its config path:
+
+```
+$ brew install openssl
+$ export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/opt/openssl/lib/pkgconfig
+```


### PR DESCRIPTION
Updated installation instructions for homebrew on Mac to include workaround for Mojave, which has been out since September 24, 2018 for macs from mid 2012 and newer, as per https://forum.crystal-lang.org/t/noob-error-in-brew-installation-on-mac/714/6?u=thbo and https://github.com/crystal-lang/crystal/pull/7494.