### PR TITLE
Fix the module instantiation example

### DIFF
--- a/syntax_and_semantics/modules.md
+++ b/syntax_and_semantics/modules.md
@@ -121,5 +121,5 @@ A module cannot be instantiated:
 module Moo
 end
 
-Moo.new # undefined method 'new' for Moo:Class
+Moo.new # undefined method 'new' for Moo:Module
 ```


### PR DESCRIPTION
The supplied compiler output is wrong and confusing because Class actually has a 'new' method.