### PR TITLE
Fix using the compiler typos

### DIFF
--- a/using_the_compiler/README.md
+++ b/using_the_compiler/README.md
@@ -366,10 +366,10 @@ specifying the current working directory.
 
 ## Environment variables
 
-The following environment variables are used by the Crystal compiler if set in the environment. Otherwise the compiler will populate them with default values. Their values can be inspected using `[crystal env](#crystal-env)`.
+The following environment variables are used by the Crystal compiler if set in the environment. Otherwise the compiler will populate them with default values. Their values can be inspected using [`crystal env`](#crystal-env).
 
-* `CRYSTAL_CACHE_DIR`: Defines path where Crystal caches partial compilation results for faster subsequent builds. This path is also used to temporarily store executables when Crystal programs are run with `[crystal env](#crystal-run)` rather than `[crystal build](#crystal-build)`.
+* `CRYSTAL_CACHE_DIR`: Defines path where Crystal caches partial compilation results for faster subsequent builds. This path is also used to temporarily store executables when Crystal programs are run with [`crystal run`](#crystal-run) rather than [`crystal build`](#crystal-build).
   Default value is the first directory that either exists or can be created of `${XDG_CACHE_HOME}/crystal` (if `XDG_CACHE_HOME` is defined), `${HOME}/.cache/crystal`, `${HOME}/.crystal`, `./.crystal`. If `CRYSTAL_CACHE_DIR` is set but points to a path that is not writeable, the default values are used instead.
 * `CRYSTAL_PATH`: Defines paths where Crystal searches for required files.
-* `CRYSTAL_VERSION` is only available as output of `crystal env`. The compiler neither sets nor reads it.
+* `CRYSTAL_VERSION` is only available as output of [`crystal env`](#crystal-env). The compiler neither sets nor reads it.
 * `CRYSTAL_LIBRARY_PATH`: The compiler uses the paths in this variable as a first lookup destination for static and dynamic libraries that are to be linked. For example, if static libraries are put in `build/libs`, setting the environment variable accordingly will tell the compiler to look for libraries there.


### PR DESCRIPTION
Fix using the compiler typos while linking sections so desired section is properly linked.