### PR TITLE
Update integers.md to mention Int128 and UInt128

### DIFF
--- a/syntax_and_semantics/literals/integers.md
+++ b/syntax_and_semantics/literals/integers.md
@@ -1,6 +1,6 @@
 # Integers
 
-There are four signed integer types, and four unsigned integer types:
+There are five signed integer types, and five unsigned integer types:
 
 Type | Length  | Minimum Value | Maximum Value
  ---------- | -----------: | -----------: |-----------:

--- a/syntax_and_semantics/literals/integers.md
+++ b/syntax_and_semantics/literals/integers.md
@@ -8,10 +8,12 @@ Type | Length  | Minimum Value | Maximum Value
 [Int16](http://crystal-lang.org/api/Int16.html)  | 16 | −32,768 | 32,767
 [Int32](http://crystal-lang.org/api/Int32.html) | 32  | −2,147,483,648 | 2,147,483,647
 [Int64](http://crystal-lang.org/api/Int64.html)   |  64 | −2<sup>63</sup> | 2<sup>63</sup> - 1
+[Int128](http://crystal-lang.org/api/Int64.html)   |  128 | −2<sup>127</sup> | 2<sup>127</sup> - 1
 [UInt8](http://crystal-lang.org/api/UInt8.html) | 8 |  0 | 255
 [UInt16](http://crystal-lang.org/api/UInt16.html) | 16 | 0 | 65,535
 [UInt32](http://crystal-lang.org/api/UInt32.html) | 32 |  0 | 4,294,967,295
 [UInt64](http://crystal-lang.org/api/UInt64.html) | 64 | 0 | 2<sup>64</sup> - 1
+[UInt128](http://crystal-lang.org/api/UInt64.html) | 128 | 0 | 2<sup>128</sup> - 1
 
 An integer literal is an optional `+` or `-` sign, followed by
 a sequence of digits and underscores, optionally followed by a suffix.
@@ -25,11 +27,13 @@ in which the number fits:
 1_i16  # Int16
 1_i32  # Int32
 1_i64  # Int64
+1_i128  # Int128
 
 1_u8   # UInt8
 1_u16  # UInt16
 1_u32  # UInt32
 1_u64  # UInt64
+1_u128  # UInt128
 
 +10    # Int32
 -20    # Int32


### PR DESCRIPTION
I noticed that Crystal supports 128 bit integers (nice!), but they aren't in the documentation.

Are 128 bit ints supported on all platforms?