### PR TITLE
Update http_server.md

### DIFF
--- a/overview/http_server.md
+++ b/overview/http_server.md
@@ -7,7 +7,7 @@ require "http/server"
 
 server = HTTP::Server.new do |context|
   context.response.content_type = "text/plain"
-  context.response.print "Hello world! The time is #{Time.now}"
+  context.response.print "Hello world! The time is #{Time.local}"
 end
 
 address = server.bind_tcp 8080


### PR DESCRIPTION
In server.cr:5:59
 5 | context.response.print "Hello world! The time is #{Time.now}"
                                                             ^--
Warning: Deprecated Time.now. Use `Time.local` or `Time.utc` instead.
A total of 1 warnings were found.
Listening on http://127.0.0.1:8080