### PR TITLE
Fix gitbook version to 3.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:6.9.2-alpine
 
 RUN npm install -g gitbook-cli@2.3.0
 
-RUN gitbook install 3.2.2
+RUN gitbook fetch 3.2.2
 
 RUN mkdir /src
 WORKDIR /src

--- a/book.json
+++ b/book.json
@@ -1,5 +1,5 @@
 {
-    "gitbook": "3.x.x",
+    "gitbook": "3.2.2",
     "links": {
         "contributePrefix": "https://github.com/crystal-lang/crystal-book/"
     },


### PR DESCRIPTION
Update docker to install fixed version directly

Otherwise there was an error bumping

```
crystal-book | info: 10 plugins are installed 
crystal-book | info: loading plugin "ga"... OK 
crystal-book | info: loading plugin "edit-link"... OK 
crystal-book | info: loading plugin "offline"... OK 
crystal-book | info: loading plugin "livereload"... OK 
crystal-book | info: loading plugin "highlight"... OK 
crystal-book | info: loading plugin "search"... OK 
crystal-book | info: loading plugin "lunr"... OK 
crystal-book | info: loading plugin "sharing"... OK 
crystal-book | info: loading plugin "fontsettings"... OK 
crystal-book | info: loading plugin "theme-default"... OK 
crystal-book | info: found 140 pages 
crystal-book | info: found 5 asset files 
crystal-book | 
crystal-book | Error: ENOENT: no such file or directory, stat '/src/_book/gitbook/gitbook-plugin-sharing/buttons.js'
```