### PR TITLE
you can test without colors

### DIFF
--- a/guides/testing.md
+++ b/guides/testing.md
@@ -116,9 +116,14 @@ By convention, specs live in the `spec/` directory of a project. Spec files must
 
 You can compile and run specs from folder trees, individual files or specific lines in a file.
 
+You can turn off colors with the switch `--no-color`.
+
 ```bash
 # Run  all specs in files matching spec/**/*_spec.cr
 crystal spec
+
+# Run  all specs in files matching spec/**/*_spec.cr without colors
+crystal spec --no-color
 
 # Run all specs in files matching spec/my/test/**/*_spec.cr
 crystal spec spec/my/test/


### PR DESCRIPTION
Took me hours to find this as I am using acme editor which meant I was getting all the all the color commands as junk and you cannot turn off through `export TERM=dumb`. Adding it to the gitbook so others dont struggle.