### PR TITLE
Use `:ditto:` instead of `ditto`

### DIFF
--- a/conventions/documenting_code.md
+++ b/conventions/documenting_code.md
@@ -96,10 +96,10 @@ For example:
 Unicorn.new.speak # => "I'm a unicorn"
 ```
 
-* Use `ditto` to use the same comment as in the previous declaration.
+* Use `:ditto:` to use the same comment as in the previous declaration.
 
 ```crystal
-# ditto
+# :ditto:
 def number_of_horns
   horns
 end
@@ -212,7 +212,7 @@ class Unicorn
     @horns
   end
 
-  # ditto
+  # :ditto:
   def number_of_horns
     horns
   end


### PR DESCRIPTION
Ref: https://github.com/crystal-lang/crystal/pull/6362

Although it is already a valid change.