### PR TITLE
channel usage example between classes

### DIFF
--- a/guides/concurrency.md
+++ b/guides/concurrency.md
@@ -377,3 +377,132 @@ After send
 ```
 
 Note that the first 2 sends are executed without switching to another fiber. However, in the third send the channel's buffer is full, so execution goes to the main fiber. Here the two values are received and the channel is depleted. At the third `receive` the main fiber blocks and execution goes to the other fiber, which sends more values, finishes, etc.
+
+
+### Channel usage example
+
+Here is an example of using channels to send messages between objects.
+Closing the channels & waiting for the `status` closed call-back from all User channels before ending.
+```
+class User
+  getter channel : Channel(String)
+  private getter name : String, email : String, status : Channel(Nil)
+
+  def initialize(@name, @email, @status)
+    @channel = Channel(String).new(1)
+    listen_for_messages
+  end
+
+  def send_message(message : String, receiver : User = self)
+    if message == "close" && receiver == self
+      # works when all messages are queued immediately i.e. no: spawn channel.send("message")
+      channel.close
+      status.send(nil)
+      puts "CLOSED: #{to_s}"
+    elsif receiver == self            # avoid infinite channel loop with self
+      post_message "SELF: #{message}"
+    elsif !receiver.channel.closed?   # avoid some runtime errors - don't send if channel already closed
+      receiver.channel.send(message)  # send immediately (not async) - to ensure channel doesn't close
+    else
+      puts "NO DELIVERY: To: #{receiver.to_s} not receiving -- Message: '#{message}'"
+    end
+  end
+
+  def to_s
+    "#{name} <#{email}>"
+  end
+
+  private def post_message(message)
+    puts "To: #{to_s} -- #{message}"
+  end
+
+  private def listen_for_messages
+    spawn do
+      loop do
+        message = channel.receive?
+        break     if message.nil?  # Channel is emppost_message(message)
+
+        post_message("CHANNEL: #{message}")
+      end
+    end
+  end
+end
+
+
+# create users
+status = Channel(Nil).new
+user_1 = User.new(name: "first",  email: "first@example.ch", status: status)
+user_2 = User.new(name: "second", email: "second@example.ch", status: status)
+
+# and user list
+users = [] of User
+users << user_1
+users << user_2
+
+puts "REAL-TIME - START"
+spawn user_1.send_message("ASYNC sent 1st", receiver: user_2)
+user_1.send_message("REAL-TIME sent 2nd", receiver: user_2)
+spawn user_1.send_message("ASYNC sent 3th", receiver: user_2)
+spawn user_2.send_message("ASYNC sent 4th", receiver: user_1)
+user_2.send_message("REAL-TIME sent 5th", receiver: user_1)
+user_1.send_message("REAL-TIME sent 6th", receiver: user_1)
+
+# close channels - async to allow messages to flush
+users.each do |user|
+  spawn user.send_message("close")
+end
+puts "REAL-TIME - DONE"
+
+puts "STATUS Channels - WAIT for all channels to call-back with status closed"
+user_count = users.size
+user_count.times { status.receive }
+puts "ALL CLEINTS CLOSED? #{ users.all?{ |u| u.channel.closed? } }"
+
+user_1.send_message("No Error", receiver: user_2)  # protected from run-time error
+# user_1.channel.send("RUNTIME Error")
+```
+
+
+Another (brute-force) way to close all channels and wait for them to clear is to do:
+```
+users.each do |user|
+  spawn user.channel.send("close")
+end
+
+puts "ALL CLIENTS CLOSED? #{ users.all?{ |u| u.channel.closed? } }"
+loop do
+  break if users.all?{ |u| u.channel.closed? }
+  Fiber.yield  # give fibers a chance to execute
+end
+puts "ALL CLIENTS CLOSED? #{ users.all?{ |u| u.channel.closed? } }"
+```
+
+With mass messaging AVOID sending messages with spawn -- it is important to get the message queued while the channel is open.  
+
+To see this in action enable the commented out `spawn` line in the following code.
+```
+users  = [] of User
+status = Channel(Nil).new
+100.times do |i|
+  user = User.new(name: "user_#{i}",  email: "user_#{i}@example.ch", status: status)
+  users << user
+end
+
+users.each do |sender|
+  users.each do |receiver|
+    sender.send_message("From: #{sender.to_s} - with channel", receiver: receiver)
+    # spawn sender.send_message("From: #{sender.to_s} - with channel", receiver: receiver)
+  end
+end
+
+users.each do |sender|
+  # sender.send_message("close")
+  spawn sender.send_message("close")
+end
+
+puts "STATUS Channels - Testing"
+user_count = users.size
+user_count.times { status.receive }
+puts "STATUS Channels - DONE"
+puts "ALL CLIENTS CLOSED? #{ users.all?{ |u| u.channel.closed? } }"
+```


### PR DESCRIPTION
**Purpose:** To document the usage of Channels for communication between classes and waiting for callbacks (to wait to end after all messages are delivered). 

**Reason:** Concurrency & lightweight Fibers are a very intersting aspect of Crystal - I found new working examples to get me started with realistic uses of Channels and Fibers.  So I thought the Crystal Git book might be a good place to add a working example using:

Crystal 0.32.1 (2019-12-18)

LLVM: 9.0.0
Default target: x86_64-apple-macosx
