### PR TITLE
Marked "when" as code in tuple literal paragraph

### DIFF
--- a/syntax_and_semantics/case.md
+++ b/syntax_and_semantics/case.md
@@ -103,7 +103,7 @@ This sometimes leads to code that is more natural to read.
 
 ## Tuple literal
 
-When a case expression is a tuple literal there are a few semantic differences if a when condition is also a tuple literal.
+When a case expression is a tuple literal there are a few semantic differences if a `when` condition is also a tuple literal.
 
 ### Tuple size must match
 


### PR DESCRIPTION
I think marking the "when" keyword as code would make the paragraph easier to understand.

Unedited version: "When a case expression is a tuple literal there are a few semantic differences if a when condition is also a tuple literal."

Edited version: "When a case expression is a tuple literal there are a few semantic differences if a `when` condition is also a tuple literal."