### PR TITLE
Modify table format

### DIFF
--- a/syntax_and_semantics/literals/integers.md
+++ b/syntax_and_semantics/literals/integers.md
@@ -2,16 +2,16 @@
 
 There are four signed integer types, and four unsigned integer types:
 
-Type | Length  | Minimum Value | Maximum Value
- ---------- | -----------: | -----------: |-----------:
-[Int8](http://crystal-lang.org/api/Int8.html)  | 8       | -128 | 127
-[Int16](http://crystal-lang.org/api/Int16.html)  | 16 | −32,768 | 32,767
-[Int32](http://crystal-lang.org/api/Int32.html) | 32  | −2,147,483,648 | 2,147,483,647
-[Int64](http://crystal-lang.org/api/Int64.html)   |  64 | −2<sup>63</sup> | 2<sup>63</sup> - 1
-[UInt8](http://crystal-lang.org/api/UInt8.html) | 8 |  0 | 255
-[UInt16](http://crystal-lang.org/api/UInt16.html) | 16 | 0 | 65,535
-[UInt32](http://crystal-lang.org/api/UInt32.html) | 32 |  0 | 4,294,967,295
-[UInt64](http://crystal-lang.org/api/UInt64.html) | 64 | 0 | 2<sup>64</sup> - 1
+| Type | Length  | Minimum Value | Maximum Value |
+| ---------- | -----------: | -----------: |-----------: |
+| [Int8](http://crystal-lang.org/api/Int8.html)  | 8       | -128 | 127 |
+| [Int16](http://crystal-lang.org/api/Int16.html)  | 16 | −32,768 | 32,767 |
+| [Int32](http://crystal-lang.org/api/Int32.html) | 32  | −2,147,483,648 | 2,147,483,647 |
+| [Int64](http://crystal-lang.org/api/Int64.html)   |  64 | −2<sup>63</sup> | 2<sup>63</sup> - 1 |
+| [UInt8](http://crystal-lang.org/api/UInt8.html) | 8 |  0 | 255 |
+| [UInt16](http://crystal-lang.org/api/UInt16.html) | 16 | 0 | 65,535 |
+| [UInt32](http://crystal-lang.org/api/UInt32.html) | 32 |  0 | 4,294,967,295 |
+| [UInt64](http://crystal-lang.org/api/UInt64.html) | 64 | 0 | 2<sup>64</sup> - 1 |
 
 An integer literal is an optional `+` or `-` sign, followed by
 a sequence of digits and underscores, optionally followed by a suffix.


### PR DESCRIPTION
When both side of vertical bar `|` of table is missing, the translation tool (Okapi framework) fails on parsing this table.

See screen shot:

![スクリーンショット 2020-04-20 3 44 49](https://user-images.githubusercontent.com/6679325/79696697-5089f300-82b9-11ea-9b84-50a684dd0035.png)

I think it is a bug of [Markdown library Okapi uses](https://github.com/vsch/flexmark-java). However it is little fix, and it does not effect readability. Please merge it for Japanese Crystal users :pray: