### PR TITLE
Fix typos

### DIFF
--- a/guides/ci/circleci.md
+++ b/guides/ci/circleci.md
@@ -1,6 +1,6 @@
 # CircleCI
 
-In this section we are going to use [CircleCI](https://circleci.com/) as our continuous-integration service. In a [few words](https://circleci.com/docs/2.0/about-circleci/#section=welcome) CircleCI automates your software builds, tests, and deployments. It supports [different programming laguages](https://circleci.com/docs/2.0/demo-apps/#section=welcome) and for our particular case, it supports the [Crystal language](https://circleci.com/docs/2.0/language-crystal/).
+In this section we are going to use [CircleCI](https://circleci.com/) as our continuous-integration service. In a [few words](https://circleci.com/docs/2.0/about-circleci/#section=welcome) CircleCI automates your software builds, tests, and deployments. It supports [different programming languages](https://circleci.com/docs/2.0/demo-apps/#section=welcome) and for our particular case, it supports the [Crystal language](https://circleci.com/docs/2.0/language-crystal/).
 
 In this section we are going to present some configuration examples to see how CircleCI implements some [continuous integration concepts](https://circleci.com/docs/2.0/concepts/).
 

--- a/guides/ci/travis.md
+++ b/guides/ci/travis.md
@@ -1,6 +1,6 @@
 # Travis CI
 
-In this section we are going to use [Travis CI](https://travis-ci.org/) as our continuous-integration service. Travis CI is [mostly used](https://docs.travis-ci.com/user/tutorial/#more-than-running-tests) for building and running tests for projects hosted at GitHub. It supports [different programming laguages](https://docs.travis-ci.com/user/tutorial/#selecting-a-different-programming-language) and for our particular case, it supports the [Crystal language](https://docs.travis-ci.com/user/languages/crystal/).
+In this section we are going to use [Travis CI](https://travis-ci.org/) as our continuous-integration service. Travis CI is [mostly used](https://docs.travis-ci.com/user/tutorial/#more-than-running-tests) for building and running tests for projects hosted at GitHub. It supports [different programming languages](https://docs.travis-ci.com/user/tutorial/#selecting-a-different-programming-language) and for our particular case, it supports the [Crystal language](https://docs.travis-ci.com/user/languages/crystal/).
 
 >**Note:**If you are new to continuous integration (or you want to refresh the basic concepts) we may start reading the [core concepts guide](https://docs.travis-ci.com/user/for-beginners/).
 

--- a/syntax_and_semantics/blocks_and_procs.md
+++ b/syntax_and_semantics/blocks_and_procs.md
@@ -354,7 +354,7 @@ twice do |i|
   puts "Got #{i}"
 end
 
-# Ouptut:
+# Output:
 # Skipping 1
 # Got 2
 ```


### PR DESCRIPTION
Hello,

This tiny PR will fix : 

- 1 typo in `guides/ci/circleci.md`
- 1 typo in `guides/ci/travis.md`
- 1 typo in `syntax_and_semantics/blocks_and_procs.md`



Best! :robot: