### PR TITLE
Database guide: Highlight different syntax for query parameters

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -67,14 +67,15 @@ To execute sql statements you can use `Database#exec`
 db.exec "create table contacts (name varchar(30), age int)"
 ```
 
-To avoid sql injection use parameters to submit data
+To avoid [SQL injection](https://owasp.org/www-community/attacks/SQL_Injection) values can be provided as query parameters.
+The syntax for using query parameters depends on the database driver because they are typically just passed through to the database. MySQL uses `?` for parameter expansion and assignment is based on argument order. PostgreSQL uses `$n` where `n` is the ordinal number of the argument (starting with 1).
 
 ```crystal
+# MySQL
 db.exec "insert into contacts values (?, ?)", "John", 30
-db.exec "insert into contacts values (?, ?)", "Sarah", 33
+# Postgres
+db.exec "insert into contacts values ($1, $2)", "Sarah", 33
 ```
-
-Note: When using the pg driver, use `$1`, `$2`, etc. instead of `?`
 
 ## Query
 


### PR DESCRIPTION
The previous trailing note was not visible enough when skimming the document.