### PR TITLE
Added entry for CamelCase enum value

### DIFF
--- a/conventions/coding_style.md
+++ b/conventions/coding_style.md
@@ -65,6 +65,15 @@ LUCKY_NUMBERS     = [3, 7, 11]
 DOCUMENTATION_URL = "http://crystal-lang.org/docs"
 ```
 
+__Enum Value Names__ are camelcased.  For example:
+
+```crystal
+enum IceCream::Flavour
+  Vanilla
+  SaltedCaramel
+  MintChocChip
+end
+```
 ### Acronyms
 
 In class names, acronyms are _all-uppercase_. For example, `HTTP`, and `LibXML`.


### PR DESCRIPTION
The approved style for enum values is CamelCase, as per https://github.com/crystal-lang/crystal/issues/7270

However this is not stated in the style guide, although the approved style for constants is.