### PR TITLE
Fix wrong description of `Int32?` in regular code

### DIFF
--- a/syntax_and_semantics/type_grammar.md
+++ b/syntax_and_semantics/type_grammar.md
@@ -45,7 +45,7 @@ is the same as:
 alias Int32OrNil = Int32 | ::Nil
 ```
 
-In regular code, `Int32?` is a syntax error.
+In regular code, `Int32?` is an `Int32 | ::Nil` union type itself.
 
 ## Pointer
 


### PR DESCRIPTION
For instance, the following code is valid:

```crystal
p Int32? # => Int32 | Nil
```

And it is used [here](https://github.com/crystal-lang/crystal/blob/2cbe65b0a13c8a2ce91bd4799f5b96b8e1953097/src/array.cr#L1774).