### PR TITLE
Add anchor links for documentation headers

### DIFF
--- a/book.json
+++ b/book.json
@@ -3,7 +3,7 @@
     "links": {
         "contributePrefix": "https://github.com/crystal-lang/crystal-book/"
     },
-    "plugins": ["ga", "edit-link", "offline"],
+    "plugins": ["anchors", "ga", "edit-link", "offline"],
     "pluginsConfig": {
         "ga": {
             "token": "UA-42353458-1"

--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   "repository": "github:crystal-lang/crystal-book",
   "devDependencies": {
     "gitbook-plugin-ga": "^1.0.1"
+  },
+  "dependencies": {
+    "gitbook-plugin-anchors": "^0.7.1"
   }
 }


### PR DESCRIPTION
This makes it easier to link to a specific part of a page without having
to hunt through the source to find the id for a particular title.