### PR TITLE
Provide an example of a symbol with Unicode codepoint

### DIFF
--- a/syntax_and_semantics/literals/symbol.md
+++ b/syntax_and_semantics/literals/symbol.md
@@ -8,6 +8,7 @@ Symbols are interpreted at compile time and cannot be created dynamically. The o
 :unquoted_symbol
 :"quoted symbol"
 :"a" # identical to :a
+:あ
 ```
 
 A double-quoted identifier can contain any unicode character including white spaces and accepts the same escape sequences as a [string literal](./string.html), yet no interpolation.


### PR DESCRIPTION
As explained in the text below, a symbol can contain Unicode codepoints.
Provide an example to prove the point.