### PR TITLE
Use proper spelling for the word truthiness

### DIFF
--- a/syntax_and_semantics/not.md
+++ b/syntax_and_semantics/not.md
@@ -1,6 +1,6 @@
 # if !
 
-The `!` operator returns a `Bool` that results from negating the [truthyness](truthy_and_falsey_values.html) of a value.
+The `!` operator returns a `Bool` that results from negating the [truthiness](truthy_and_falsey_values.html) of a value.
 
 When used in an `if` in conjunction with a variable, `is_a?`, `responds_to?` or `nil?` the compiler will restrict the types accordingly:
 


### PR DESCRIPTION
See, for example, https://en.wikipedia.org/wiki/Truthiness