### PR TITLE
Restore the page overview/README.md, delete all unused & empty pages

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,6 +5,7 @@
   * [A Command Line Application](getting_started/cli.md)
 * [Using the compiler](using_the_compiler/README.md)
 * [The shards command](the_shards_command/README.md)
+* [About this guide](overview/README.md)
 * [Syntax and semantics](syntax_and_semantics/README.md)
    * [Comments](syntax_and_semantics/comments.md)
    * [Literals](syntax_and_semantics/literals.md)

--- a/syntax_and_semantics/blocks_performance.md
+++ b/syntax_and_semantics/blocks_performance.md
@@ -1,2 +1,0 @@
-# Performance
-

--- a/syntax_and_semantics/proc_pointer.md
+++ b/syntax_and_semantics/proc_pointer.md
@@ -1,1 +1,0 @@
-# Proc pointer


### PR DESCRIPTION
Pages that are never linked to are impossible to view, and MkDocs would've complained about that.