### PR TITLE
Use actual admonition syntax for "NOTE:"

### DIFF
--- a/docs/conventions/documenting_code.md
+++ b/docs/conventions/documenting_code.md
@@ -170,7 +170,8 @@ Some documentation specific to *id*'s usage within `Child`.
 Some documentation common to every *id*.
 ```
 
-> **NOTE:** Inheriting documentation only works on _instance_, non-constructor methods.
+!!! note
+    Inheriting documentation only works on _instance_, non-constructor methods.
 
 ### Flagging Classes, Modules, and Methods
 

--- a/docs/database/transactions.md
+++ b/docs/database/transactions.md
@@ -160,7 +160,8 @@ db.transaction do |tx|
 end
 ```
 
-**NOTE:** After `commit` or `rollback` are used, the transaction is no longer usable. The connection is still open but any statement will be performed outside the context of the terminated transaction.
+!!! note
+    After `commit` or `rollback` are used, the transaction is no longer usable. The connection is still open but any statement will be performed outside the context of the terminated transaction.
 
 ## Nested transactions
 

--- a/docs/getting_started/README.md
+++ b/docs/getting_started/README.md
@@ -66,7 +66,8 @@ $ crystal hello_world.cr
 Hello World!
 ```
 
-**Note:** The main routine is simply the program itself. There's no need to define a "main" function or something similar.
+!!! note
+    The main routine is simply the program itself. There's no need to define a "main" function or something similar.
 
 Here we have two more examples to continue our first steps in Crystal:
 

--- a/docs/guides/ci/circleci.md
+++ b/docs/guides/ci/circleci.md
@@ -138,7 +138,8 @@ orbs:
 version: 2.1
 ```
 
-**Note:** The explicit `checkout` in the `pre-steps` is to have the `test-data/setup.sql` file available.
+!!! note
+    The explicit `checkout` in the `pre-steps` is to have the `test-data/setup.sql` file available.
 
 ## Caching
 

--- a/docs/guides/ci/travis.md
+++ b/docs/guides/ci/travis.md
@@ -2,7 +2,8 @@
 
 In this section we are going to use [Travis CI](https://travis-ci.org/) as our continuous-integration service. Travis CI is [mostly used](https://docs.travis-ci.com/user/tutorial/#more-than-running-tests) for building and running tests for projects hosted at GitHub. It supports [different programming languages](https://docs.travis-ci.com/user/tutorial/#selecting-a-different-programming-language) and for our particular case, it supports the [Crystal language](https://docs.travis-ci.com/user/languages/crystal/).
 
->**Note:**If you are new to continuous integration (or you want to refresh the basic concepts) we may start reading the [core concepts guide](https://docs.travis-ci.com/user/for-beginners/).
+!!! note
+    If you are new to continuous integration (or you want to refresh the basic concepts) we may start reading the [core concepts guide](https://docs.travis-ci.com/user/for-beginners/).
 
 Now let's see some examples!
 
@@ -37,7 +38,8 @@ script:
 
 With this configuration, Travis CI will run the tests using both Crystal `latest` and `nightly` releases on every push to a branch on your Github repository.
 
-**Note:** When [creating a Crystal project](../../using_the_compiler/#creating-a-crystal-project) using `crystal init`, Crystal creates a `.travis.yml` file for us.
+!!! note
+    When [creating a Crystal project](../../using_the_compiler/#creating-a-crystal-project) using `crystal init`, Crystal creates a `.travis.yml` file for us.
 
 ### Using a specific Crystal release
 
@@ -58,9 +60,11 @@ script:
   - docker run -v $PWD:/src -w /src crystallang/crystal:0.31.1 crystal spec
 ```
 
-**Note:** We may read about different (languages)[https://docs.travis-ci.com/user/languages/] supported by Travis CI, included [minimal](https://docs.travis-ci.com/user/languages/minimal-and-generic/).
+!!! note
+    We may read about different (languages)[https://docs.travis-ci.com/user/languages/] supported by Travis CI, included [minimal](https://docs.travis-ci.com/user/languages/minimal-and-generic/).
 
-**Note:** A list with the different official [Crystal docker images](https://hub.docker.com/r/crystallang/crystal/tags) is available at [DockerHub](https://hub.docker.com/r/crystallang/crystal).
+!!! note
+    A list with the different official [Crystal docker images](https://hub.docker.com/r/crystallang/crystal/tags) is available at [DockerHub](https://hub.docker.com/r/crystallang/crystal).
 
 ### Using `latest`, `nightly` and a specific Crystal release all together!
 
@@ -111,7 +115,8 @@ script:
   - docker run -v $PWD:/src -w /src crystallang/crystal:0.31.1 crystal spec
 ```
 
-**Note:** Since the shards will be installed in `./lib/` folder, it will be preserved for the second docker run command.
+!!! note
+    Since the shards will be installed in `./lib/` folder, it will be preserved for the second docker run command.
 
 ## Installing binary dependencies
 
@@ -168,7 +173,8 @@ script:
   - docker run -v $PWD:/src -w /src testing crystal spec
 ```
 
-**Note:** Dockerfile arguments can be used to use the same Dockerfile for latest, nightly or a specific version.
+!!! note
+    Dockerfile arguments can be used to use the same Dockerfile for latest, nightly or a specific version.
 
 ## Using services
 

--- a/docs/guides/hosting/github.md
+++ b/docs/guides/hosting/github.md
@@ -8,10 +8,13 @@ $ git add -A && git commit -am "shard complete"
 ```
 - Add the remote: (Be sure to replace `<YOUR-GITHUB-USERNAME>` and `<YOUR-REPOSITORY-NAME>` accordingly)
 
-NOTE: If you like, feel free to replace `public` with `origin`, or a remote name of your choosing.
+!!! note
+    If you like, feel free to replace `public` with `origin`, or a remote name of your choosing.
+
 ```console
 $ git remote add public https://github.com/<YOUR-GITHUB-NAME>/<YOUR-REPOSITORY-NAME>.git
 ```
+
 - Push it: 
 ```console
 $ git push public master

--- a/docs/guides/writing_shards.md
+++ b/docs/guides/writing_shards.md
@@ -107,7 +107,8 @@ Most importantly, your README should explain:
 
 This explanation should include a few examples along with subheadings.
 
-NOTE: Be sure to replace all instances of `[your-github-name]` in the Crystal-generated README template with your GitHub/GitLab username. If you're using GitLab, you'll also want to change all instances of `github` with `gitlab`.
+!!! note
+    Be sure to replace all instances of `[your-github-name]` in the Crystal-generated README template with your GitHub/GitLab username. If you're using GitLab, you'll also want to change all instances of `github` with `gitlab`.
 
 
 #### Coding Style

--- a/docs/syntax_and_semantics/annotations.md
+++ b/docs/syntax_and_semantics/annotations.md
@@ -179,13 +179,15 @@ annotation_read
 
 Annotations can be read off of a [`TypeNode`](https://crystal-lang.org/api/Crystal/Macros/TypeNode.html), [`Def`](https://crystal-lang.org/api/Crystal/Macros/Def.html), or [`MetaVar`](https://crystal-lang.org/api/Crystal/Macros/MetaVar.html) using the `.annotation(type : TypeNode)` method.  This method return an [`Annotation`](https://crystal-lang.org/api/master/Crystal/Macros/Annotation.html) object representing the applied annotation of the supplied type.
 
-**NOTE:** If multiple annotations of the same type are applied, the `.annotation` method will return the _last_ one.
+!!! note
+    If multiple annotations of the same type are applied, the `.annotation` method will return the _last_ one.
 
 The [`@type`](./macros.md#type-information) and [`@def`](./macros.md#method-information) variables can be used to get a `TypeNode` or `Def` object to use the `.annotation` method on.  However, it is also possible to get `TypeNode`/`Def` types using other methods on `TypeNode`.  For example `TypeNode.all_subclasses` or `TypeNode.methods`, respectively.
 
 The `TypeNode.instance_vars` can be used to get an array of instance variable `MetaVar` objects that would allow reading annotations defined on those instance variables.
 
-**NOTE:** `TypeNode.instance_vars` currently only works in the context of an instance/class method.
+!!! note
+    `TypeNode.instance_vars` currently only works in the context of an instance/class method.
 
 ```crystal
 annotation MyClass

--- a/docs/syntax_and_semantics/as.md
+++ b/docs/syntax_and_semantics/as.md
@@ -29,7 +29,8 @@ If it is impossible for a type to be restricted by another type, a compile-time 
 1.as(String) # Compile-time error
 ```
 
-**Note: ** you can't use `as` to convert a type to an unrelated type: `as` is not like a `cast` in other languages. Methods on integers, floats and chars are provided for these conversions. Alternatively, use pointer casts as explained below.
+!!! note
+    You can't use `as` to convert a type to an unrelated type: `as` is not like a `cast` in other languages. Methods on integers, floats and chars are provided for these conversions. Alternatively, use pointer casts as explained below.
 
 ## Converting between pointer types
 

--- a/docs/syntax_and_semantics/c_bindings/fun.md
+++ b/docs/syntax_and_semantics/c_bindings/fun.md
@@ -92,4 +92,5 @@ lib MyLib
 end
 ```
 
-**Note:** The C `char` type is `UInt8` in Crystal, so a `char*` or a `const char*` is `UInt8*`. The `Char` type in Crystal is a unicode codepoint so it is represented by four bytes, making it similar to an `Int32`, not to an `UInt8`. There's also the alias `LibC::Char` if in doubt.
+!!! note
+    The C `char` type is `UInt8` in Crystal, so a `char*` or a `const char*` is `UInt8*`. The `Char` type in Crystal is a unicode codepoint so it is represented by four bytes, making it similar to an `Int32`, not to an `UInt8`. There's also the alias `LibC::Char` if in doubt.

--- a/docs/syntax_and_semantics/literals/range.md
+++ b/docs/syntax_and_semantics/literals/range.md
@@ -10,7 +10,8 @@ A [Range](http://crystal-lang.org/api/Range.html) represents an interval between
 (0...5).to_a # => [0, 1, 2, 3, 4]
 ```
 
-**NOTE:** Range literals are often wrapped in parentheses, for example if it is meant to be used as the receiver of a call. `0..5.to_a` without parentheses would be semantically equivalent to `0..(5.to_a)` because method calls and other operators have higher precedence than the range literal.
+!!! note
+    Range literals are often wrapped in parentheses, for example if it is meant to be used as the receiver of a call. `0..5.to_a` without parentheses would be semantically equivalent to `0..(5.to_a)` because method calls and other operators have higher precedence than the range literal.
 
 An easy way to remember which one is inclusive and which one is exclusive it to think of the extra dot as if it pushes *y* further away, thus leaving it outside of the range.
 

--- a/docs/using_the_compiler/README.md
+++ b/docs/using_the_compiler/README.md
@@ -47,7 +47,8 @@ The `--static` flag can be used to build a statically-linked executable:
 $ crystal build hello_world.cr --release --static
 ```
 
-**NOTE:** Building fully statical linked executables is currently only supported on Alpine Linux.
+!!! note
+    Building fully statical linked executables is currently only supported on Alpine Linux.
 
 More information about statically linking [can be found on the wiki](https://github.com/crystal-lang/crystal/wiki/Static-Linking).
 
@@ -172,7 +173,8 @@ $ echo 'puts "Hello World"' | crystal eval
 Hello World!
 ```
 
-NOTE: When running interactively, stdin can usually be closed by typing the end of transmission character (`Ctrl+D`).
+!!! note
+    When running interactively, stdin can usually be closed by typing the end of transmission character (`Ctrl+D`).
 
 **Common options:**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ plugins:
   - section-index
 
 markdown_extensions:
+  - admonition
   - pymdownx.highlight
   - pymdownx.magiclink
   - pymdownx.superfences


### PR DESCRIPTION
This is made possible by mkdocs, but is certainly not a required change.
It's up to you whether you like this style change.

Preview: https://oprypin.github.io/crystal-book/guides/hosting/github.html

Reference: https://squidfunk.github.io/mkdocs-material/reference/admonitions/#supported-types