### PR TITLE
Properly indent paragraphs that should be part of a list

### DIFF
--- a/docs/conventions/documenting_code.md
+++ b/docs/conventions/documenting_code.md
@@ -6,114 +6,114 @@ To generate documentation for a project, invoke `crystal docs`. By default this 
 
 * Documentation should be positioned right above definitions of classes, modules, and methods. Leave no blanks between them.
 
-```crystal
-# A unicorn is a **legendary animal** (see the `Legendary` module) that has been
-# described since antiquity as a beast with a large, spiraling horn projecting
-# from its forehead.
-class Unicorn
-end
+    ```crystal
+    # A unicorn is a **legendary animal** (see the `Legendary` module) that has been
+    # described since antiquity as a beast with a large, spiraling horn projecting
+    # from its forehead.
+    class Unicorn
+    end
 
-# Bad: This is not attached to any class.
+    # Bad: This is not attached to any class.
 
-class Legendary
-end
-```
+    class Legendary
+    end
+    ```
 
 * The documentation of a method is included into the method summary and the method details. The former includes only the first line, the latter includes the entire documentation. In short, it is preferred to:
 
     1. State a method's purpose or functionality in the first line.
     2. Supplement it with details and usages after that.
 
-For instance:
+    For instance:
 
-``````crystal
-# Returns the number of horns this unicorn has.
-#
-# ```
-# Unicorn.new.horns # => 1
-# ```
-def horns
-  @horns
-end
-``````
+    ``````crystal
+    # Returns the number of horns this unicorn has.
+    #
+    # ```
+    # Unicorn.new.horns # => 1
+    # ```
+    def horns
+      @horns
+    end
+    ``````
 
 * Use the third person: `Returns the number of horns this unicorn has` instead of `Return the number of horns this unicorn has`.
 
 * Parameter names should be *italicized* (surrounded with single asterisks `*` or underscores `_`):
 
-```crystal
-# Creates a unicorn with the specified number of *horns*.
-def initialize(@horns = 1)
-  raise "Not a unicorn" if @horns != 1
-end
-```
+    ```crystal
+    # Creates a unicorn with the specified number of *horns*.
+    def initialize(@horns = 1)
+      raise "Not a unicorn" if @horns != 1
+    end
+    ```
 
 * Code blocks that have Crystal code can be surrounded with triple backticks or indented with four spaces.
 
-``````crystal
-# ```
-# unicorn = Unicorn.new
-# unicorn.speak
-# ```
-``````
+    ``````crystal
+    # ```
+    # unicorn = Unicorn.new
+    # unicorn.speak
+    # ```
+    ``````
 
-or
+    or
 
-```crystal
-#     unicorn = Unicorn.new
-#     unicorn.speak
-```
+    ```crystal
+    #     unicorn = Unicorn.new
+    #     unicorn.speak
+    ```
 
 * Text blocks, for example to show program output, must be surrounded with triple backticks followed by the "text" keyword.
 
-``````crystal
-# ```text
-# "I'm a unicorn"
-# ```
-``````
+    ``````crystal
+    # ```text
+    # "I'm a unicorn"
+    # ```
+    ``````
 
 * To automatically link to other types, enclose them with single backticks.
 
-```crystal
-# the `Legendary` module
-```
+    ```crystal
+    # the `Legendary` module
+    ```
 
 * To automatically link to methods of the currently documented type, use a hash like `#horns` or `#index(char)`, and enclose it with single backticks.
 
 * To automatically link to methods in other types, do `OtherType#method(arg1, arg2)` or just `OtherType#method`, and enclose it with single backticks.
 
-For example:
+    For example:
 
-```crystal
-# Check the number of horns with `#horns`.
-# See what a unicorn would say with `Unicorn#speak`.
-```
+    ```crystal
+    # Check the number of horns with `#horns`.
+    # See what a unicorn would say with `Unicorn#speak`.
+    ```
 
 * To show the value of an expression inside code blocks, use `# =>`.
 
-```crystal
-1 + 2             # => 3
-Unicorn.new.speak # => "I'm a unicorn"
-```
+    ```crystal
+    1 + 2             # => 3
+    Unicorn.new.speak # => "I'm a unicorn"
+    ```
 
 * Use `:ditto:` to use the same comment as in the previous declaration.
 
-```crystal
-# :ditto:
-def number_of_horns
-  horns
-end
-```
+    ```crystal
+    # :ditto:
+    def number_of_horns
+      horns
+    end
+    ```
 
 * Use `:nodoc:` to hide public declarations from the generated documentation. Private and protected methods are always hidden.
 
-```crystal
-class Unicorn
-  # :nodoc:
-  class Helper
-  end
-end
-```
+    ```crystal
+    class Unicorn
+      # :nodoc:
+      class Helper
+      end
+    end
+    ```
 
 ### Inheriting Documentation
 

--- a/docs/getting_started/http_server.md
+++ b/docs/getting_started/http_server.md
@@ -19,46 +19,46 @@ The above code will make sense once you read the whole language reference, but w
 
 * You can [require](../syntax_and_semantics/requiring_files.md) code defined in other files:
 
-```crystal
-require "http/server"
-```
+    ```crystal
+    require "http/server"
+    ```
 
 * You can define [local variables](../syntax_and_semantics/local_variables.md) without the need to specify their type:
 
-```crystal
-server = HTTP::Server.new ...
-```
+    ```crystal
+    server = HTTP::Server.new ...
+    ```
 
 * The port of the HTTP server is set by using the method bind_tcp on the object HTTP::Server (the port set to 8080).
 
-```crystal
-address = server.bind_tcp 8080
-```
+    ```crystal
+    address = server.bind_tcp 8080
+    ```
 
 * You program by invoking [methods](../syntax_and_semantics/classes_and_methods.md) (or sending messages) to objects.
 
-```crystal
-HTTP::Server.new ...
-...
-Time.local
-...
-address = server.bind_tcp 8080
-...
-puts "Listening on http://#{address}"
-...
-server.listen
-```
+    ```crystal
+    HTTP::Server.new ...
+    ...
+    Time.local
+    ...
+    address = server.bind_tcp 8080
+    ...
+    puts "Listening on http://#{address}"
+    ...
+    server.listen
+    ```
 
 * You can use code blocks, or simply [blocks](../syntax_and_semantics/blocks_and_procs.md), which are a very convenient way to reuse code and get some features from the functional world:
 
-```crystal
-HTTP::Server.new do |context|
-    ...
-end
-```
+    ```crystal
+    HTTP::Server.new do |context|
+        ...
+    end
+    ```
 
 * You can easily create strings with embedded content, known as string interpolation. The language comes with other [syntax](../syntax_and_semantics/literals.md) as well to create arrays, hashes, ranges, tuples and more:
 
-```crystal
-"Hello world! The time is #{Time.local}"
-```
+    ```crystal
+    "Hello world! The time is #{Time.local}"
+    ```

--- a/docs/guides/hosting/github.md
+++ b/docs/guides/hosting/github.md
@@ -3,19 +3,24 @@
 - Create a repository with the same `name` and `description` as specified in your `shard.yml`.
 
 - Add and commit everything:
-```console
-$ git add -A && git commit -am "shard complete"
-```
+
+    ```console
+    $ git add -A && git commit -am "shard complete"
+    ```
+
 - Add the remote: (Be sure to replace `<YOUR-GITHUB-USERNAME>` and `<YOUR-REPOSITORY-NAME>` accordingly)
 
-NOTE: If you like, feel free to replace `public` with `origin`, or a remote name of your choosing.
-```console
-$ git remote add public https://github.com/<YOUR-GITHUB-NAME>/<YOUR-REPOSITORY-NAME>.git
-```
-- Push it: 
-```console
-$ git push public master
-```
+    NOTE: If you like, feel free to replace `public` with `origin`, or a remote name of your choosing.
+
+    ```console
+    $ git remote add public https://github.com/<YOUR-GITHUB-NAME>/<YOUR-REPOSITORY-NAME>.git
+    ```
+
+- Push it:
+
+    ```console
+    $ git push public master
+    ```
 
 #### GitHub Releases
 It's good practice to do GitHub Releases.


### PR DESCRIPTION
This is not directly related to MkDocs, just an improvement. Although Gitbook's parser did kinda botch this if this change was applied.

Preview: https://oprypin.github.io/crystal-book/conventions/documenting_code.html