### PR TITLE
Convert tables in operators.md to markdown

### DIFF
--- a/docs/syntax_and_semantics/operators.md
+++ b/docs/syntax_and_semantics/operators.md
@@ -109,76 +109,23 @@ The compiler transforms it to an `if` expression.
 This list is sorted by precedence, so upper entries bind stronger than lower
 ones.
 
-<table>
-<thead>
-<tr>
-<th>Category</th>
-<th>Operators</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>Index accessors</td>
-<td><code>[]</code>, <code>[]?</code></td>
-</tr>
-<tr>
-<td>Unary</td>
-<td><code>+</code>, <code>&amp;+</code>, <code>-</code>, <code>&amp;-</code>, <code>!</code>, <code>~</code>, <code>*</code>, <code>**</code></td>
-</tr>
-<tr>
-<td>Exponential</td>
-<td><code>**</code>, <code>&amp;**</code></td>
-</tr>
-<tr>
-<td>Multiplicative</td>
-<td><code>*</code>, <code>&amp;*</code>, <code>/</code>, <code>//</code>, <code>%</code></td>
-</tr>
-<tr>
-<td>Additive</td>
-<td><code>+</code>, <code>&amp;+</code>, <code>-</code>, <code>&amp;-</code></td>
-</tr>
-<tr>
-<td>Shift</td>
-<td><code>&lt;&lt;</code>, <code>&gt;&gt;</code></td>
-</tr>
-<tr>
-<td>Binary AND</td>
-<td><code>&amp;</code></td>
-</tr>
-<tr>
-<td>Binary OR/XOR</td>
-<td><code>|</code>,<code>^</code></td>
-</tr>
-<tr>
-<td>Equality</td>
-<td><code>==</code>, <code>!=</code>, <code>=~</code>, <code>!~</code>, <code>===</code></td>
-</tr>
-<tr>
-<td>Comparison</td>
-<td><code>&lt;</code>, <code>&lt;=</code>, <code>&gt;</code>, <code>&gt;=</code>, <code>&lt;=&gt;</code></td>
-</tr>
-<tr>
-<td>Logical AND</td>
-<td><code>&amp;&amp;</code></td>
-</tr>
-<tr>
-<td>Logical OR</td>
-<td><code>||</code></td>
-</tr>
-<tr>
-<td>Range</td>
-<td><code>..</code>, <code>...</code></td>
-</tr>
-<tr>
-<td>Conditional</td>
-<td><code>?:</code></td>
-</tr>
-<tr>
-<td>Assignment</td>
-<td><code>=</code>, <code>[]=</code>, <code>+=</code>, <code>&amp;+=</code>, <code>-=</code>, <code>&amp;-=</code>, <code>*=</code>, <code>&amp;*=</code>, <code>/=</code>, <code>//=</code>, <code>%=</code>, <code>|=</code>, <code>&amp;=</code>,<code>^=</code>,<code>**=</code>,<code>&lt;&lt;=</code>,<code>&gt;&gt;=</code>, <code>||=</code>, <code>&amp;&amp;=</code></td>
-</tr>
-</tbody>
-</table>
+| Category | Operators |
+|---|---|
+| Index accessors | `[]`, `[]?` |
+| Unary | `+`, `&+`, `-`, `&-`, `!`, `~`, `*`, `**` |
+| Exponential | `**`, `&**` |
+| Multiplicative | `*`, `&*`, `/`, `//`, `%` |
+| Additive | `+`, `&+`, `-`, `&-` |
+| Shift | `<<`, `>>` |
+| Binary AND | `&` |
+| Binary OR/XOR | `|`,`^` |
+| Equality | `==`, `!=`, `=~`, `!~`, `===` |
+| Comparison | `<`, `<=`, `>`, `>=`, `<=>` |
+| Logical AND | `&&` |
+| Logical OR | `||` |
+| Range | `..`, `...` |
+| Conditional | `?:` |
+| Assignment | `=`, `[]=`, `+=`, `&+=`, `-=`, `&-=`, `*=`, `&*=`, `/=`, `//=`, `%=`, `|=`, `&=`,`^=`,`**=`,`<<=`,`>>=`, `||=`, `&&=` |
 
 ## List of operators
 
@@ -230,36 +177,11 @@ ones.
 
 ### Binary
 
-<table>
-<thead>
-<tr>
-<th>Operator</th>
-<th>Description</th>
-<th>Example</th>
-<th>Overloadable</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>&amp;</code></td>
-<td>binary AND</td>
-<td><code>1 &amp; 2</code></td>
-<td>yes</td>
-</tr>
-<tr>
-<td><code>|</code></td>
-<td>binary OR</td>
-<td><code>1 | 2</code></td>
-<td>yes</td>
-</tr>
-<tr>
-<td><code>^</code></td>
-<td>binary XOR</td>
-<td><code>1 ^ 2</code></td>
-<td>yes</td>
-</tr>
-</tbody>
-</table>
+| Operator | Description | Example | Overloadable |
+|---|---|---|---|
+| `&` | binary AND | `1 & 2` | yes |
+| `|` | binary OR | `1 | 2` | yes |
+| `^` | binary XOR | `1 ^ 2` | yes |
 
 ### Equality
 
@@ -299,30 +221,10 @@ proven faster than equality).
 
 ### Logical
 
-<table>
-<thead>
-<tr>
-<th>Operator</th>
-<th>Description</th>
-<th>Example</th>
-<th>Overloadable</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>&amp;&amp;</code></td>
-<td><a href="and.md">logical AND</a></td>
-<td><code>true &amp;&amp; false</code></td>
-<td>no</td>
-</tr>
-<tr>
-<td><code>||</code></td>
-<td><a href="or.md">logical OR</a></td>
-<td><code>true || false</code></td>
-<td>no</td>
-</tr>
-</tbody>
-</table>
+| Operator | Description | Example | Overloadable |
+|---|---|---|---|
+| `&&` | [logical AND](and.md) | `true && false` | no |
+| `||` | [logical OR](or.md) | `true || false` | no |
 
 ### Range
 
@@ -390,120 +292,25 @@ be callable.
 
 The receiver can't be anything else than a variable or call.
 
-<table>
-<thead>
-<tr>
-<th>Operator</th>
-<th>Description</th>
-<th>Example</th>
-<th>Overloadable</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>+=</code></td>
-<td>addition <em>and</em> assignment</td>
-<td><code>i += 1</code></td>
-<td>no</td>
-</tr>
-<tr>
-<td><code>&amp;+=</code></td>
-<td>wrapping addition <em>and</em> assignment</td>
-<td><code>i &amp;+= 1</code></td>
-<td>no</td>
-</tr>
-<tr>
-<td><code>-=</code></td>
-<td>subtraction <em>and</em> assignment</td>
-<td><code>i -= 1</code></td>
-<td>no</td>
-</tr>
-<tr>
-<td><code>&amp;-=</code></td>
-<td>wrapping subtraction <em>and</em> assignment</td>
-<td><code>i &amp;-= 1</code></td>
-<td>no</td>
-</tr>
-<tr>
-<td><code>*=</code></td>
-<td>multiplication <em>and</em> assignment</td>
-<td><code>i *= 1</code></td>
-<td>no</td>
-</tr>
-<tr>
-<td><code>&amp;*=</code></td>
-<td>wrapping multiplication <em>and</em> assignment</td>
-<td><code>i &amp;*= 1</code></td>
-<td>no</td>
-</tr>
-<tr>
-<td><code>/=</code></td>
-<td>division <em>and</em> assignment</td>
-<td><code>i /= 1</code></td>
-<td>no</td>
-</tr>
-<tr>
-<td><code>//=</code></td>
-<td>floor division <em>and</em> assignment</td>
-<td><code>i //= 1</code></td>
-<td>no</td>
-</tr>
-<tr>
-<td><code>%=</code></td>
-<td>modulo <em>and</em> assignment</td>
-<td><code>i %= 1</code></td>
-<td>yes</td>
-</tr>
-<tr>
-<td><code>|=</code></td>
-<td>binary or <em>and</em> assignment</td>
-<td><code>i |= 1</code></td>
-<td>no</td>
-</tr>
-<tr>
-<td><code>&amp;=</code></td>
-<td>binary and <em>and</em> assignment</td>
-<td><code>i &amp;= 1</code></td>
-<td>no</td>
-</tr>
-<tr>
-<td><code>^=</code></td>
-<td>binary xor <em>and</em> assignment</td>
-<td><code>i ^= 1</code></td>
-<td>no</td>
-</tr>
-<tr>
-<td><code>**=</code></td>
-<td>exponential <em>and</em> assignment</td>
-<td><code>i **= 1</code></td>
-<td>no</td>
-</tr>
-<tr>
-<td><code>&lt;&lt;=</code></td>
-<td>left shift <em>and</em> assignment</td>
-<td><code>i &lt;&lt;= 1</code></td>
-<td>no</td>
-</tr>
-<tr>
-<td><code>&gt;&gt;=</code></td>
-<td>right shift <em>and</em> assignment</td>
-<td><code>i &gt;&gt;= 1</code></td>
-<td>no</td>
-</tr>
-<tr>
-<td><code>||=</code></td>
-<td>logical or <em>and</em>  assignment</td>
-<td><code>i ||= true</code></td>
-<td>no</td>
-</tr>
-<tr>
-<td><code>&amp;&amp;=</code></td>
-<td>logical and <em>and</em> assignment</td>
-<td><code>i &amp;&amp;= true</code></td>
-<td>no</td>
-</tr>
-</tbody>
-</table>
+| Operator | Description | Example | Overloadable |
+|---|---|---|---|
+| `+=` | addition *and* assignment | `i += 1` | no |
+| `&+=` | wrapping addition *and* assignment | `i &+= 1` | no |
+| `-=` | subtraction *and* assignment | `i -= 1` | no |
+| `&-=` | wrapping subtraction *and* assignment | `i &-= 1` | no |
+| `*=` | multiplication *and* assignment | `i *= 1` | no |
+| `&*=` | wrapping multiplication *and* assignment | `i &*= 1` | no |
+| `/=` | division *and* assignment | `i /= 1` | no |
+| `//=` | floor division *and* assignment | `i //= 1` | no |
+| `%=` | modulo *and* assignment | `i %= 1` | yes |
+| `|=` | binary or *and* assignment | `i |= 1` | no |
+| `&=` | binary and *and* assignment | `i &= 1` | no |
+| `^=` | binary xor *and* assignment | `i ^= 1` | no |
+| `**=` | exponential *and* assignment | `i **= 1` | no |
+| `<<=` | left shift *and* assignment | `i <<= 1` | no |
+| `>>=` | right shift *and* assignment | `i >>= 1` | no |
+| `||=` | logical or *and*  assignment | `i ||= true` | no |
+| `&&=` | logical and *and* assignment | `i &&= true` | no |
 
 ### Index Accessors
 


### PR DESCRIPTION
Rendering was broken in gitbook, but now properly works with mkdocs