### PR TITLE
Markdown lint fixes

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,4 +1,5 @@
 # Summary
+
 * [Introduction](README.md)
 * [Getting started](getting_started/README.md)
     * [An HTTP Server](getting_started/http_server.md)

--- a/docs/conventions/documenting_code.md
+++ b/docs/conventions/documenting_code.md
@@ -115,7 +115,7 @@ To generate documentation for a project, invoke `crystal docs`. By default this 
     end
     ```
 
-### Inheriting Documentation
+## Inheriting Documentation
 
 When an instance method has no doc comment, but a method with the same signature exists in a parent type, the documentation is inherited from the parent method.
 
@@ -173,7 +173,7 @@ Some documentation common to every *id*.
 !!! note
     Inheriting documentation only works on _instance_, non-constructor methods.
 
-### Flagging Classes, Modules, and Methods
+## Flagging Classes, Modules, and Methods
 
 Given a valid keyword, Crystal will automatically generate visual flags that help highlight problems, notes and/or possible issues.
 
@@ -206,7 +206,7 @@ def talk
 end
 ``````
 
-### Use Crystal's code formatter
+## Use Crystal's code formatter
 
 Crystal's built-in code formatter can be used not just to format your code,
 but also to format code samples included in documentation blocks.
@@ -232,7 +232,7 @@ Crystal itself.
 The formatter is also fast, so very little time is lost if you format the
 entire project instead of a single file.
 
-### A Complete Example
+## A Complete Example
 
 ``````crystal
 # A unicorn is a **legendary animal** (see the `Legendary` module) that has been

--- a/docs/database/connection.md
+++ b/docs/database/connection.md
@@ -145,8 +145,7 @@ end
 As we may notice, the `database` is polymorphic with a `connection` object with regard to the `#exec` / `#query` / `#transaction` methods. The database is responsible for the use of the connections. Great!
 
 ## When to use one or the other?
+
 Given the examples, it may come to our attention that **the number of connections is relevant**.
 If we are programming a short living application with only one user starting requests to the  database then a single connection managed by us (i.e. a `DB::Connection` object) should be enough (think of a command line application that receives parameters, then starts a request to the database and finally displays the result to the user)
 On the other hand, if we are building a system with many concurrent users and with heavy database access, then we should use a `DB::Database` object; which by using a connection pool will have a number of connections already prepared and ready to use (no bootstrap/initialization-time penalizations). Or imagine that you are building a long-living application (like a background job) then a connection pool will free you from the responsibility of monitoring the state of the connection: is it alive or does it need to reconnect?
-
-

--- a/docs/database/connection_pool.md
+++ b/docs/database/connection_pool.md
@@ -17,9 +17,9 @@ end
 When executing statements using `db.query`, `db.exec`, `db.scalar`, etc. the algorithm goes:
 
 1. Find an available connection in the pool.
-   1. Create one if needed and possible.
-   2. If the pool is not allowed to create a new connection, wait a for a connection to become available.
-      1. But this wait should be aborted if it takes too long.
+    1. Create one if needed and possible.
+    2. If the pool is not allowed to create a new connection, wait a for a connection to become available.
+        1. But this wait should be aborted if it takes too long.
 2. Checkout that connection from the pool.
 3. Execute the SQL command.
 4. If there is no `DB::ResultSet` yielded, return the connection to the pool. Otherwise, the connection will be returned to the pool when the ResultSet is closed.

--- a/docs/database/transactions.md
+++ b/docs/database/transactions.md
@@ -23,7 +23,6 @@ deposit db, "Sarah", 50
 withdraw db, "John", 50
 ```
 
-
 It is important to have in mind that if one of the operations fails then the final state would be inconsistent. So we need to execute the **two operations** (deposit and withdraw) as **one operation**. And if an error occurs then we would like to go back in time as if that one operation was never executed.
 
 ```crystal

--- a/docs/guides/ci/README.md
+++ b/docs/guides/ci/README.md
@@ -83,9 +83,9 @@ And this is all we need for our continuous integration examples! Let's start!
 Here's the list of items we want to achieve:
 
 1. Build and run specs using 3 different Crystal's versions:
-   * latest
-   * nightly
-   * 0.31.1 (using a Docker image)
+    * latest
+    * nightly
+    * 0.31.1 (using a Docker image)
 2. Install shards packages
 3. Install binary dependencies
 4. Use a database (for example MySQL)

--- a/docs/guides/ci/circleci.md
+++ b/docs/guides/ci/circleci.md
@@ -144,4 +144,3 @@ version: 2.1
 ## Caching
 
 Caching is enabled by default when using the job `crystal/test`, because internally it uses the `command` [with-shards-cache](https://circleci.com/orbs/registry/orb/manastech/crystal#commands-with-shards-cache)
-

--- a/docs/guides/ci/travis.md
+++ b/docs/guides/ci/travis.md
@@ -99,7 +99,7 @@ matrix:
 
 In native _runners_ (`language: crystal`), Travis CI already automatically installs shards dependencies using `shards install`. To improve build performance we may add [caching](#caching) on top of that.
 
-#### Using Docker
+### Using Docker
 
 In a Docker-based _runner_ we need to run `shards install` explicitly, like this:
 
@@ -141,7 +141,7 @@ script:
   - crystal spec
 ```
 
-#### Using Docker
+### Using Docker
 
 We are going to build a new docker image based on [crystallang/crystal](https://hub.docker.com/r/crystallang/crystal/), and in this new image we will be installing the binary dependencies.
 
@@ -246,7 +246,7 @@ Pushing these changes will trigger Travis CI and the build should be successful!
 
 If we read Travis CI job log, we will find that every time the job runs, Travis CI needs to fetch the libraries needed to run the application:
 
-```log
+```
 Fetching https://github.com/crystal-lang/crystal-mysql.git
 Fetching https://github.com/crystal-lang/crystal-db.git
 ```

--- a/docs/guides/concurrency.md
+++ b/docs/guides/concurrency.md
@@ -216,7 +216,7 @@ puts "After receive"
 
 This prints:
 
-```text
+```
 Before receive
 Before send
 After receive
@@ -247,7 +247,7 @@ puts value # => 2
 
 Output:
 
-```text
+```
 Before first receive
 Before first send
 1
@@ -328,7 +328,7 @@ puts "After yield"
 
 Output:
 
-```text
+```
 Before yield
 Before send
 Before receive

--- a/docs/guides/hosting/github.md
+++ b/docs/guides/hosting/github.md
@@ -23,18 +23,19 @@
     $ git push public master
     ```
 
-#### GitHub Releases
+## GitHub Releases
+
 It's good practice to do GitHub Releases.
 
 Add the following markdown build badge below the description in your README to inform users what the most current release is:
 (Be sure to replace `<YOUR-GITHUB-USERNAME>` and `<YOUR-REPOSITORY-NAME>` accordingly)
 
-```Markdown
+```markdown
 [![GitHub release](https://img.shields.io/github/release/<YOUR-GITHUB-USERNAME>/<YOUR-REPOSITORY-NAME>.svg)](https://github.com/<YOUR-GITHUB-USERNAME>/<YOUR-REPOSITORY-NAME>/releases)
 ```
 
 Start by navigating to your repository's _releases_ page.
-  - This can be found at `https://github.com/<YOUR-GITHUB-NAME>/<YOUR-REPOSITORY-NAME>/releases`
+This can be found at `https://github.com/<YOUR-GITHUB-NAME>/<YOUR-REPOSITORY-NAME>/releases`
 
 Click "Create a new release".
 
@@ -49,18 +50,22 @@ You'll now notice that the GitHub Release badge has updated in your README.
 
 Follow [Semantic Versioning](http://semver.org/) and create a new release every time your push new code to `master`.
 
-### Travis CI and `.travis.yml`
+## Travis CI and `.travis.yml`
+
 If you haven't already, [sign up for Travis CI](https://travis-ci.org/).
 
 Insert the following markdown build badge below the description in your README.md:
 (be sure to replace `<YOUR-GITHUB-USERNAME>` and `<YOUR-REPOSITORY-NAME>` accordingly)
-```Markdown
+
+```markdown
 [![Build Status](https://travis-ci.org/<YOUR-GITHUB-USERNAME>/<YOUR-REPOSITORY-NAME>.svg?branch=master)](https://travis-ci.org/<YOUR-GITHUB-USERNAME>/<YOUR-REPOSITORY-NAME>) 
 ```
+
 Build badges are a simple way to tell people whether your Travis CI build passes.
 
 Add the following lines to your `.travis.yml`:
-```YAML
+
+```yaml
 script:
   - crystal spec
 ```
@@ -68,16 +73,15 @@ script:
 This tells Travis CI to run your tests. 
 Accordingly with the outcome of this command, Travis CI will return a [build status](https://docs.travis-ci.com/user/for-beginners/#breaking-the-build) of "passed", "errored", "failed" or "canceled".
 
-
 If you want to verify that all your code has been formatted with `crystal tool format`, add a script for `crystal tool format --check`. If the code is not formatted correctly, this will [break the build](https://docs.travis-ci.com/user/for-beginners/#breaking-the-build) just as failing tests would.
 
 e.g.
-```YAML
+
+```yaml
 script:
   - crystal spec
   - crystal tool format --check
 ```
-
 
 Commit and push to GitHub.
 
@@ -85,11 +89,11 @@ Follow [these guidelines](https://docs.travis-ci.com/user/getting-started/) to g
 
 Once you're up and running, and the build is passing, the build badge will update in your README.
 
-
-#### Hosting your `docs` on GitHub-Pages
+## Hosting your `docs` on GitHub-Pages
 
 Add the following `script` to your `.travis.yml`:
-```YAML
+
+```yaml
   - crystal docs
 ```
 
@@ -97,7 +101,8 @@ This tells Travis CI to generate your documentation.
 
 Next, add the following lines to your `.travis.yml`.
 (Be sure to replace all instances of `<YOUR-GITHUB-REPOSITORY-NAME>` accordingly)
-```YAML
+
+```yaml
 deploy:
   provider: pages
   skip_cleanup: true
@@ -112,7 +117,7 @@ deploy:
 
 If you've been following along, your `.travis.yml` file should look something like this:
 
-```YAML
+```yaml
 language: crystal
 script:
   - crystal spec

--- a/docs/guides/hosting/gitlab.md
+++ b/docs/guides/hosting/gitlab.md
@@ -28,7 +28,7 @@
     $ git push origin master
     ```
 
-### Pipelines
+## Pipelines
 
 Next, let's setup a [GitLab Pipeline](https://docs.gitlab.com/ee/ci/pipelines.html) that can run our tests and build/deploy the docs when we push code to the repo.
 
@@ -88,7 +88,6 @@ And now if the pipleline has finished we'll have docs and we can link to them wi
 
 - Link: `https://<YOUR-GITLAB-USERNAME>.gitlab.io/<YOUR-REPOSITORY-NAME>`
 - Image: `https://img.shields.io/badge/docs-available-brightgreen.svg`
-
 
 ## Releases
 

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -103,6 +103,7 @@ Always remember that it's not just the time that has improved: memory usage is a
 Sometimes you need to work directly with strings built from combining string literals with other values. You shouldn't just concatenate these strings with `String#+(String)` but rather use [string interpolation](../syntax_and_semantics/literals/string.md#interpolation) which allows to embed expressions into a string literal: `"Hello, #{name}"` is better than `"Hello, " +  name.to_s`.
 
 Interpolated strings are transformed by the compiler to append to a string IO so that it automatically avoids intermediate strings. The example above translates to:
+
 ```crystal
 String.build do |io|
   io << "Hello, " << name
@@ -142,7 +143,6 @@ $ crystal run --release str_benchmark.cr
 String.build 597.57k (  1.67µs) (± 5.52%)       fastest
   IO::Memory 423.82k (  2.36µs) (± 3.76%)  1.41× slower
 ```
-
 
 ### Avoid creating temporary objects over and over
 

--- a/docs/guides/writing_shards.md
+++ b/docs/guides/writing_shards.md
@@ -29,6 +29,7 @@ Begin by using [the Crystal compiler](../using_the_compiler/README.md)'s `init l
 In your terminal: `crystal init lib <YOUR-SHARD-NAME>`
 
 e.g.
+
 ```console
 $ crystal init lib palindrome-example
     create  palindrome-example/.gitignore
@@ -47,6 +48,7 @@ Initialized empty Git repository in /<YOUR-DIRECTORY>/.../palindrome-example/.gi
 ...and `cd` into the directory:
 
 e.g.
+
 ```bash
 cd palindrome-example
 ```
@@ -91,7 +93,7 @@ See below for instructions on hosting your compiler-generated docs on GitHub/Git
 Once your documentation is ready and available, you can add a documentation badge to your repository so users know that it exists. In GitLab this badge belongs to the project so we'll cover it in the GitLab instructions below, for GitHub it is common to place it below the description in your README.md like so:
 (Be sure to replace `<LINK-TO-YOUR-DOCUMENTATION>` accordingly)
 
-```Markdown
+```markdown
 [![Docs](https://img.shields.io/badge/docs-available-brightgreen.svg)](<LINK-TO-YOUR-DOCUMENTATION>)
 ```
 
@@ -101,6 +103,7 @@ A good README can make or break your project.
 [Awesome README](https://github.com/matiassingers/awesome-readme) is a nice curation of examples and resources on the topic.
 
 Most importantly, your README should explain:
+
 1. What your library is
 2. What it does
 3. How to use it
@@ -110,13 +113,13 @@ This explanation should include a few examples along with subheadings.
 !!! note
     Be sure to replace all instances of `[your-github-name]` in the Crystal-generated README template with your GitHub/GitLab username. If you're using GitLab, you'll also want to change all instances of `github` with `gitlab`.
 
-
 #### Coding Style
 
 - It's fine to have your own style, but sticking to [some core rubrics defined by the Crystal team](../conventions/coding_style.md) can help keep your code consistent, readable and usable for other developers.
 - Utilize Crystal's [built-in code formatter](../conventions/documenting_code.md) to automatically format all `.cr` files in a directory.
 
 e.g.
+
 ```
 crystal tool format
 ```
@@ -124,37 +127,42 @@ crystal tool format
 To check if your code is formatted correctly, or to check if using the formatter wouldn't produce any changes, simply add `--check` to the end of this command.
 
 e.g.
+
 ```
 crystal tool format --check
 ```
 
 See the Travis CI section below to implement this in your build.
 
-
 ### Writing a `shard.yml`
 
 [The spec](https://github.com/crystal-lang/shards/blob/master/SPEC.md) is your rulebook. Follow it.
 
 #### Name
+
 Your `shard.yml`'s `name` property should be concise and descriptive.
 
 - Search [crystalshards.xyz](https://crystalshards.xyz/) to check if your name is already taken.
 
 e.g.
-```YAML
+
+```yaml
 name: palindrome-example
 ```
 
 #### Description
+
 Add a `description` to your `shard.yml`.
 
 A `description` is a single line description used to search for and find your shard.
 
 A description should be:
+
 1. Informative
 2. Discoverable
 
 #### Optimizing
+
 It's hard for anyone to use your project if they can't find it.
 [crystalshards.xyz](https://crystalshards.xyz/) is currently the go-to place for Crystal libraries, so that's what we'll optimize for.
 
@@ -162,7 +170,8 @@ There are people looking for the _exact_ functionality of our library and the _g
 e.g. Bob needs a palindrome library, but Felipe is just looking for libraries involving text and Susan is looking for libraries involving spelling.
 
 Our `name` is already descriptive enough for Bob's search of "palindrome". We don't need to repeat the _palindrome_ keyword. Instead, we'll catch Susan's search for "spelling" and Felipe's search for "text".
-```YAML
+
+```yaml
 description: |
   A textual algorithm to tell if a word is spelled the same way forwards as it is backwards.
 ```

--- a/docs/syntax_and_semantics/assignment.md
+++ b/docs/syntax_and_semantics/assignment.md
@@ -63,7 +63,7 @@ objects[1] ||= 2 # same as: objects[1]? || (objects[1] = 2)
 objects[1] &&= 2 # same as: objects[1]? && (objects[1] = 2)
 ```
 
-# Chained assignment
+## Chained assignment
 
 You can assign the same value to multiple variables using chained assignment:
 
@@ -78,7 +78,7 @@ c # => 123
 
 The chained assignment is not only available to [local variables](local_variables.md) but also to [instance variables](methods_and_instance_variables.md), [class variables](class_variables.md) and setter methods (methods that end with `=`).
 
-# Multiple assignment
+## Multiple assignment
 
 You can declare/assign multiple variables at the same time by separating expressions with a comma (`,`):
 

--- a/docs/syntax_and_semantics/blocks_and_procs.md
+++ b/docs/syntax_and_semantics/blocks_and_procs.md
@@ -200,6 +200,7 @@ If the method has other required parameters, the short syntax argument should al
 ```
 
 Is equivalent to:
+
 ```crystal
 ["a", "b"].join(",") { |s| s.upcase }
 ```

--- a/docs/syntax_and_semantics/c_bindings/callbacks.md
+++ b/docs/syntax_and_semantics/c_bindings/callbacks.md
@@ -42,7 +42,7 @@ If you want to pass `NULL` instead of a callback, just pass `nil`:
 X.callback nil
 ```
 
-### Passing a closure to a C function
+## Passing a closure to a C function
 
 Most of the time a C function that allows setting a callback also provide an argument for custom data. This custom data is then sent as an argument to the callback. For example, suppose a C function that invokes a callback at every tick, passing that tick:
 

--- a/docs/syntax_and_semantics/class_methods.md
+++ b/docs/syntax_and_semantics/class_methods.md
@@ -27,7 +27,7 @@ Class methods can also be defined by [extending a `Module`](modules.md#extend-se
 A class method can be called under the same name as it was defined (`CaesarCipher.decrypt("HELLO")`).
 When called from within the same class or module scope the receiver can be `self` or implicit (like `encrypt(string)`).
 
-# Constructors
+## Constructors
 
 Constructors are normal class methods which [create a new instance of the class](new,_initialize_and_allocate.md).
 By default all classes in Crystal have at least one constructor called `new`, but they may also define other constructors with different names.

--- a/docs/syntax_and_semantics/closures.md
+++ b/docs/syntax_and_semantics/closures.md
@@ -85,6 +85,3 @@ x = 1
 x = 'a'
 x # : Int32 | String | Char
 ```
-
-
-

--- a/docs/syntax_and_semantics/constants.md
+++ b/docs/syntax_and_semantics/constants.md
@@ -29,7 +29,7 @@ end
 TEN # => 10
 ```
 
-# Pseudo Constants
+## Pseudo Constants
 
 Crystal provides a few pseudo-constants which provide reflective data about the source code being executed.
 
@@ -64,7 +64,7 @@ end
 # Directory file is in: /crystal_code
 ```
 
-# Dynamic assignment
+## Dynamic assignment
 
 Dynamically assigning values to constants using the [chained assignment](assignment.md#chained-assignment) or the [multiple assignment](assignment.md#multiple-assignment) is not supported and results in a syntax error.
 

--- a/docs/syntax_and_semantics/declare_var.md
+++ b/docs/syntax_and_semantics/declare_var.md
@@ -16,4 +16,3 @@ buffer = uninitialized UInt8[256]
 The buffer is allocated on the stack, avoiding a heap allocation.
 
 The type after the `uninitialized` keyword follows the [type grammar](type_grammar.md).
-

--- a/docs/syntax_and_semantics/default_and_named_arguments.md
+++ b/docs/syntax_and_semantics/default_and_named_arguments.md
@@ -1,4 +1,4 @@
-# Default values
+## Default values
 
 A method can specify default values for the last arguments:
 
@@ -19,7 +19,7 @@ john.become_older 2
 john.age # => 3
 ```
 
-# Named arguments
+## Named arguments
 
 All arguments can also be specified, in addition to their position, by their name. For example:
 

--- a/docs/syntax_and_semantics/default_values_named_arguments_splats_tuples_and_overloading.md
+++ b/docs/syntax_and_semantics/default_values_named_arguments_splats_tuples_and_overloading.md
@@ -164,4 +164,3 @@ def increment(value, by amount)
   value + amount
 end
 ```
-

--- a/docs/syntax_and_semantics/if_varresponds_to.md
+++ b/docs/syntax_and_semantics/if_varresponds_to.md
@@ -38,4 +38,3 @@ if (a = @a).responds_to?(:abs)
   # here a is guaranteed to respond to `abs`
 end
 ```
-

--- a/docs/syntax_and_semantics/inheritance.md
+++ b/docs/syntax_and_semantics/inheritance.md
@@ -138,7 +138,7 @@ class Test
 end
 ```
 
-we've declared `@arr` as type `Array(Foo)` so we may be tempted to think that we can start putting `Bar`s in there. Not quite. In the `initialize`, the type of the `[Bar.new]` expression is `Array(Bar)`, period. And `Array(Bar)` is *not* assignable to an `Array(Foo)` instance var. 
+we've declared `@arr` as type `Array(Foo)` so we may be tempted to think that we can start putting `Bar`s in there. Not quite. In the `initialize`, the type of the `[Bar.new]` expression is `Array(Bar)`, period. And `Array(Bar)` is *not* assignable to an `Array(Foo)` instance var.
 
 What's the right way to do this? Change the expression so that it *is* of the right type: `Array(Foo)` (see example above).
 

--- a/docs/syntax_and_semantics/literals/bool.md
+++ b/docs/syntax_and_semantics/literals/bool.md
@@ -2,7 +2,6 @@
 
 [Bool](http://crystal-lang.org/api/Bool.html) has only two possible values: `true` and `false`. They are constructed using the following literals:
 
-
 ```crystal
 true  # A Bool that is true
 false # A Bool that is false

--- a/docs/syntax_and_semantics/literals/char.md
+++ b/docs/syntax_and_semantics/literals/char.md
@@ -15,6 +15,7 @@ It is typically created with a char literal by enclosing an UTF-8 character in s
 A backslash denotes a special character, which can either be a named escape sequence or a numerical representation of a unicode codepoint.
 
 Available escape sequences:
+
 ```crystal
 '\''         # single quote
 '\\'         # backslash

--- a/docs/syntax_and_semantics/literals/command.md
+++ b/docs/syntax_and_semantics/literals/command.md
@@ -9,7 +9,7 @@ Similar to percent string literals, valid delimiters for `%x` are parentheses `(
 
 The special variable `$?` holds the exit status of the command as a [`Process::Status`](https://crystal-lang.org/api/0.27.0/Process/Status.html). It is only available in the same scope as the command literal.
 
-```cr
+```crystal
 `echo foo`  # => "foo"
 $?.success? # => true
 ```
@@ -20,7 +20,7 @@ Internally, the compiler rewrites command literals to calls to the top-level met
 
 While command literals may prove useful for simple script-like tools, special caution is advised when interpolating user input because it may easily lead to command injection.
 
-```cr
+```crystal
 user_input = "hello; rm -rf *"
 `echo #{user_input}`
 ```
@@ -29,7 +29,7 @@ This command will write `hello` and subsequently delete all files and folders in
 
 To avoid this, command literals should generally not be used with interpolated user input. [`Process`](https://crystal-lang.org/api/latest/Process.html) from the standard library offers a safe way to provide user input as command arguments:
 
-```cr
+```crystal
 user_input = "hello; rm -rf *"
 process = Process.new("echo", [user_input], output: Process::Redirect::Pipe)
 process.output.gets_to_end # => "hello; rm -rf *"

--- a/docs/syntax_and_semantics/literals/hash.md
+++ b/docs/syntax_and_semantics/literals/hash.md
@@ -8,7 +8,7 @@ Hashes are typically created with a hash literal denoted by curly braces (`{ }`)
 {"one" => 1, "two" => 2}
 ```
 
-# Generic Type Argument
+## Generic Type Argument
 
 The generic type arguments for keys `K` and values `V` are inferred from the types of the keys or values inside the literal, respectively. When all have the same type, `K`/`V` equals to that. Otherwise it will be a union of all key types or value types respectively.
 
@@ -20,6 +20,7 @@ The generic type arguments for keys `K` and values `V` are inferred from the typ
 Explicit types can be specified by immediately following the closing bracket with `of` (separated by whitespace), a key type (`K`) followed by `=>` as delimiter and a value type (`V`). This overwrites the inferred types and can be used for example to create a hash that holds only some types initially but can accept other types as well.
 
 Empty hash literals always need type specifications:
+
 ```crystal
 {} of Int32 => Int32 # => Hash(Int32, Int32).new
 ```

--- a/docs/syntax_and_semantics/literals/range.md
+++ b/docs/syntax_and_semantics/literals/range.md
@@ -5,7 +5,7 @@ A [Range](http://crystal-lang.org/api/Range.html) represents an interval between
 * `x..y`: Two dots denote an inclusive range, including `x` and `y` and all values in between (in mathematics: `[x, y]`) .
 * `x...y`: Three dots denote an exclusive range, including `x` and all values up to but not including `y` (in mathematics: `[x, y)`).
 
-```cr
+```crystal
 (0..5).to_a  # => [0, 1, 2, 3, 4, 5]
 (0...5).to_a # => [0, 1, 2, 3, 4]
 ```
@@ -21,7 +21,7 @@ The begin and end values do not necessarily need to be of the same type: `true..
 
 Ranges with `nil` as begin are called begin-less and `nil` as end are called end-less ranges. In the literal notation, `nil` can be omitted: `x..` is an end-less range starting from `x`, and `..x` is an begin-less range ending at `x`.
 
-```cr
+```crystal
 numbers = [1, 10, 3, 4, 5, 8]
 numbers.select(6..) # => [10, 8]
 numbers.select(..6) # => [1, 3, 4, 5]

--- a/docs/syntax_and_semantics/literals/regex.md
+++ b/docs/syntax_and_semantics/literals/regex.md
@@ -39,6 +39,7 @@ Note that special characters of the PCRE syntax need to be escaped if they are i
 Interpolation works in regular expression literals just as it does in [string literals](./string.md). Be aware that using this feature will cause an exception to be raised at runtime, if the resulting string results in an invalid regular expression.
 
 ## Modifiers
+
 The closing delimiter may be followed by a number of optional modifiers to adjust the matching behaviour of the regular expression.
 
 * `i`: case-insensitive matching (`PCRE_CASELESS`):  Unicode letters in the pattern match both upper and lower case letters in the subject string.

--- a/docs/syntax_and_semantics/literals/string.md
+++ b/docs/syntax_and_semantics/literals/string.md
@@ -13,6 +13,7 @@ A String is typically created with a string literal enclosing UTF-8 characters i
 A backslash denotes a special character inside a string, which can either be a named escape sequence or a numerical representation of a unicode codepoint.
 
 Available escape sequences:
+
 ```crystal
 "\""                  # double quote
 "\\"                  # backslash
@@ -89,7 +90,7 @@ String.build do |io|
 end
 ```
 
-# Percent string literals
+## Percent string literals
 
 Besides double-quotes strings, Crystal also supports string literals indicated by a percent sign (`%`) and a pair of delimiters. Valid delimiters are parentheses `()`, square brackets `[]`, curly braces `{}`, angles `<>` and pipes `||`. Except for the pipes, all delimiters can be nested meaning a start delimiter inside the string escapes the next end delimiter.
 
@@ -111,7 +112,7 @@ name = "world"
 %Q(hello \n #{name}) # => "hello \n world"
 ```
 
-## Percent string array literal
+### Percent string array literal
 
 Besides the single string literal, there is also a percent literal to create an [Array](https://crystal-lang.org/api/Array.html) of strings. It is indicated by `%w` and a pair of delimiters. Valid delimiters are as same as [percent string literals](#percent-string-literals).
 
@@ -201,7 +202,7 @@ upcase(<<-STRING) # => "HELLO WORLD"
 
 If multiple heredocs start in the same line, their bodies are read sequentially:
 
-```cr
+```crystal
 print(<<-FIRST, <<-SECOND) # prints "HelloWorld"
   Hello
   FIRST

--- a/docs/syntax_and_semantics/literals/symbol.md
+++ b/docs/syntax_and_semantics/literals/symbol.md
@@ -21,6 +21,7 @@ For an unquoted identifier the same naming rules apply as for methods. It can co
 ```
 
 All [Crystal operators](../operators.md) can be used as symbol names unquoted:
+
 ```crystal
 :+
 :-

--- a/docs/syntax_and_semantics/methods_and_instance_variables.md
+++ b/docs/syntax_and_semantics/methods_and_instance_variables.md
@@ -140,4 +140,3 @@ end
 ```
 
 This will initialize `@age` to zero in every constructor. This is useful to avoid duplication, but also to avoid the `Nil` type when reopening a class and adding instance variables to it.
-

--- a/docs/syntax_and_semantics/modules.md
+++ b/docs/syntax_and_semantics/modules.md
@@ -124,7 +124,7 @@ end
 Moo.new # undefined method 'new' for Moo:Module
 ```
 
-# Module Type Checking
+## Module Type Checking
 
 Modules can also be used for type checking.
 
@@ -168,6 +168,7 @@ three.is_a?(B) # => true
 ```
 
 This allows you to define arrays and methods based on module type instead of class:
+
 ```crystal
 one = One.new
 two = Two.new

--- a/docs/syntax_and_semantics/new,_initialize_and_allocate.md
+++ b/docs/syntax_and_semantics/new,_initialize_and_allocate.md
@@ -58,4 +58,3 @@ end
 First, note the `self.new` notation. This is a [class method](class_methods.md) that belongs to the **class** `Person`, not to particular instances of that class. This is why we can do `Person.new`.
 
 Second, `allocate` is a low-level class method that creates an uninitialized object of the given type. It basically allocates the necessary memory for the object, then `initialize` is invoked on it and finally the instance is returned. You generally never invoke `allocate`, as it is [unsafe](unsafe.md), but that's the reason why `new` and `initialize` are related.
-

--- a/docs/syntax_and_semantics/offsetof.md
+++ b/docs/syntax_and_semantics/offsetof.md
@@ -2,14 +2,15 @@
 
 An `offsetof` expression returns the byte offset of an instance variable in a struct or class type. It accepts the type as first argument and the instance variable name prefixed by an `@` as second argument:
 
-```cr
+```crystal
 offsetof(Type, @ivar)
 ```
 
 This is a low-level primitive and only useful if a C API needs to directly interface with the data layout of a Crystal type.
 
 Example:
-```cr
+
+```crystal
 struct Foo
   @x = 0_i64
   @y = 34_i32

--- a/docs/syntax_and_semantics/pointerof.md
+++ b/docs/syntax_and_semantics/pointerof.md
@@ -38,4 +38,3 @@ point.x # => 10
 ```
 
 Because `pointerof` involves pointers, it is considered [unsafe](unsafe.md).
-

--- a/docs/syntax_and_semantics/structs.md
+++ b/docs/syntax_and_semantics/structs.md
@@ -78,7 +78,6 @@ What happens with the `strukt` here:
 
 `Klass` is a class, so it is passed by reference to `modify`, and `object.array = ["new"]` saves the reference to the newly created array in the original `klass` object, not in the copy as it was with the `strukt`.
 
-
 ## Inheritance
 
 * A struct implicitly inherits from [Struct](http://crystal-lang.org/api/Struct.html), which inherits from [Value](http://crystal-lang.org/api/Value.html). A class implicitly inherits from [Reference](http://crystal-lang.org/api/Reference.html).

--- a/docs/syntax_and_semantics/type_restrictions.md
+++ b/docs/syntax_and_semantics/type_restrictions.md
@@ -248,4 +248,3 @@ end
 push(4, [1, 2, 3])      # OK
 push("oops", [1, 2, 3]) # Error
 ```
-

--- a/docs/syntax_and_semantics/unsafe.md
+++ b/docs/syntax_and_semantics/unsafe.md
@@ -18,4 +18,3 @@ ptr[100_000] = 2 # undefined behaviour, probably a segmentation fault
 However, regular code usually never involves pointer manipulation or uninitialized variables. And C bindings are usually wrapped in safe wrappers that include null pointers and bounds checks.
 
 No language is 100% safe: some parts will inevitably be low-level, interface with the operating system and involve pointer manipulation. But once you abstract that and operate on a higher level, and assume (after mathematical proof or thorough testing) that the lower grounds are safe, you can be confident that your entire codebase is safe.
-

--- a/docs/using_the_compiler/README.md
+++ b/docs/using_the_compiler/README.md
@@ -218,6 +218,7 @@ an application not intended to be used as a dependency. A library doesn't have a
 in its repository and no build target in `shard.yml`, but instructions for using it as a dependency.
 
 Example:
+
 ```console
 $ crystal init lib my_cool_lib
     create  my_cool_lib/.gitignore


### PR DESCRIPTION
* Nested lists not recognized as such
* Multiple H1 headings
* Jumps in headings more than 1 level
* Too many newlines
* No newline around code block
* Consistency in code language identifiers
    * Tip: `git grep -hEo '```.+' | sort | uniq -c`