### PR TITLE
Indent list item paragraphs in performance guide

### DIFF
--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -164,29 +164,29 @@ There are two ways to solve this:
 
 1. Use a tuple. If you use `{"crystal", "ruby", "java"}` in the above program it will work the same way, but since a tuple doesn't involve heap memory it will be faster, consume less memory, and give more chances for the compiler to optimize the program.
 
-  ```crystal
-  lines_with_language_reference = 0
-  while line = gets
-    if {"crystal", "ruby", "java"}.any? { |string| line.includes?(string) }
-      lines_with_language_reference += 1
+    ```crystal
+    lines_with_language_reference = 0
+    while line = gets
+      if {"crystal", "ruby", "java"}.any? { |string| line.includes?(string) }
+        lines_with_language_reference += 1
+      end
     end
-  end
-  puts "Lines that mention crystal, ruby or java: #{lines_with_language_reference}"
-  ```
+    puts "Lines that mention crystal, ruby or java: #{lines_with_language_reference}"
+    ```
 
-2. Move the array to a constant.
+1. Move the array to a constant.
 
-  ```crystal
-  LANGS = ["crystal", "ruby", "java"]
+    ```crystal
+    LANGS = ["crystal", "ruby", "java"]
 
-  lines_with_language_reference = 0
-  while line = gets
-    if LANGS.any? { |string| line.includes?(string) }
-      lines_with_language_reference += 1
+    lines_with_language_reference = 0
+    while line = gets
+      if LANGS.any? { |string| line.includes?(string) }
+        lines_with_language_reference += 1
+      end
     end
-  end
-  puts "Lines that mention crystal, ruby or java: #{lines_with_language_reference}"
-  ```
+    puts "Lines that mention crystal, ruby or java: #{lines_with_language_reference}"
+    ```
 
 Using tuples is the preferred way.
 


### PR DESCRIPTION
The Markdown spec requires that multiple paragraphs within a list item be indented 4 spaces or 1 tab, as does MkDocs (via the `markdown` package).

This was causing a display issue in the rendered site.

---
Before
![2021-02-27-01 14 00_796x618](https://user-images.githubusercontent.com/7873686/109377594-4f8efe00-789a-11eb-8a17-fa6e83a44b26.png)

---
After
![2021-02-27-01 13 46_785x629](https://user-images.githubusercontent.com/7873686/109377595-5158c180-789a-11eb-851a-34ed753b4ece.png)
