### PR TITLE
Apply format_api_docs_links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ clean: ## Remove build directory
 clean_deps: ## Remove .venv directory
 	rm -rf .venv
 
+.PHONY: format_api_docs_links
+format_api_docs_links:
+	echo $(DOCS_FILES) | xargs sed -i -E -e 's|https?://(www\.)?crystal-lang.org/api/([A-Z])|https://crystal-lang.org/api/latest/\2|g'
+
 .PHONY: help
 help: ## Show this help
 	@echo

--- a/docs/guides/concurrency.md
+++ b/docs/guides/concurrency.md
@@ -170,7 +170,7 @@ end
 Fiber.yield
 ```
 
-Now it works because we are creating a [Proc](http://crystal-lang.org/api/Proc.html) and we invoke it passing `i`, so the value gets copied and now the spawned fiber receives a copy.
+Now it works because we are creating a [Proc](https://crystal-lang.org/api/latest/Proc.html) and we invoke it passing `i`, so the value gets copied and now the spawned fiber receives a copy.
 
 To avoid all this boilerplate, the standard library provides a `spawn` macro that accepts a call expression and basically rewrites it to do the above. Using it, we end up with:
 

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -144,7 +144,7 @@ end
 
 Tagging an example group (`describe` or `context`) extends to all of the contained examples.
 
-Multiple tags can be specified by giving an [`Enumerable`](https://crystal-lang.org/api/Enumerable.html), such as [`Array`](https://crystal-lang.org/api/Array.html) or [`Set`](https://crystal-lang.org/api/Set.html).
+Multiple tags can be specified by giving an [`Enumerable`](https://crystal-lang.org/api/latest/Enumerable.html), such as [`Array`](https://crystal-lang.org/api/latest/Array.html) or [`Set`](https://crystal-lang.org/api/latest/Set.html).
 
 ## Running specs
 

--- a/docs/guides/writing_shards.md
+++ b/docs/guides/writing_shards.md
@@ -79,7 +79,7 @@ The code you write is up to you, but how you write it impacts whether people wan
 #### Testing the Code
 
 - Test your code. All of it. It's the only way for anyone, including you, to know if it works.
-- Crystal has [a built-in testing library](https://crystal-lang.org/api/Spec.html). Use it!
+- Crystal has [a built-in testing library](https://crystal-lang.org/api/latest/Spec.html). Use it!
 
 #### Documentation
 

--- a/docs/syntax_and_semantics/annotations/README.md
+++ b/docs/syntax_and_semantics/annotations/README.md
@@ -1,6 +1,6 @@
 # Annotations
 
-Annotations can be used to add metadata to certain features in the source code. Types, methods and instance variables may be annotated.  User-defined annotations, such as the standard library's [JSON::Field](https://crystal-lang.org/api/JSON/Field.html), are defined using the `annotation` keyword.  A number of [built-in annotations](built_in_annotations.md) are provided by the compiler.
+Annotations can be used to add metadata to certain features in the source code. Types, methods and instance variables may be annotated.  User-defined annotations, such as the standard library's [JSON::Field](https://crystal-lang.org/api/latest/JSON/Field.html), are defined using the `annotation` keyword.  A number of [built-in annotations](built_in_annotations.md) are provided by the compiler.
 
 Users can define their own annotations using the `annotation` keyword, which works similarly to defining a `class` or `struct`.
 
@@ -41,7 +41,7 @@ A few applications for annotations:
 
 ### Object Serialization
 
-Have an annotation that when applied to an instance variable determines if that instance variable should be serialized, or with what key. Crystal's [`JSON::Serializable`](https://crystal-lang.org/api/JSON/Serializable.html) and [`YAML::Serializable`](https://crystal-lang.org/api/YAML/Serializable.html) are examples of this.
+Have an annotation that when applied to an instance variable determines if that instance variable should be serialized, or with what key. Crystal's [`JSON::Serializable`](https://crystal-lang.org/api/latest/JSON/Serializable.html) and [`YAML::Serializable`](https://crystal-lang.org/api/latest/YAML/Serializable.html) are examples of this.
 
 ### ORMs
 
@@ -64,7 +64,7 @@ end
 
 ### Key/value
 
-The values of annotation key/value pairs can be accessed at compile time via the [`[]`](https://crystal-lang.org/api/Crystal/Macros/Annotation.html#%5B%5D%28name%3ASymbolLiteral%7CStringLiteral%7CMacroId%29%3AASTNode-instance-method) method.
+The values of annotation key/value pairs can be accessed at compile time via the [`[]`](https://crystal-lang.org/api/latest/Crystal/Macros/Annotation.html#%5B%5D%28name%3ASymbolLiteral%7CStringLiteral%7CMacroId%29%3AASTNode-instance-method) method.
 
 ```crystal
 annotation MyAnnotation
@@ -93,7 +93,7 @@ end
 annotation_named_args # => {value: 2, name: "Jim"}
 ```
 
-Since this method returns a `NamedTupleLiteral`, all of the [methods](https://crystal-lang.org/api/Crystal/Macros/NamedTupleLiteral.html) on that type are available for use.  Especially `#double_splat` which makes it easy to pass annotation arguments to methods.
+Since this method returns a `NamedTupleLiteral`, all of the [methods](https://crystal-lang.org/api/latest/Crystal/Macros/NamedTupleLiteral.html) on that type are available for use.  Especially `#double_splat` which makes it easy to pass annotation arguments to methods.
 
 ```crystal
 annotation MyAnnotation
@@ -115,7 +115,7 @@ new_test # => #<SomeClass:0x5621a19ddf00 @name="Jim", @value=2>
 
 ### Positional
 
-Positional values can be accessed at compile time via the [`[]`](<https://crystal-lang.org/api/Crystal/Macros/Annotation.html#%5B%5D%28index%3ANumberLiteral%29%3AASTNode-instance-method>) method; however, only one index can be accessed at a time.
+Positional values can be accessed at compile time via the [`[]`](<https://crystal-lang.org/api/latest/Crystal/Macros/Annotation.html#%5B%5D%28index%3ANumberLiteral%29%3AASTNode-instance-method>) method; however, only one index can be accessed at a time.
 
 ```crystal
 annotation MyAnnotation
@@ -153,7 +153,7 @@ end
 annotation_args # => {1, 2, 3, 4}
 ```
 
-Since the return type of `TupleLiteral` is iterable, we can rewrite the previous example in a better way.  By extension, all of the [methods](https://crystal-lang.org/api/Crystal/Macros/TupleLiteral.html) on `TupleLiteral` are available for use as well.
+Since the return type of `TupleLiteral` is iterable, we can rewrite the previous example in a better way.  By extension, all of the [methods](https://crystal-lang.org/api/latest/Crystal/Macros/TupleLiteral.html) on `TupleLiteral` are available for use as well.
 
 ```crystal
 annotation MyAnnotation
@@ -177,7 +177,7 @@ annotation_read
 
 ## Reading
 
-Annotations can be read off of a [`TypeNode`](https://crystal-lang.org/api/Crystal/Macros/TypeNode.html), [`Def`](https://crystal-lang.org/api/Crystal/Macros/Def.html), or [`MetaVar`](https://crystal-lang.org/api/Crystal/Macros/MetaVar.html) using the `.annotation(type : TypeNode)` method.  This method return an [`Annotation`](https://crystal-lang.org/api/master/Crystal/Macros/Annotation.html) object representing the applied annotation of the supplied type.
+Annotations can be read off of a [`TypeNode`](https://crystal-lang.org/api/latest/Crystal/Macros/TypeNode.html), [`Def`](https://crystal-lang.org/api/latest/Crystal/Macros/Def.html), or [`MetaVar`](https://crystal-lang.org/api/latest/Crystal/Macros/MetaVar.html) using the `.annotation(type : TypeNode)` method.  This method return an [`Annotation`](https://crystal-lang.org/api/master/Crystal/Macros/Annotation.html) object representing the applied annotation of the supplied type.
 
 !!! note
     If multiple annotations of the same type are applied, the `.annotation` method will return the _last_ one.

--- a/docs/syntax_and_semantics/blocks_and_procs.md
+++ b/docs/syntax_and_semantics/blocks_and_procs.md
@@ -236,7 +236,7 @@ end
 
 The above prints "2" and "3".
 
-A `yield` expression's value is mostly useful for transforming and filtering values. The best examples of this are [Enumerable#map](https://crystal-lang.org/api/Enumerable.html#map%28%26block%3AT-%3EU%29forallU-instance-method) and [Enumerable#select](https://crystal-lang.org/api/Enumerable.html#select%28%26block%3AT-%3E%29-instance-method):
+A `yield` expression's value is mostly useful for transforming and filtering values. The best examples of this are [Enumerable#map](https://crystal-lang.org/api/latest/Enumerable.html#map%28%26block%3AT-%3EU%29forallU-instance-method) and [Enumerable#select](https://crystal-lang.org/api/latest/Enumerable.html#select%28%26block%3AT-%3E%29-instance-method):
 
 ```crystal
 ary = [1, 2, 3]
@@ -320,7 +320,7 @@ end
 value # :: Int32 | String
 ```
 
-If a `break` receives many arguments, they are automatically transformed to a [Tuple](http://crystal-lang.org/api/Tuple.html):
+If a `break` receives many arguments, they are automatically transformed to a [Tuple](https://crystal-lang.org/api/latest/Tuple.html):
 
 ```crystal
 values = twice { break 1, 2 }
@@ -382,7 +382,7 @@ end
 # 3
 ```
 
-If a `next` receives many arguments, they are automatically transformed to a [Tuple](http://crystal-lang.org/api/Tuple.html). If it receives no arguments it's the same as receiving a single `nil` argument.
+If a `next` receives many arguments, they are automatically transformed to a [Tuple](https://crystal-lang.org/api/latest/Tuple.html). If it receives no arguments it's the same as receiving a single `nil` argument.
 
 ## with ... yield
 
@@ -435,7 +435,7 @@ end
 
 That means that any type that responds to `[]` with integers can be unpacked in a block parameter.
 
-For [Tuple](http://crystal-lang.org/api/Tuple.html) parameters you can take advantage of auto-splatting and do not need parentheses:
+For [Tuple](https://crystal-lang.org/api/latest/Tuple.html) parameters you can take advantage of auto-splatting and do not need parentheses:
 
 ```crystal
 array = [{1, "one", true}, {2, "two", false}]
@@ -444,7 +444,7 @@ array.each do |number, word, bool|
 end
 ```
 
-[Hash(K, V)#each](http://crystal-lang.org/api/Hash.html#each(&):Nil-instance-method) passes `Tuple(K, V)` to the block so iterating key-value pairs works with auto-splatting:
+[Hash(K, V)#each](https://crystal-lang.org/api/latest/Hash.html#each(&):Nil-instance-method) passes `Tuple(K, V)` to the block so iterating key-value pairs works with auto-splatting:
 
 ```crystal
 h = {"foo" => "bar"}

--- a/docs/syntax_and_semantics/c_bindings/callbacks.md
+++ b/docs/syntax_and_semantics/c_bindings/callbacks.md
@@ -11,7 +11,7 @@ lib X
 end
 ```
 
-Then you can pass a function (a [Proc](http://crystal-lang.org/api/Proc.html)) like this:
+Then you can pass a function (a [Proc](https://crystal-lang.org/api/latest/Proc.html)) like this:
 
 ```crystal
 f = ->(x : Int32) { x + 1 }

--- a/docs/syntax_and_semantics/capturing_blocks.md
+++ b/docs/syntax_and_semantics/capturing_blocks.md
@@ -13,7 +13,7 @@ proc = int_to_int { |x| x + 1 }
 proc.call(1) # => 2
 ```
 
-The above code captures the block of code passed to `int_to_int` in the `block` variable, and returns it from the method. The type of `proc` is [`Proc(Int32, Int32)`](http://crystal-lang.org/api/Proc.html), a function that accepts a single `Int32` argument and returns an `Int32`.
+The above code captures the block of code passed to `int_to_int` in the `block` variable, and returns it from the method. The type of `proc` is [`Proc(Int32, Int32)`](https://crystal-lang.org/api/latest/Proc.html), a function that accepts a single `Int32` argument and returns an `Int32`.
 
 In this way a block can be saved as a callback:
 

--- a/docs/syntax_and_semantics/case.md
+++ b/docs/syntax_and_semantics/case.md
@@ -25,7 +25,7 @@ else
 end
 ```
 
-For comparing an expression against a `case`'s value the *case equality operator* `===` is used. It is defined as a method on [`Object`](https://crystal-lang.org/api/Object.html#%3D%3D%3D%28other%29-instance-method) and can be overridden by subclasses to provide meaningful semantics in case statements. For example, [`Class`](https://crystal-lang.org/api/Class.html#%3D%3D%3D%28other%29-instance-method) defines case equality as when an object is an instance of that class, [`Regex`](https://crystal-lang.org/api/Regex.html#%3D%3D%3D%28other%3AString%29-instance-method) as when the value matches the regular expression and [`Range`](https://crystal-lang.org/api/Range.html#%3D%3D%3D%28value%29-instance-method) as when the value is included in that range.
+For comparing an expression against a `case`'s value the *case equality operator* `===` is used. It is defined as a method on [`Object`](https://crystal-lang.org/api/latest/Object.html#%3D%3D%3D%28other%29-instance-method) and can be overridden by subclasses to provide meaningful semantics in case statements. For example, [`Class`](https://crystal-lang.org/api/latest/Class.html#%3D%3D%3D%28other%29-instance-method) defines case equality as when an object is an instance of that class, [`Regex`](https://crystal-lang.org/api/latest/Regex.html#%3D%3D%3D%28other%3AString%29-instance-method) as when the value matches the regular expression and [`Range`](https://crystal-lang.org/api/latest/Range.html#%3D%3D%3D%28value%29-instance-method) as when the value is included in that range.
 
 If a `when`'s expression is a type, `is_a?` is used. Additionally, if the case expression is a variable or a variable assignment the type of the variable is restricted:
 

--- a/docs/syntax_and_semantics/declare_var.md
+++ b/docs/syntax_and_semantics/declare_var.md
@@ -7,7 +7,7 @@ x = uninitialized Int32
 x # => some random value, garbage, unreliable
 ```
 
-This is [unsafe](unsafe.md) code and is almost always used in low-level code for declaring uninitialized [StaticArray](http://crystal-lang.org/api/StaticArray.html) buffers without a performance penalty:
+This is [unsafe](unsafe.md) code and is almost always used in low-level code for declaring uninitialized [StaticArray](https://crystal-lang.org/api/latest/StaticArray.html) buffers without a performance penalty:
 
 ```crystal
 buffer = uninitialized UInt8[256]

--- a/docs/syntax_and_semantics/enum.md
+++ b/docs/syntax_and_semantics/enum.md
@@ -47,7 +47,7 @@ Color::Red.value # :: UInt8
 
 Only integer types are allowed as the underlying type.
 
-All enums inherit from [Enum](http://crystal-lang.org/api/Enum.html).
+All enums inherit from [Enum](https://crystal-lang.org/api/latest/Enum.html).
 
 ## Flags enums
 
@@ -117,7 +117,7 @@ Class variables are allowed, but instance variables are not.
 
 ## Usage
 
-Enums are a type-safe alternative to [Symbol](http://crystal-lang.org/api/Symbol.html). For example, an API's method can specify a [type restriction](type_restrictions.md) using an enum type:
+Enums are a type-safe alternative to [Symbol](https://crystal-lang.org/api/latest/Symbol.html). For example, an API's method can specify a [type restriction](type_restrictions.md) using an enum type:
 
 ```crystal
 def paint(color : Color)

--- a/docs/syntax_and_semantics/exception_handling.md
+++ b/docs/syntax_and_semantics/exception_handling.md
@@ -11,13 +11,13 @@ raise "OH NO!"
 raise Exception.new("Some error")
 ```
 
-The String version just creates a new [Exception](http://crystal-lang.org/api/Exception.html) instance with that message.
+The String version just creates a new [Exception](https://crystal-lang.org/api/latest/Exception.html) instance with that message.
 
 Only `Exception` instances or subclasses can be raised.
 
 ## Defining custom exceptions
 
-To define a custom exception type, just subclass from [Exception](http://crystal-lang.org/api/Exception.html):
+To define a custom exception type, just subclass from [Exception](https://crystal-lang.org/api/latest/Exception.html):
 
 ```crystal
 class MyException < Exception

--- a/docs/syntax_and_semantics/finalize.md
+++ b/docs/syntax_and_semantics/finalize.md
@@ -15,8 +15,8 @@ end
 Use this method to release resources allocated by external libraries that are
 not directly managed by Crystal garbage collector.
 
-Examples of this can be found in [`IO::FileDescriptor#finalize`](https://crystal-lang.org/api/IO/FileDescriptor.html#finalize-instance-method)
-or [`OpenSSL::Digest#finalize`](https://crystal-lang.org/api/OpenSSL/Digest.html#finalize-instance-method).
+Examples of this can be found in [`IO::FileDescriptor#finalize`](https://crystal-lang.org/api/latest/IO/FileDescriptor.html#finalize-instance-method)
+or [`OpenSSL::Digest#finalize`](https://crystal-lang.org/api/latest/OpenSSL/Digest.html#finalize-instance-method).
 
 **Notes**:
 

--- a/docs/syntax_and_semantics/if_var.md
+++ b/docs/syntax_and_semantics/if_var.md
@@ -62,7 +62,7 @@ if a = @a
 end
 ```
 
-Another option is to use [`Object#try`](https://crystal-lang.org/api/Object.html#try%28%26block%29-instance-method) found in the standard library which only executes the block if the value is not `nil`:
+Another option is to use [`Object#try`](https://crystal-lang.org/api/latest/Object.html#try%28%26block%29-instance-method) found in the standard library which only executes the block if the value is not `nil`:
 
 ```crystal
 @a.try do |a|

--- a/docs/syntax_and_semantics/literals/array.md
+++ b/docs/syntax_and_semantics/literals/array.md
@@ -1,6 +1,6 @@
 # Array
 
-An [Array](http://crystal-lang.org/api/Array.html) is an ordered and integer-indexed generic collection of elements of a specific type `T`.
+An [Array](https://crystal-lang.org/api/latest/Array.html) is an ordered and integer-indexed generic collection of elements of a specific type `T`.
 
 Arrays are typically created with an array literal denoted by square brackets (`[]`) and individual elements separated by a comma (`,`).
 

--- a/docs/syntax_and_semantics/literals/bool.md
+++ b/docs/syntax_and_semantics/literals/bool.md
@@ -1,6 +1,6 @@
 # Bool
 
-[Bool](http://crystal-lang.org/api/Bool.html) has only two possible values: `true` and `false`. They are constructed using the following literals:
+[Bool](https://crystal-lang.org/api/latest/Bool.html) has only two possible values: `true` and `false`. They are constructed using the following literals:
 
 ```crystal
 true  # A Bool that is true

--- a/docs/syntax_and_semantics/literals/char.md
+++ b/docs/syntax_and_semantics/literals/char.md
@@ -1,6 +1,6 @@
 # Char
 
-A [Char](http://crystal-lang.org/api/Char.html) represents a 32-bit [Unicode](http://en.wikipedia.org/wiki/Unicode) [code point](http://en.wikipedia.org/wiki/Code_point).
+A [Char](https://crystal-lang.org/api/latest/Char.html) represents a 32-bit [Unicode](http://en.wikipedia.org/wiki/Unicode) [code point](http://en.wikipedia.org/wiki/Code_point).
 
 It is typically created with a char literal by enclosing an UTF-8 character in single quotes.
 

--- a/docs/syntax_and_semantics/literals/command.md
+++ b/docs/syntax_and_semantics/literals/command.md
@@ -7,7 +7,7 @@ The same [escaping](./string.md#escaping) and [interpolation rules](./string.md#
 
 Similar to percent string literals, valid delimiters for `%x` are parentheses `()`, square brackets `[]`, curly braces `{}`, angles `<>` and pipes `||`. Except for the pipes, all delimiters can be nested; meaning a start delimiter inside the string escapes the next end delimiter.
 
-The special variable `$?` holds the exit status of the command as a [`Process::Status`](https://crystal-lang.org/api/0.27.0/Process/Status.html). It is only available in the same scope as the command literal.
+The special variable `$?` holds the exit status of the command as a [`Process::Status`](https://crystal-lang.org/api/latest/Process/Status.html). It is only available in the same scope as the command literal.
 
 ```crystal
 `echo foo`  # => "foo"

--- a/docs/syntax_and_semantics/literals/floats.md
+++ b/docs/syntax_and_semantics/literals/floats.md
@@ -1,6 +1,6 @@
 # Floats
 
-There are two floating point types, [Float32](http://crystal-lang.org/api/Float32.html) and [Float64](http://crystal-lang.org/api/Float64.html),
+There are two floating point types, [Float32](https://crystal-lang.org/api/latest/Float32.html) and [Float64](https://crystal-lang.org/api/latest/Float64.html),
 which correspond to the [binary32](http://en.wikipedia.org/wiki/Single_precision_floating-point_format)
 and [binary64](http://en.wikipedia.org/wiki/Double_precision_floating-point_format)
 types defined by IEEE.

--- a/docs/syntax_and_semantics/literals/hash.md
+++ b/docs/syntax_and_semantics/literals/hash.md
@@ -1,6 +1,6 @@
 # Hash
 
-A [Hash](http://crystal-lang.org/api/Hash.html) is a generic collection of key-value pairs mapping keys of type `K` to values of type `V`.
+A [Hash](https://crystal-lang.org/api/latest/Hash.html) is a generic collection of key-value pairs mapping keys of type `K` to values of type `V`.
 
 Hashes are typically created with a hash literal denoted by curly braces (`{ }`) enclosing a list of pairs using `=>` as delimiter between key and value and separated by commas `,`.
 

--- a/docs/syntax_and_semantics/literals/integers.md
+++ b/docs/syntax_and_semantics/literals/integers.md
@@ -4,14 +4,14 @@ There are four signed integer types, and four unsigned integer types:
 
 | Type | Length  | Minimum Value | Maximum Value |
 | ---------- | -----------: | -----------: |-----------: |
-| [Int8](http://crystal-lang.org/api/Int8.html)  | 8       | -128 | 127 |
-| [Int16](http://crystal-lang.org/api/Int16.html)  | 16 | −32,768 | 32,767 |
-| [Int32](http://crystal-lang.org/api/Int32.html) | 32  | −2,147,483,648 | 2,147,483,647 |
-| [Int64](http://crystal-lang.org/api/Int64.html)   |  64 | −2<sup>63</sup> | 2<sup>63</sup> - 1 |
-| [UInt8](http://crystal-lang.org/api/UInt8.html) | 8 |  0 | 255 |
-| [UInt16](http://crystal-lang.org/api/UInt16.html) | 16 | 0 | 65,535 |
-| [UInt32](http://crystal-lang.org/api/UInt32.html) | 32 |  0 | 4,294,967,295 |
-| [UInt64](http://crystal-lang.org/api/UInt64.html) | 64 | 0 | 2<sup>64</sup> - 1 |
+| [Int8](https://crystal-lang.org/api/latest/Int8.html)  | 8       | -128 | 127 |
+| [Int16](https://crystal-lang.org/api/latest/Int16.html)  | 16 | −32,768 | 32,767 |
+| [Int32](https://crystal-lang.org/api/latest/Int32.html) | 32  | −2,147,483,648 | 2,147,483,647 |
+| [Int64](https://crystal-lang.org/api/latest/Int64.html)   |  64 | −2<sup>63</sup> | 2<sup>63</sup> - 1 |
+| [UInt8](https://crystal-lang.org/api/latest/UInt8.html) | 8 |  0 | 255 |
+| [UInt16](https://crystal-lang.org/api/latest/UInt16.html) | 16 | 0 | 65,535 |
+| [UInt32](https://crystal-lang.org/api/latest/UInt32.html) | 32 |  0 | 4,294,967,295 |
+| [UInt64](https://crystal-lang.org/api/latest/UInt64.html) | 64 | 0 | 2<sup>64</sup> - 1 |
 
 An integer literal is an optional `+` or `-` sign, followed by
 a sequence of digits and underscores, optionally followed by a suffix.

--- a/docs/syntax_and_semantics/literals/named_tuple.md
+++ b/docs/syntax_and_semantics/literals/named_tuple.md
@@ -1,6 +1,6 @@
 # NamedTuple
 
-A [NamedTuple](http://crystal-lang.org/api/NamedTuple.html) is typically created with a named tuple literal:
+A [NamedTuple](https://crystal-lang.org/api/latest/NamedTuple.html) is typically created with a named tuple literal:
 
 ```crystal
 tuple = {name: "Crystal", year: 2011} # NamedTuple(name: String, year: Int32)

--- a/docs/syntax_and_semantics/literals/nil.md
+++ b/docs/syntax_and_semantics/literals/nil.md
@@ -1,6 +1,6 @@
 # Nil
 
-The [Nil](http://crystal-lang.org/api/Nil.html) type is used to represent the absence of a value, similar to `null` in other languages. It only has a single value:
+The [Nil](https://crystal-lang.org/api/latest/Nil.html) type is used to represent the absence of a value, similar to `null` in other languages. It only has a single value:
 
 ```crystal
 nil

--- a/docs/syntax_and_semantics/literals/proc.md
+++ b/docs/syntax_and_semantics/literals/proc.md
@@ -1,6 +1,6 @@
 # Proc
 
-A [Proc](http://crystal-lang.org/api/Proc.html) represents a function pointer with an optional context (the closure data). It is typically created with a proc literal:
+A [Proc](https://crystal-lang.org/api/latest/Proc.html) represents a function pointer with an optional context (the closure data). It is typically created with a proc literal:
 
 ```crystal
 # A proc without parameters

--- a/docs/syntax_and_semantics/literals/range.md
+++ b/docs/syntax_and_semantics/literals/range.md
@@ -1,6 +1,6 @@
 # Range
 
-A [Range](http://crystal-lang.org/api/Range.html) represents an interval between two values. It is typically constructed with a range literal, consisting of two or three dots:
+A [Range](https://crystal-lang.org/api/latest/Range.html) represents an interval between two values. It is typically constructed with a range literal, consisting of two or three dots:
 
 * `x..y`: Two dots denote an inclusive range, including `x` and `y` and all values in between (in mathematics: `[x, y]`) .
 * `x...y`: Three dots denote an exclusive range, including `x` and all values up to but not including `y` (in mathematics: `[x, y)`).

--- a/docs/syntax_and_semantics/literals/regex.md
+++ b/docs/syntax_and_semantics/literals/regex.md
@@ -1,6 +1,6 @@
 # Regular Expressions
 
-Regular expressions are represented by the [Regex](http://crystal-lang.org/api/Regex.html) class.
+Regular expressions are represented by the [Regex](https://crystal-lang.org/api/latest/Regex.html) class.
 
 A Regex is typically created with a regex literal using [PCRE](http://pcre.org/pcre.txt) syntax. It consists of a string of UTF-8 characters enclosed in forward slashes (`/`):
 

--- a/docs/syntax_and_semantics/literals/string.md
+++ b/docs/syntax_and_semantics/literals/string.md
@@ -1,6 +1,6 @@
 # String
 
-A [String](http://crystal-lang.org/api/String.html) represents an immutable sequence of UTF-8 characters.
+A [String](https://crystal-lang.org/api/latest/String.html) represents an immutable sequence of UTF-8 characters.
 
 A String is typically created with a string literal enclosing UTF-8 characters in double quotes (`"`):
 
@@ -66,7 +66,7 @@ b = 2
 "sum: #{a} + #{b} = #{a + b}" # => "sum: 1 + 2 = 3"
 ```
 
-String interpolation is also possible with [String#%](https://crystal-lang.org/api/String.html#%25%28other%29-instance-method).
+String interpolation is also possible with [String#%](https://crystal-lang.org/api/latest/String.html#%25%28other%29-instance-method).
 
 Any expression may be placed inside the interpolated section, but it’s best to keep the expression small for readability.
 
@@ -77,7 +77,7 @@ Interpolation can be disabled by escaping the `#` character with a backslash or 
 %q(#{a + b}) # => "#{a + b}"
 ```
 
-Interpolation is implemented using a [String::Builder](http://crystal-lang.org/api/String/Builder.html) and invoking `Object#to_s(IO)` on each expression enclosed by `#{...}`. The expression `"sum: #{a} + #{b} = #{a + b}"` is equivalent to:
+Interpolation is implemented using a [String::Builder](https://crystal-lang.org/api/latest/String/Builder.html) and invoking `Object#to_s(IO)` on each expression enclosed by `#{...}`. The expression `"sum: #{a} + #{b} = #{a + b}"` is equivalent to:
 
 ```crystal
 String.build do |io|
@@ -114,7 +114,7 @@ name = "world"
 
 ### Percent string array literal
 
-Besides the single string literal, there is also a percent literal to create an [Array](https://crystal-lang.org/api/Array.html) of strings. It is indicated by `%w` and a pair of delimiters. Valid delimiters are as same as [percent string literals](#percent-string-literals).
+Besides the single string literal, there is also a percent literal to create an [Array](https://crystal-lang.org/api/latest/Array.html) of strings. It is indicated by `%w` and a pair of delimiters. Valid delimiters are as same as [percent string literals](#percent-string-literals).
 
 ```crystal
 %w(foo bar baz)  # => ["foo", "bar", "baz"]

--- a/docs/syntax_and_semantics/literals/symbol.md
+++ b/docs/syntax_and_semantics/literals/symbol.md
@@ -1,6 +1,6 @@
 # Symbol
 
-A [Symbol](http://crystal-lang.org/api/Symbol.html) represents a unique name inside the entire source code.
+A [Symbol](https://crystal-lang.org/api/latest/Symbol.html) represents a unique name inside the entire source code.
 
 Symbols are interpreted at compile time and cannot be created dynamically. The only way to create a Symbol is by using a symbol literal, denoted by a colon (`:`) followed by an identifier. The identifier may optionally be enclosed in double quotes (`"`).
 
@@ -55,7 +55,7 @@ Internally, symbols are implemented as constants with a numeric value of type `I
 
 ## Percent symbol array literal
 
-Besides the single symbol literal, there is also a percent literal to create an [Array](https://crystal-lang.org/api/Array.html) of symbols. It is indicated by `%i` and a pair of delimiters. Valid delimiters are parentheses `()`, square brackets `[]`, curly braces `{}`, angles `<>` and pipes `||`. Except for the pipes, all delimiters can be nested; meaning a start delimiter inside the string escapes the next end delimiter.
+Besides the single symbol literal, there is also a percent literal to create an [Array](https://crystal-lang.org/api/latest/Array.html) of symbols. It is indicated by `%i` and a pair of delimiters. Valid delimiters are parentheses `()`, square brackets `[]`, curly braces `{}`, angles `<>` and pipes `||`. Except for the pipes, all delimiters can be nested; meaning a start delimiter inside the string escapes the next end delimiter.
 
 ```crystal
 %i(foo bar baz)  # => [:foo, :bar, :baz]

--- a/docs/syntax_and_semantics/literals/tuple.md
+++ b/docs/syntax_and_semantics/literals/tuple.md
@@ -1,6 +1,6 @@
 # Tuple
 
-A [Tuple](http://crystal-lang.org/api/Tuple.html) is typically created with a tuple literal:
+A [Tuple](https://crystal-lang.org/api/latest/Tuple.html) is typically created with a tuple literal:
 
 ```crystal
 tuple = {1, "hello", 'x'} # Tuple(Int32, String, Char)
@@ -9,7 +9,7 @@ tuple[1]                  # => "hello" (String)
 tuple[2]                  # => 'x'     (Char)
 ```
 
-To create an empty tuple use [Tuple.new](https://crystal-lang.org/api/Tuple.html#new%28%2Aargs%3A%2AT%29-class-method).
+To create an empty tuple use [Tuple.new](https://crystal-lang.org/api/latest/Tuple.html#new%28%2Aargs%3A%2AT%29-class-method).
 
 To denote a tuple type you can write:
 

--- a/docs/syntax_and_semantics/macros/README.md
+++ b/docs/syntax_and_semantics/macros/README.md
@@ -71,13 +71,13 @@ Note that the node is pasted as-is. If in the previous example we pass a symbol,
 define_method :foo, 1
 ```
 
-Note that `:foo` was the result of the interpolation, because that's what was passed to the macro. You can use the method [`ASTNode#id`](https://crystal-lang.org/api/Crystal/Macros/ASTNode.html#id%3AMacroId-instance-method) in these cases, where you just need an identifier.
+Note that `:foo` was the result of the interpolation, because that's what was passed to the macro. You can use the method [`ASTNode#id`](https://crystal-lang.org/api/latest/Crystal/Macros/ASTNode.html#id%3AMacroId-instance-method) in these cases, where you just need an identifier.
 
 ## Macro calls
 
-You can invoke a **fixed subset** of methods on AST nodes at compile-time. These methods are documented in a fictitious [Crystal::Macros](http://crystal-lang.org/api/Crystal/Macros.html) module.
+You can invoke a **fixed subset** of methods on AST nodes at compile-time. These methods are documented in a fictitious [Crystal::Macros](https://crystal-lang.org/api/latest/Crystal/Macros.html) module.
 
-For example, invoking [`ASTNode#id`](https://crystal-lang.org/api/Crystal/Macros/ASTNode.html#id%3AMacroId-instance-method) in the above example solves the problem:
+For example, invoking [`ASTNode#id`](https://crystal-lang.org/api/latest/Crystal/Macros/ASTNode.html#id%3AMacroId-instance-method) in the above example solves the problem:
 
 ```crystal
 macro define_method(name, content)
@@ -154,7 +154,7 @@ bar # => two
 baz # => 3
 ```
 
-Similar to regular code, [`Nop`](https://crystal-lang.org/api/Crystal/Macros/Nop.html), [`NilLiteral`](https://crystal-lang.org/api/Crystal/Macros/NilLiteral.html) and a false [`BoolLiteral`](https://crystal-lang.org/api/Crystal/Macros/BoolLiteral.html) are considered *falsey*, while everything else is considered *truthy*.
+Similar to regular code, [`Nop`](https://crystal-lang.org/api/latest/Crystal/Macros/Nop.html), [`NilLiteral`](https://crystal-lang.org/api/latest/Crystal/Macros/NilLiteral.html) and a false [`BoolLiteral`](https://crystal-lang.org/api/latest/Crystal/Macros/BoolLiteral.html) are considered *falsey*, while everything else is considered *truthy*.
 
 Macro conditionals can be used outside a macro definition:
 
@@ -182,7 +182,7 @@ PI_2 # => 6.28318...
 PI_3 # => 9.42477...
 ```
 
-To iterate an [`ArrayLiteral`](https://crystal-lang.org/api/Crystal/Macros/ArrayLiteral.html):
+To iterate an [`ArrayLiteral`](https://crystal-lang.org/api/latest/Crystal/Macros/ArrayLiteral.html):
 
 ```crystal
 macro define_dummy_methods(names)
@@ -202,7 +202,7 @@ baz # => 2
 
 The `index` variable in the above example is optional.
 
-To iterate a [`HashLiteral`](https://crystal-lang.org/api/Crystal/Macros/HashLiteral.html):
+To iterate a [`HashLiteral`](https://crystal-lang.org/api/latest/Crystal/Macros/HashLiteral.html):
 
 ```crystal
 macro define_dummy_methods(hash)
@@ -252,9 +252,9 @@ bar # => 1
 baz # => 2
 ```
 
-The arguments are packed into a [`TupleLiteral`](https://crystal-lang.org/api/Crystal/Macros/TupleLiteral.html) and passed to the macro.
+The arguments are packed into a [`TupleLiteral`](https://crystal-lang.org/api/latest/Crystal/Macros/TupleLiteral.html) and passed to the macro.
 
-Additionally, using `*` when interpolating a [`TupleLiteral`](https://crystal-lang.org/api/Crystal/Macros/TupleLiteral.html) interpolates the elements separated by commas:
+Additionally, using `*` when interpolating a [`TupleLiteral`](https://crystal-lang.org/api/latest/Crystal/Macros/TupleLiteral.html) interpolates the elements separated by commas:
 
 ```crystal
 macro println(*values)
@@ -266,7 +266,7 @@ println 1, 2, 3 # outputs 123\n
 
 ## Type information
 
-When a macro is invoked you can access the current scope, or type, with a special instance variable: `@type`. The type of this variable is [`TypeNode`](https://crystal-lang.org/api/Crystal/Macros/TypeNode.html), which gives you access to type information at compile time.
+When a macro is invoked you can access the current scope, or type, with a special instance variable: `@type`. The type of this variable is [`TypeNode`](https://crystal-lang.org/api/latest/Crystal/Macros/TypeNode.html), which gives you access to type information at compile time.
 
 Note that `@type` is always the *instance* type, even when the macro is invoked in a class method.
 
@@ -293,7 +293,7 @@ Foo.describe     # => "Class is Foo"
 
 ## Method information
 
-When a macro is invoked you can access the method, the macro is in with a special instance variable: `@def`. The type of this variable is [`Def`](https://crystal-lang.org/api/Crystal/Macros/Def.html) unless the macro is outside of a method, in this case it's [`NilLiteral`](https://crystal-lang.org/api/Crystal/Macros/NilLiteral.html).
+When a macro is invoked you can access the method, the macro is in with a special instance variable: `@def`. The type of this variable is [`Def`](https://crystal-lang.org/api/latest/Crystal/Macros/Def.html) unless the macro is outside of a method, in this case it's [`NilLiteral`](https://crystal-lang.org/api/latest/Crystal/Macros/NilLiteral.html).
 
 Example:
 
@@ -321,7 +321,7 @@ VALUES = [1, 2, 3]
 {% end %}
 ```
 
-If the constant denotes a type, you get back a [`TypeNode`](https://crystal-lang.org/api/Crystal/Macros/TypeNode.html).
+If the constant denotes a type, you get back a [`TypeNode`](https://crystal-lang.org/api/latest/Crystal/Macros/TypeNode.html).
 
 ## Nested macros
 

--- a/docs/syntax_and_semantics/pointerof.md
+++ b/docs/syntax_and_semantics/pointerof.md
@@ -1,6 +1,6 @@
 # pointerof
 
-The `pointerof` expression returns a [Pointer](http://crystal-lang.org/api/Pointer.html) that points to the contents of a variable or instance variable.
+The `pointerof` expression returns a [Pointer](https://crystal-lang.org/api/latest/Pointer.html) that points to the contents of a variable or instance variable.
 
 An example with a variable:
 

--- a/docs/syntax_and_semantics/sizeof.md
+++ b/docs/syntax_and_semantics/sizeof.md
@@ -7,7 +7,7 @@ sizeof(Int32) # => 4
 sizeof(Int64) # => 8
 ```
 
-For [Reference](http://crystal-lang.org/api/Reference.html) types, the size is the same as the size of a pointer:
+For [Reference](https://crystal-lang.org/api/latest/Reference.html) types, the size is the same as the size of a pointer:
 
 ```crystal
 # On a 64 bits machine

--- a/docs/syntax_and_semantics/splats_and_tuples.md
+++ b/docs/syntax_and_semantics/splats_and_tuples.md
@@ -15,7 +15,7 @@ sum 1, 2, 3      # => 6
 sum 1, 2, 3, 4.5 # => 10.5
 ```
 
-The passed arguments become a [Tuple](http://crystal-lang.org/api/Tuple.html) in the method's body:
+The passed arguments become a [Tuple](https://crystal-lang.org/api/latest/Tuple.html) in the method's body:
 
 ```crystal
 # elements is Tuple(Int32, Int32, Int32)

--- a/docs/syntax_and_semantics/structs.md
+++ b/docs/syntax_and_semantics/structs.md
@@ -11,7 +11,7 @@ struct Point
 end
 ```
 
-Structs inherit from [Value](https://crystal-lang.org/api/Value.html) so they are allocated on the stack and passed by value: when passed to methods, returned from methods or assigned to variables, a copy of the value is actually passed (while classes inherit from [Reference](https://crystal-lang.org/api/Reference.html), are allocated on the heap and passed by reference).
+Structs inherit from [Value](https://crystal-lang.org/api/latest/Value.html) so they are allocated on the stack and passed by value: when passed to methods, returned from methods or assigned to variables, a copy of the value is actually passed (while classes inherit from [Reference](https://crystal-lang.org/api/latest/Reference.html), are allocated on the heap and passed by reference).
 
 Therefore structs are mostly useful for immutable data types and/or stateless wrappers of other types, usually for performance reasons to avoid lots of small memory allocations when passing small copies might be more efficient (for more details, see the [performance guide](https://crystal-lang.org/docs/guides/performance.html#use-structs-when-possible)).
 
@@ -80,7 +80,7 @@ What happens with the `strukt` here:
 
 ## Inheritance
 
-* A struct implicitly inherits from [Struct](http://crystal-lang.org/api/Struct.html), which inherits from [Value](http://crystal-lang.org/api/Value.html). A class implicitly inherits from [Reference](http://crystal-lang.org/api/Reference.html).
+* A struct implicitly inherits from [Struct](https://crystal-lang.org/api/latest/Struct.html), which inherits from [Value](https://crystal-lang.org/api/latest/Value.html). A class implicitly inherits from [Reference](https://crystal-lang.org/api/latest/Reference.html).
 * A struct cannot inherit from a non-abstract struct.
 
 The second point has a reason to it: a struct has a very well defined memory layout. For example, the above `Point` struct occupies 8 bytes. If you have an array of points the points are embedded inside the array's buffer:

--- a/docs/syntax_and_semantics/unsafe.md
+++ b/docs/syntax_and_semantics/unsafe.md
@@ -2,7 +2,7 @@
 
 These parts of the language are considered unsafe:
 
-* Code involving raw pointers: the [Pointer](http://crystal-lang.org/api/Pointer.html) type and [pointerof](pointerof.md).
+* Code involving raw pointers: the [Pointer](https://crystal-lang.org/api/latest/Pointer.html) type and [pointerof](pointerof.md).
 * The [allocate](new,_initialize_and_allocate.md) class method.
 * Code involving C bindings
 * [Uninitialized variable declaration](declare_var.md)


### PR DESCRIPTION
Replaces API docs links to `crystal-lang.org/api/XXX` with `crystal-lang.org/api/latest/XXX`, effectively pre- resolving and thus avoiding the HTTP redirect.
The main benefit is having a singular format. And we chose the one that's the redirect target from the other one.

cf https://github.com/crystal-lang/crystal-book/pull/471#discussion_r593492828