### PR TITLE
Increase font size in admonitions

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -6,3 +6,7 @@
     width: 1.6rem;
     height: 1.6rem;
 }
+
+.md-typeset .admonition {
+    font-size: 0.72rem;
+}


### PR DESCRIPTION
The font size in admonition paragraphs is very small at 80% of regular body copy. This actually makes it hard to read in comparison.
This patch increases the font size to 90% of regular paragraphs:

### Before

![grafik](https://user-images.githubusercontent.com/466378/111393293-c14bb200-86b8-11eb-992f-4c4994b18363.png)

### After

![grafik](https://user-images.githubusercontent.com/466378/111393644-69fa1180-86b9-11eb-80d1-87dc7958fb68.png)

