### PR TITLE
Add snippet for crystal-version

### DIFF
--- a/crystal-version.txt
+++ b/crystal-version.txt
@@ -1,0 +1,4 @@
+Crystal 0.36.1 [c3a3c1823] (2021-02-02)
+
+LLVM: 10.0.0
+Default target: x86_64-apple-macosx

--- a/docs/getting_started/README.md
+++ b/docs/getting_started/README.md
@@ -14,10 +14,7 @@ We may check the Crystal compiler version. If Crystal is installed correctly the
 
 ```console
 $ crystal --version
-Crystal 0.34.0 (2020-04-07)
-
-LLVM: 10.0.0
-Default target: x86_64-apple-macosx
+--8<-- "crystal-version.txt"
 ```
 
 Great!

--- a/docs/getting_started/cli.md
+++ b/docs/getting_started/cli.md
@@ -20,10 +20,7 @@ It is a very common practice to pass options to the application. For example, we
 
 ```console
 $ crystal -v
-Crystal 0.31.1 (2019-10-02)
-
-LLVM: 8.0.1
-Default target: x86_64-apple-macosx
+--8<-- "crystal-version.txt"
 ```
 
 and if we run: `crystal -h`, then Crystal will show all the accepted options and how to use them.

--- a/docs/using_the_compiler/README.md
+++ b/docs/using_the_compiler/README.md
@@ -199,10 +199,7 @@ Example:
 
 ```console
 $ crystal version
-Crystal 0.25.1 [b782738ff] (2018-06-27)
-
-LLVM: 4.0.0
-Default target: x86_64-unknown-linux-gnu
+--8<-- "crystal-version.txt"
 ```
 
 ### `crystal init`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ markdown_extensions:
   - pymdownx.superfences
   - toc:
       permalink: true
+  - pymdownx.snippets
 
 google_analytics:
   - UA-42353458-1


### PR DESCRIPTION
The current output of `crystal version` is placed in crystal-version.txt and only this location needs to be updated when a new version is released. The content is automatically included in all places where `crystal version` output is used as an example.