### PR TITLE
Fix link to Syntax and Semantics page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ The core documentation of the Crystal language, standard library and tooling.
 <div class="cards" markdown="1">
   <div class="card" markdown="1">
 
-### [Language Reference](syntax-and-semantics/)
+### [Language Reference](syntax_and_semantics/)
 Specification of the language.
 
   </div>


### PR DESCRIPTION
The page https://crystal-lang.org/reference/ has a link "Language Reference", which points to https://crystal-lang.org/reference/syntax-and-semantics/, but that link does not work. It should be https://crystal-lang.org/reference/syntax_and_semantics instead
I fixed this by replacing "-" by "_" in docs/README.md