### PR TITLE
Disallow unchecked intra-site links

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -21,6 +21,15 @@ jobs:
           restore-keys: pip-
       - name: Build book
         run: make build
+      - name: Disallow unchecked intra-site links
+        run: |
+          if grep -P '\[\w.*?\]\((?!http)[^ )]*?(\.html|/)(#[^ )]*?)?\)' docs/**/*.md; then
+            echo "Links within the site must end with .md"; exit 1
+          fi
+          if grep -P '\]\(/|//crystal-lang.org/reference/' docs/**/*.md; then
+            echo "Absolute links within the site are disallowed, use relative links instead"; exit 1
+          fi
+
       - name: Configure AWS Credentials
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -22,14 +22,7 @@ jobs:
       - name: Build book
         run: make build
       - name: Disallow unchecked intra-site links
-        run: |
-          if grep -P '\[\w.*?\]\((?!http)[^ )]*?(\.html|/)(#[^ )]*?)?\)' docs/**/*.md; then
-            echo "Links within the site must end with .md"; exit 1
-          fi
-          if grep -P '\]\(/|//crystal-lang.org/reference/' docs/**/*.md; then
-            echo "Absolute links within the site are disallowed, use relative links instead"; exit 1
-          fi
-
+        run: make check_internal_links
       - name: Configure AWS Credentials
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: aws-actions/configure-aws-credentials@v1

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,14 @@ clean_all: clean clean_deps clean_vendor
 format_api_docs_links:
 	echo $(DOCS_FILES) | xargs sed -i -E -e 's|https?://(www\.)?crystal-lang.org/api/([A-Z])|https://crystal-lang.org/api/latest/\2|g'
 
+check_internal_links:
+	if grep -P '\[\w.*?\]\((?!http)[^ )]*?(\.html|/)(#[^ )]*?)?\)' docs/**/*.md; then \
+		echo "Links within the site must end with .md"; exit 1; \
+	fi
+	if grep -P '\]\(/|//crystal-lang.org/reference/' docs/**/*.md; then \
+		echo "Absolute links within the site are disallowed, use relative links instead"; exit 1; \
+	fi
+
 .PHONY: help
 help: ## Show this help
 	@echo

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ The core documentation of the Crystal language, standard library and tooling.
 <div class="cards" markdown="1">
   <div class="card" markdown="1">
 
-### [Language Reference](syntax_and_semantics/)
+### [Language Reference](syntax_and_semantics/README.md)
 Specification of the language.
 
   </div>

--- a/docs/database/connection.md
+++ b/docs/database/connection.md
@@ -70,9 +70,9 @@ DB.connect "mysql://root:root@localhost/test" do |cnn|
 end
 ```
 
-First, in this example, we are using a transaction (check the [transactions](https://crystal-lang.org/reference/database/transactions.html) section for more information on this topic)
+First, in this example, we are using a transaction (check the [transactions](transactions.md) section for more information on this topic)
 Second, it's important to notice that the connection given by the transaction **is the same connection** that we were working with, before the transaction begin. That is, there is only **one** connection at all times in our program.
-And last, we are using the method `#exec` and `#query`. You may read more about executing queries in the [database](https://crystal-lang.org/reference/database/) section.
+And last, we are using the method `#exec` and `#query`. You may read more about executing queries in the [database](README.md) section.
 
 Now that we have a good idea about creating a connection, let's present the **second way** for creating one: `DB#open`
 
@@ -90,7 +90,7 @@ As with a connection, we should close the database once we don't need it anymore
 Or instead, we could use a block and let Crystal close the database for us!
 
 But, where is the connection?
-Well, we should be asking for the **connections**. When a database is created, a pool of connections is created with connections to the database prepared and ready to use! (Do you want to read more about **pool of connections**? In the [connection pool](https://crystal-lang.org/reference/database/connection_pool.html) section you may read all about this interesting topic!)
+Well, we should be asking for the **connections**. When a database is created, a pool of connections is created with connections to the database prepared and ready to use! (Do you want to read more about **pool of connections**? In the [connection pool](connection_pool.md) section you may read all about this interesting topic!)
 
 How do we use a connection from the `database` object?
 For this, we could ask the database for a connection using the method `Database#checkout`. But, doing this will require to explicitly return the connection to the pool using `Connection#release`. Here is an example:

--- a/docs/getting_started/cli.md
+++ b/docs/getting_started/cli.md
@@ -300,7 +300,7 @@ In let_it_cli.cr:5:46
 Error: undefined method 'upper_case' for Nil (compile-time type is (String | Nil))
 ```
 
-Ah! We should have known better: the type of the user input is the [union type](https://crystal-lang.org/reference/syntax_and_semantics/type_grammar.html) `String | Nil`.
+Ah! We should have known better: the type of the user input is the [union type](../syntax_and_semantics/type_grammar.md) `String | Nil`.
 So, we have to test for `Nil` and for `empty` and act naturally for each case:
 
 !!! example "let_it_cli.cr"

--- a/docs/guides/ci/README.md
+++ b/docs/guides/ci/README.md
@@ -15,7 +15,7 @@ We are going to use Conway's Game of Life as the example application. More preci
 
 Note that we won't be using TDD in the example itself, but we will mimic as if the example code is the result of the first iterations.
 
-Another important thing to mention is that we are using `crystal init` to [create the application](../using_the_compiler/#creating-a-crystal-project).
+Another important thing to mention is that we are using `crystal init` to [create the application](../../using_the_compiler/README.md#creating-a-crystal-project).
 
 And here's the implementation:
 

--- a/docs/guides/ci/travis.md
+++ b/docs/guides/ci/travis.md
@@ -39,7 +39,7 @@ Let's see another example:
 With this configuration, Travis CI will run the tests using both Crystal `latest` and `nightly` releases on every push to a branch on your Github repository.
 
 !!! note
-    When [creating a Crystal project](../../using_the_compiler/#creating-a-crystal-project) using `crystal init`, Crystal creates a `.travis.yml` file for us.
+    When [creating a Crystal project](../../using_the_compiler/README.md#creating-a-crystal-project) using `crystal init`, Crystal creates a `.travis.yml` file for us.
 
 ### Using a specific Crystal release
 


### PR DESCRIPTION
In CI, use regular expressions to check against the kinds of links that could be made safer by letting MkDocs check their validity:

* Links not ending with '.md' (but the check is specifically for '.html' and '/' endings)
* Links starting with '/' or containing the site URL itself.

Closes #498