### PR TITLE
Add documentation for chaining of comparisons and equalities

### DIFF
--- a/docs/syntax_and_semantics/operators.md
+++ b/docs/syntax_and_semantics/operators.md
@@ -229,7 +229,7 @@ For example `a <= b <= c` is treated as `a <= b && b <= c`
 and it is even possible to mix operators of the same 
 [operator precedence](#operator-precedence) 
 like `a >= b <= c > d`. 
-It is not advised to chain operators of different precedences since this may lead to compile time errors.
+Operators with different precedences can be chained too, however, it is advised to avoid it, since it is makes the code harder to understand. For instance `a == b <= c` is interpreted as `a == b && b <= c`, while `a <= b == c` is interpreted as `a <= (b == c)`. 
 
 ### Logical
 

--- a/docs/syntax_and_semantics/operators.md
+++ b/docs/syntax_and_semantics/operators.md
@@ -224,20 +224,12 @@ proven faster than equality).
 #### Chaining Equality and Comparison
 
 The compiler allows for `==`, `!=`, `===`, `<`, `>`, `<=`, and `>=` 
-to be chained together.  
+to be chained together. 
 For example `a <= b <= c` is treated as `a <= b && b <= c`
-and it is even possible to mix operators like `a == b <= c > d`.
-
-There are cases where this does not work due to 
-[operator precedence](#operator-precedence),
-e.g. `a <= b == c` results in a compile time error
-while `a == b <= c` works fine.
-To ensure precedence, the compiler 
-treats `a <= b == c` as `a.<=(b.==(c))` and throws an error since `<=` cannot be used with a `Bool`. The same thing happens for `(a == b) <= c` or `(a.==(b)).<=(c)`.
-However, `a == b <= c` is just treated as `a.==(b).<=(c)` where the compiler can infer that this is a chain of comparisons/equalities and produces `a == b && b <= c`.
-
-Because of this rather confusing behavior, it is advised to only make use of this feature
-in obvious cases, e.g. `a <= b <= c`.
+and it is even possible to mix operators of the same 
+[operator precedence](#operator-precedence) 
+like `a >= b <= c > d`. 
+It is not advised to chain operators of different precedences since this may lead to compile time errors.
 
 ### Logical
 

--- a/docs/syntax_and_semantics/operators.md
+++ b/docs/syntax_and_semantics/operators.md
@@ -223,8 +223,8 @@ proven faster than equality).
 
 #### Chaining Equality and Comparison
 
-The compiler allows for `==`, `!=`, `===`, `<`, `>`, `<=`, and `>=` 
-to be chained together. 
+Equality and comparison operators `==`, `!=`, `===`, `<`, `>`, `<=`, and `>=` 
+can be chained together and are interpreted as a compound expression. 
 For example `a <= b <= c` is treated as `a <= b && b <= c`
 and it is even possible to mix operators of the same 
 [operator precedence](#operator-precedence) 

--- a/docs/syntax_and_semantics/operators.md
+++ b/docs/syntax_and_semantics/operators.md
@@ -183,7 +183,9 @@ ones.
 | `|` | binary OR | `1 | 2` | yes |
 | `^` | binary XOR | `1 ^ 2` | yes |
 
-### Equality
+### Equality and Comparison
+
+#### Equality
 
 Three base operators test equality:
 
@@ -209,7 +211,7 @@ proven faster than equality).
 | `!~` | no pattern match | `"foo" !~ /fo/` | yes |
 | `===` | [case equality](case.md) | `/foo/ === "foo"` | yes |
 
-### Comparison
+#### Comparison
 
 | Operator | Description | Example | Overloadable |
 |---|---|---|---|
@@ -218,6 +220,24 @@ proven faster than equality).
 | `>` | greater | `1 > 2` | yes |
 | `>=` | greater or equal | `1 >= 2` | yes |
 | `<=>` | comparison | `1 <=> 2` | yes |
+
+#### Chaining Equality and Comparison
+
+The compiler allows for `==`, `!=`, `===`, `<`, `>`, `<=`, and `>=` 
+to be chained together.  
+For example `a <= b <= c` is treated as `a <= b && b <= c`
+and it is even possible to mix operators like `a == b <= c > d`.
+
+There are cases where this does not work due to 
+[operator precedence](#operator-precedence),
+e.g. `a <= b == c` results in a compile time error
+while `a == b <= c` works fine.
+To ensure precedence, the compiler 
+treats `a <= b == c` as `a.<=(b.==(c))` and throws an error since `<=` cannot be used with a `Bool`. The same thing happens for `(a == b) <= c` or `(a.==(b)).<=(c)`.
+However, `a == b <= c` is just treated as `a.==(b).<=(c)` where the compiler can infer that this is a chain of comparisons/equalities and produces `a == b && b <= c`.
+
+Because of this rather confusing behavior, it is advised to only make use of this feature
+in obvious cases, e.g. `a <= b <= c`.
 
 ### Logical
 


### PR DESCRIPTION
fixes #510 

As discussed in #510, the compiler allows to chain some of the comparisons and equality together but this was not documented yet.  
In this PR, I now added a little section about this.

I also investigated this a little more and noticed that in some cases compile time errors occur, e.g. for `a <= b == c`.
This is because the precedence handling (I think this is done here: https://github.com/crystal-lang/crystal/blob/a7544b5f0f3e23d05cb4622ff4db3cbb7f1b996a/src/compiler/crystal/syntax/parser.cr#L537) interferes with the normalization (https://github.com/crystal-lang/crystal/blob/a7544b5f0f3e23d05cb4622ff4db3cbb7f1b996a/src/compiler/crystal/semantic/normalizer.cr#L100).
I tried to describe this a little bit in the documentation as well.

Probably it is worthwhile to discuss this issue also in https://github.com/crystal-lang/crystal since I think that this behavior is far from being obvious and it seems to depend on the implementation details of the compiler currently.
Maybe this can be fixed by adjusting the parsing or normalization process but I'm not sure right now which implications this might have.

Any feedback is very much appreciated :)