### PR TITLE
Add docs for `@top_level` macro variable

### DIFF
--- a/docs/syntax_and_semantics/macros/README.md
+++ b/docs/syntax_and_semantics/macros/README.md
@@ -291,6 +291,21 @@ Foo.new.describe # => "Class is Foo"
 Foo.describe     # => "Class is Foo"
 ```
 
+## The top level module
+
+It is posible to access the top level module, as a [`TypeNode`](https://crystal-lang.org/api/latest/Crystal/Macros/TypeNode.html), with a special instance variable: `@top_level`. The following example shows its utility:
+
+```crystal
+A_CONSTANT = 0
+
+{% if @top_level.has_constant?("A_CONSTANT") %}
+puts "this is printed"
+{% else %}
+puts "this is not printed"
+{% end %}
+```
+
+
 ## Method information
 
 When a macro is invoked you can access the method, the macro is in with a special instance variable: `@def`. The type of this variable is [`Def`](https://crystal-lang.org/api/latest/Crystal/Macros/Def.html) unless the macro is outside of a method, in this case it's [`NilLiteral`](https://crystal-lang.org/api/latest/Crystal/Macros/NilLiteral.html).

--- a/docs/syntax_and_semantics/macros/README.md
+++ b/docs/syntax_and_semantics/macros/README.md
@@ -293,7 +293,7 @@ Foo.describe     # => "Class is Foo"
 
 ## The top level module
 
-It is posible to access the top level module, as a [`TypeNode`](https://crystal-lang.org/api/latest/Crystal/Macros/TypeNode.html), with a special instance variable: `@top_level`. The following example shows its utility:
+It is possible to access the top-level namespace, as a [`TypeNode`](https://crystal-lang.org/api/latest/Crystal/Macros/TypeNode.html), with a special variable: `@top_level`. The following example shows its utility:
 
 ```crystal
 A_CONSTANT = 0


### PR DESCRIPTION
To be merged once the corresponding [PR](https://github.com/crystal-lang/crystal/pull/10682) gets merged.