### PR TITLE
Remove Void outside of references to C code

### DIFF
--- a/docs/syntax_and_semantics/capturing_blocks.md
+++ b/docs/syntax_and_semantics/capturing_blocks.md
@@ -45,7 +45,7 @@ def some_proc(&block : Int32 ->)
 end
 
 proc = some_proc { |x| x + 1 }
-proc.call(1) # nil
+proc.call(1) # => nil
 ```
 
 To have something returned, either specify the return type or use an underscore to allow any return type:

--- a/docs/syntax_and_semantics/capturing_blocks.md
+++ b/docs/syntax_and_semantics/capturing_blocks.md
@@ -45,7 +45,7 @@ def some_proc(&block : Int32 ->)
 end
 
 proc = some_proc { |x| x + 1 }
-proc.call(1) # void
+proc.call(1) # nil
 ```
 
 To have something returned, either specify the return type or use an underscore to allow any return type:

--- a/docs/syntax_and_semantics/literals/proc.md
+++ b/docs/syntax_and_semantics/literals/proc.md
@@ -33,8 +33,8 @@ To denote a Proc type you can write:
 # A Proc accepting a single Int32 argument and returning a String
 Proc(Int32, String)
 
-# A proc accepting no arguments and returning Void
-Proc(Void)
+# A proc accepting no arguments and returning Nil
+Proc(Nil)
 
 # A proc accepting two arguments (one Int32 and one String) and returning a Char
 Proc(Int32, String, Char)


### PR DESCRIPTION
`Void` is a construct that is only relevant to C bindings. Referencing it outside of that explicit context could be confusing, and could lead people to use it where it's not meant to be used. (Evidence: me, about a year and a half ago :stuck_out_tongue:)