### PR TITLE
Add documentation for splat expansions in array / tuple literals

### DIFF
--- a/docs/syntax_and_semantics/literals/array.md
+++ b/docs/syntax_and_semantics/literals/array.md
@@ -80,3 +80,32 @@ The type arguments can be explicitly specified as part of the type name:
 ```crystal
 Set(Int32){1, 2, 3}
 ```
+
+## Splat Expansion
+
+The splat operator can be used inside array and array-like literals to insert multiple values at once.
+
+```crystal
+[1, *coll, 2, 3]
+Set{1, *coll, 2, 3}
+```
+
+The only requirement is that `coll`'s type must include [`Enumerable`](https://crystal-lang.org/api/latest/Enumerable.html). The above is equivalent to:
+
+```crystal
+array = Array(typeof(...)).new
+array << 1
+array.concat(coll)
+array << 2
+array << 3
+
+array_like = Set(typeof(...)).new
+array_like << 1
+coll.each do |elem|
+  array_like << elem
+end
+array_like << 2
+array_like << 3
+```
+
+In these cases, the generic type argument is additionally inferred using `coll`'s elements.

--- a/docs/syntax_and_semantics/literals/tuple.md
+++ b/docs/syntax_and_semantics/literals/tuple.md
@@ -24,3 +24,16 @@ In type restrictions, generic type arguments and other places where a type is ex
 # An array of tuples of Int32, String and Char
 Array({Int32, String, Char})
 ```
+
+## Splat Expansion
+
+The splat operator can be used inside tuple literals to unpack multiple values at once. The splatted value must be another tuple.
+
+```crystal
+tuple = {1, *{"hello", 'x'}, 2} # => {1, "hello", 'x', 2}
+typeof(tuple)                   # => Tuple(Int32, String, Char, Int32)
+
+tuple = {3.5, true}
+tuple = {*tuple, *tuple} # => {3.5, true, 3.5, true}
+typeof(tuple)            # => Tuple(Float64, Bool, Float64, Bool)
+```


### PR DESCRIPTION
Add wording for crystal-lang/crystal#10429.