### PR TITLE
Fix type in performance.md example block

### DIFF
--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -200,7 +200,7 @@ You shouldn't always use a struct, though. Structs are passed by value, so if yo
 
 For example:
 
-!!! example "class_vs_struct.cr'
+!!! example "class_vs_struct.cr"
     ```crystal
     require "benchmark"
 


### PR DESCRIPTION
This PR fixes a typo in an example block declaration that prevented the file name being displayed correctly above the example code.

Before:
<img width="244" alt="Screen Shot 2021-06-02 at 12 42 31 AM" src="https://user-images.githubusercontent.com/583503/120443908-f7a1e080-c33b-11eb-85cd-8cbe521013f6.png">
After:
<img width="288" alt="Screen Shot 2021-06-02 at 12 41 59 AM" src="https://user-images.githubusercontent.com/583503/120443905-f7094a00-c33b-11eb-9b90-2537998072f4.png">