### PR TITLE
Improve Makefile

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -21,6 +21,8 @@ jobs:
           path: ~/.cache/pip
           key: pip-${{ hashFiles('requirements.txt') }}
           restore-keys: pip-
+      - name: Install dependencies
+        run: make deps
       - name: Build book
         run: LINT=1 make build
       - name: Disallow unchecked intra-site links

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ serve: $(MKDOCS) mkdocs.yml
 deps: $(MKDOCS)
 
 $(MKDOCS): $(PIP) requirements.txt
-	$(PIP) install -q -r requirements.txt
+	$(PIP) install -q --no-deps -r requirements.txt && touch $(MKDOCS)
 
 $(PIP):
 	python3 -m venv .venv
@@ -75,7 +75,8 @@ clean_all: clean clean_deps clean_vendor
 format_api_docs_links:
 	echo $(DOCS_FILES) | xargs sed -i -E -e 's|https?://(www\.)?crystal-lang.org/api/([A-Z])|https://crystal-lang.org/api/latest/\2|g'
 
-check_internal_links:
+.PHONY: check_internal_links
+check_internal_links: $(DOCS_FILES)
 	if grep -P '\[\w.*?\]\((?!http)[^ )]*?(\.html|/)(#[^ )]*?)?\)' docs/**/*.md; then \
 		echo "Links within the site must end with .md"; exit 1; \
 	fi


### PR DESCRIPTION
* `pip` works slightly faster with `--no-deps`, and our deps are always fully resolved.
* Seems like when installing `mkdocs`, its executable would have an old mtime, then the site is always considered outdated as it depends on the executable.
* GH workflow: split out the deps step for timing measurement purposes
* `check_internal_links` is not a file target
