### PR TITLE
Exponentiation operators should have right associativity

### DIFF
--- a/docs/syntax_and_semantics/operators.md
+++ b/docs/syntax_and_semantics/operators.md
@@ -145,8 +145,8 @@ ones.
 
 | Operator | Description | Example | Overloadable | Associativity |
 |---|---|---|---|---|
-| `**` | exponentiation | `1 ** 2` | yes | left |
-| `&**` | wrapping exponentiation | `1 &** 2` | yes | left |
+| `**` | exponentiation | `1 ** 2` | yes | right |
+| `&**` | wrapping exponentiation | `1 &** 2` | yes | right |
 | `*` | multiplication | `1 * 2` | yes | left |
 | `&*` | wrapping multiplication | `1 &* 2` | yes | left |
 | `/` | division | `1 / 2` | yes | left |


### PR DESCRIPTION
`puts 2 ** 3 ** 2` results in `512`.  Repeated exponentiation is parsed as right-associative, as in `puts 2 ** (3 ** 2)`.
The crystal language implements this correctly.  This is just a documentation fix.