### PR TITLE
Update list of admonition keywords

### DIFF
--- a/docs/syntax_and_semantics/documenting_code.md
+++ b/docs/syntax_and_semantics/documenting_code.md
@@ -129,10 +129,12 @@ Several admonition keywords are supported to visually highlight problems, notes 
 
 - `BUG`
 - `DEPRECATED`
+- `EXPERIMENTAL`
 - `FIXME`
 - `NOTE`
 - `OPTIMIZE`
 - `TODO`
+- `WARNING`
 
 Admonition keywords must be the first word in their respective line and must be in all caps. An optional trailing colon is preferred for readability.
 


### PR DESCRIPTION
`EXPERIMENTAL` was missing (only the corresponding annotation is mentioned). `WARNING` is due to crystal-lang/crystal#10898.