### PR TITLE
Downgrade mkdocs-redirects plugin back to an older version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,5 +2,5 @@ mkdocs>=1.2
 mkdocs-material>=7.1.8
 mkdocs-literate-nav>=0.2
 mkdocs-section-index>=0.2.3
-mkdocs-redirects>=1.0.1
+mkdocs-redirects==1.0.1
 mkdocs-code-validator>=0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ mkdocs-material==7.1.11
     # via
     #   -r requirements.in
     #   mkdocs-material-extensions
-mkdocs-redirects==1.0.3
+mkdocs-redirects==1.0.1
     # via -r requirements.in
 mkdocs-section-index==0.3.1
     # via -r requirements.in
@@ -63,9 +63,7 @@ pyyaml==5.4.1
     #   mkdocs
     #   pyyaml-env-tag
 six==1.16.0
-    # via
-    #   mkdocs-redirects
-    #   python-dateutil
+    # via python-dateutil
 watchdog==2.1.3
     # via mkdocs
 zipp==3.5.0


### PR DESCRIPTION
Due to a bug, redirects to "README.md" are no longer recognized correctly as "index.html":
https://github.com/datarobot/mkdocs-redirects/issues/23
