### PR TITLE
Demote i386-linux-gnu to Tier 2

### DIFF
--- a/docs/platform_support.md
+++ b/docs/platform_support.md
@@ -18,7 +18,6 @@ Tier 1 platforms can be thought of as “guaranteed to work”. Specifically the
 | ------ | -------- | --- | ----------- |
 | x86_64-darwin | ✓ | ✓ | 64-bit OSX (10.7+, Lion+) |
 | x86_64-linux-gnu | ✓ | ✓ | 64-bit Linux (2.6.18+) |
-| i386-linux-gnu | ✓ | ✓ | 32-bit Linux (2.6.18+) |
 
 ***
 
@@ -31,6 +30,7 @@ Tier 2 platforms can be thought of as “expected to build”. Automated tests a
 | aarch64-linux-gnu | ✓ | ✓ | ARM 64-bit Linux (GNU, hardfloat) |
 | aarch64-linux-musl | ✓ | ✓ | ARM 64-bit Linux (MUSL, hardfloat) |
 | arm-linux-gnueabihf | ✓ | ✓ | ARM 32-bit Linux (GNU, hardfloat) |
+| i386-linux-gnu | ✓ | ✓ | 32-bit Linux (2.6.18+) |
 | i386-linux-musl | ✓ | ✓ | 32-bit Linux (MUSL) |
 | x86_64-linux-musl | ✓ | ✓ | 64-bit Linux (MUSL) |
 | x86_64-openbsd | ✓ | ✓ | 64-bit OpenBSD (6.x) |


### PR DESCRIPTION
We're experiencing issues with running the automated tests on i386-linux-gnu (see crystal-lang/crystal#11127) and that's unlikely to change anytime soon.

