### PR TITLE
Document null and hash character escape sequences in char and string literals

### DIFF
--- a/docs/syntax_and_semantics/literals/char.md
+++ b/docs/syntax_and_semantics/literals/char.md
@@ -27,6 +27,7 @@ Available escape sequences:
 '\r'         # carriage return
 '\t'         # tab
 '\v'         # vertical tab
+'\0'         # null character
 '\uFFFF'     # hexadecimal unicode character
 '\u{10FFFF}' # hexadecimal unicode character
 ```

--- a/docs/syntax_and_semantics/literals/string.md
+++ b/docs/syntax_and_semantics/literals/string.md
@@ -17,6 +17,7 @@ Available escape sequences:
 ```crystal
 "\""                  # double quote
 "\\"                  # backslash
+"\#"                  # hash character (to escape interpolation)
 "\a"                  # alert
 "\b"                  # backspace
 "\e"                  # escape
@@ -70,7 +71,7 @@ String interpolation is also possible with [String#%](https://crystal-lang.org/a
 
 Any expression may be placed inside the interpolated section, but it’s best to keep the expression small for readability.
 
-Interpolation can be disabled by escaping the `#` character with a backslash or by using a non-interpolating string literal like `%q()`.
+Interpolation can be disabled by escaping the hash character (`#`) with a backslash or by using a non-interpolating string literal like `%q()`.
 
 ```crystal
 "\#{a + b}"  # => "#{a + b}"


### PR DESCRIPTION
The missing documentation of `'\0'` was discovered in #11260

I cross-checked with the lexer and noticed escaped hash character (`"\#"`) is also missing for string literals.
Now all escape sequences should be properly documented.