### PR TITLE
Update crystal shards location

### DIFF
--- a/docs/guides/writing_shards.md
+++ b/docs/guides/writing_shards.md
@@ -160,7 +160,7 @@ A description should be:
 #### Optimizing
 
 It's hard for anyone to use your project if they can't find it.
-Take a look [here](https://crystal-lang.org/community/#shards) for more information on where to find shards
+There are several services for discovering shards, a list is available on the [Crystal Community page](https://crystal-lang.org/community/#shards).
 
 There are people looking for the _exact_ functionality of our library and the _general_ functionality of our library.
 e.g. Bob needs a palindrome library, but Felipe is just looking for libraries involving text and Susan is looking for libraries involving spelling.

--- a/docs/guides/writing_shards.md
+++ b/docs/guides/writing_shards.md
@@ -160,7 +160,7 @@ A description should be:
 #### Optimizing
 
 It's hard for anyone to use your project if they can't find it.
-[crystalshards.xyz](https://crystalshards.xyz/) is currently the go-to place for Crystal libraries, so that's what we'll optimize for.
+[crystalshards.xyz](https://crystalshards.org/) is currently the go-to place for Crystal libraries, so that's what we'll optimize for.
 
 There are people looking for the _exact_ functionality of our library and the _general_ functionality of our library.
 e.g. Bob needs a palindrome library, but Felipe is just looking for libraries involving text and Susan is looking for libraries involving spelling.

--- a/docs/guides/writing_shards.md
+++ b/docs/guides/writing_shards.md
@@ -160,7 +160,7 @@ A description should be:
 #### Optimizing
 
 It's hard for anyone to use your project if they can't find it.
-[crystalshards.xyz](https://crystalshards.org/) is currently the go-to place for Crystal libraries, so that's what we'll optimize for.
+Take a look [here](https://crystal-lang.org/community/#shards) for more information on where to find shards
 
 There are people looking for the _exact_ functionality of our library and the _general_ functionality of our library.
 e.g. Bob needs a palindrome library, but Felipe is just looking for libraries involving text and Susan is looking for libraries involving spelling.


### PR DESCRIPTION
CrystalShards.xyz is down once again. CrystalShards.org is more stable and has not experienced downtime in the last few years.