### PR TITLE
Use branch names like 'release/1.2' for versioned deployment

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -30,8 +30,8 @@ jobs:
         id: branch
         shell: bash -x {0}
         run: |
-          if [[ $GITHUB_REF =~ ^refs/heads/(master|[0-9][0-9.]+)$ ]]; then
-            echo "::set-output name=branch::${BASH_REMATCH[1]}"
+          if [[ $GITHUB_REF =~ ^refs/heads/(master|release/[0-9][0-9.]+)$ ]]; then
+            echo "::set-output name=branch::${BASH_REMATCH[1]#release/}"
           fi
       - name: Build versions file
         if: github.event_name == 'push' && steps.branch.outputs.branch != null

--- a/scripts/docs-versions.sh
+++ b/scripts/docs-versions.sh
@@ -3,7 +3,7 @@ set -e
 
 printf '['
 latest='"latest"'
-for ver in $(git ls-remote --heads "${1:-.}" | grep -P -o '(?<=refs/heads/)[0-9][0-9.]+' | sort -V -r); do
+for ver in $(git ls-remote --heads "${1:-.}" | grep -P -o '(?<=refs/heads/release/)[0-9][0-9.]+' | sort -V -r); do
   printf '{"version": "%s", "title": "%s", "aliases": [%s]}, ' "$ver" "$ver" "$latest"
   latest=''
 done


### PR DESCRIPTION
Closes #568﻿
