### PR TITLE
Reland: Use the version of Crystal according to the current branch

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -34,8 +34,14 @@ jobs:
           restore-keys: pip-
       - name: Install dependencies
         run: make deps
+      - name: Determine a version for API doc links
+        shell: bash -x {0}
+        run: |
+          if [[ '${{ steps.branch.outputs.branch }}' =~ ^[0-9] ]]; then
+            echo "CRYSTAL_VERSION=${{ steps.crystal.outputs.crystal }}" >> ${GITHUB_ENV}
+          fi
       - name: Build book
-        run: CRYSTAL_VERSION=${{ steps.crystal.outputs.crystal }} LINT=true make build
+        run: LINT=true make build
       - name: Build versions file
         if: github.event_name == 'push' && steps.branch.outputs.branch != null
         run: scripts/docs-versions.sh origin | tee /dev/stderr > versions.json

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -16,8 +16,8 @@ jobs:
         id: branch
         shell: bash -x {0}
         run: |
-          if [[ $GITHUB_REF =~ ^refs/heads/(master|release/[0-9][0-9.]+)$ ]]; then
-            echo "::set-output name=branch::${BASH_REMATCH[1]#release/}"
+          if [[ ${GITHUB_BASE_REF:-$GITHUB_REF} =~ ^(refs/heads/)?(master|release/[0-9][0-9.]+)$ ]]; then
+            echo "::set-output name=branch::${BASH_REMATCH[2]#release/}"
           fi
       - name: Install Crystal
         id: crystal

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -12,8 +12,18 @@ jobs:
     steps:
       - name: Download source
         uses: actions/checkout@v2
+      - name: Extract branch name to deploy
+        id: branch
+        shell: bash -x {0}
+        run: |
+          if [[ $GITHUB_REF =~ ^refs/heads/(master|release/[0-9][0-9.]+)$ ]]; then
+            echo "::set-output name=branch::${BASH_REMATCH[1]#release/}"
+          fi
       - name: Install Crystal
+        id: crystal
         uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{ steps.branch.outputs.branch }}
       - name: Install Python
         uses: actions/setup-python@v2
       - name: Cache dependencies
@@ -25,14 +35,7 @@ jobs:
       - name: Install dependencies
         run: make deps
       - name: Build book
-        run: LINT=true make build
-      - name: Extract branch name to deploy
-        id: branch
-        shell: bash -x {0}
-        run: |
-          if [[ $GITHUB_REF =~ ^refs/heads/(master|release/[0-9][0-9.]+)$ ]]; then
-            echo "::set-output name=branch::${BASH_REMATCH[1]#release/}"
-          fi
+        run: CRYSTAL_VERSION=${{ steps.crystal.outputs.crystal }} LINT=true make build
       - name: Build versions file
         if: github.event_name == 'push' && steps.branch.outputs.branch != null
         run: scripts/docs-versions.sh origin | tee /dev/stderr > versions.json

--- a/hooks.py
+++ b/hooks.py
@@ -1,7 +1,10 @@
 import logging
+import os
 import re
 
+
 log = logging.getLogger('mkdocs')
+version = os.getenv('CRYSTAL_VERSION', 'latest')
 
 
 def on_page_markdown(markdown, page, **kwargs):
@@ -19,3 +22,9 @@ def on_page_markdown(markdown, page, **kwargs):
             f"Documentation file '{path}' contains a version-pinned link to the API: '{bad}'\n"
             f"Suggested fix: '{good}'"
         )
+
+    return re.sub(
+        r'\bhttps?://(www\.)?crystal-lang\.org/api/(?!([0-9]+(\.[0-9]+)+|latest|master)/)',
+        f'https://crystal-lang.org/api/{version}/',
+        markdown
+    )

--- a/hooks.py
+++ b/hooks.py
@@ -4,7 +4,7 @@ import re
 
 
 log = logging.getLogger('mkdocs')
-version = os.getenv('CRYSTAL_VERSION', 'latest')
+version = os.getenv('CRYSTAL_VERSION', 'master')
 
 
 def on_page_markdown(markdown, page, **kwargs):


### PR DESCRIPTION
Currently pull requests don't see a valid branch name, so the selection of Crystal version (to validate against) doesn't work at all for them.

This is a fixup for #562
