### PR TITLE
Revert "Use the version of Crystal according to the current branch"

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -12,18 +12,8 @@ jobs:
     steps:
       - name: Download source
         uses: actions/checkout@v2
-      - name: Extract branch name to deploy
-        id: branch
-        shell: bash -x {0}
-        run: |
-          if [[ $GITHUB_REF =~ ^refs/heads/(master|release/[0-9][0-9.]+)$ ]]; then
-            echo "::set-output name=branch::${BASH_REMATCH[1]#release/}"
-          fi
       - name: Install Crystal
-        id: crystal
         uses: crystal-lang/install-crystal@v1
-        with:
-          crystal: ${{ steps.branch.outputs.branch }}
       - name: Install Python
         uses: actions/setup-python@v2
       - name: Cache dependencies
@@ -35,7 +25,14 @@ jobs:
       - name: Install dependencies
         run: make deps
       - name: Build book
-        run: CRYSTAL_VERSION=${{ steps.crystal.outputs.crystal }} LINT=true make build
+        run: LINT=true make build
+      - name: Extract branch name to deploy
+        id: branch
+        shell: bash -x {0}
+        run: |
+          if [[ $GITHUB_REF =~ ^refs/heads/(master|release/[0-9][0-9.]+)$ ]]; then
+            echo "::set-output name=branch::${BASH_REMATCH[1]#release/}"
+          fi
       - name: Build versions file
         if: github.event_name == 'push' && steps.branch.outputs.branch != null
         run: scripts/docs-versions.sh origin | tee /dev/stderr > versions.json

--- a/hooks.py
+++ b/hooks.py
@@ -1,10 +1,7 @@
 import logging
-import os
 import re
 
-
 log = logging.getLogger('mkdocs')
-version = os.getenv('CRYSTAL_VERSION', 'latest')
 
 
 def on_page_markdown(markdown, page, **kwargs):
@@ -22,9 +19,3 @@ def on_page_markdown(markdown, page, **kwargs):
             f"Documentation file '{path}' contains a version-pinned link to the API: '{bad}'\n"
             f"Suggested fix: '{good}'"
         )
-
-    return re.sub(
-        r'\bhttps?://(www\.)?crystal-lang\.org/api/(?!([0-9]+(\.[0-9]+)+|latest|master)/)',
-        f'https://crystal-lang.org/api/{version}/',
-        markdown
-    )


### PR DESCRIPTION
Reverts #562:
the replacement of API doc links works incorrectly for `master` (puts the commit hash), although it works for versioned releases
