### PR TITLE
Automatically populate crystal-version.txt

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -40,6 +40,8 @@ jobs:
           if [[ '${{ steps.branch.outputs.branch }}' =~ ^[0-9] ]]; then
             echo "CRYSTAL_VERSION=${{ steps.crystal.outputs.crystal }}" >> ${GITHUB_ENV}
           fi
+      - name: Populate sample version of Crystal
+        run: crystal --version | tee crystal-version.txt
       - name: Build book
         run: LINT=true make build
       - name: Build versions file


### PR DESCRIPTION
Note:
* The original file is kept even though it won't be manually updated anymore.
* The `crystal` invocation is kept separate from the build process.

This ensures that 'crystal-book' doesn't have 'crystal' as a hard build dependency.

---

Ref https://github.com/crystal-lang/crystal-book/pull/578#issuecomment-1007216153

Made possible by https://github.com/crystal-lang/crystal-book/pull/562 