### PR TITLE
fix bool error in spec example

### DIFF
--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -134,11 +134,11 @@ Tags can be used to group specs, allowing to only run a subset of specs when pro
 ```crystal
 it "is slow", tags: "slow" do
   sleep 60
-  true.should be(true)
+  true.should be_true
 end
 
 it "is fast", tags: "fast" do
-  true.should be(true)
+  true.should be_true
 end
 ```
 


### PR DESCRIPTION
this fixes the following error:
```
actual_value.same? @expected_value
                   ^----
Error: undefined method 'same?' for Bool
```