### PR TITLE
Rename homepage to *Welcome* and hide navigation bar

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 ---
 hide:
   - toc        # Hide table of contents
+  - navigation # Hide sidebar nabigation
 ---
 
 # Crystal Book

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,6 +1,6 @@
 # Summary
 
-* [Home](README.md)
+* [Welcome](README.md)
     * [Getting started](getting_started/README.md)
         * [An HTTP Server](getting_started/http_server.md)
         * [A Command Line Application](getting_started/cli.md)


### PR DESCRIPTION
The sidebar navigation seems out of place on the homepage because the site itself is already a big navigation hub with links to all pages in its section. Having those links duplicated in the sidebar nav is confusing. It looks like those links are more important in the context than the rest of the page, which is not the case. It's a landing page for all the content in the Crystal Book.

![Unbenannt](https://user-images.githubusercontent.com/466378/157862882-acba1e71-8f82-4f8a-b4f4-7a91c4ae6c91.jpg)

The sidebar navigation stays visible on pages in the section (see https://deploy-preview-592--crystal-book.netlify.app/platform_support.html for example).

The page title gets renamed from *Home* to *Welcome* in order to avoid confusion with the Crystal home page at https://crystal-lang.org/
Alternative names could be *Index*  or *Table of Contents* but they don't feel as welcoming... 😁 