### PR TITLE
Add links for *Install* and *Try Online* to home page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,9 @@ These instructions and courses help you get to know the language and how to use 
 ### [Getting started](getting_started/README.md)
 Install Crystal and get it running.
 
+* [Install](https://crystal-lang.org/install)
+* [Try Online](https://play.crystal-lang.org/#/cr)
+
   </div>
   <div class="card" markdown="1">
 


### PR DESCRIPTION
These are relevant resources for *Getting started* and there were no direct links so far.