### PR TITLE
Add Generics with variable number of arguments

### DIFF
--- a/docs/syntax_and_semantics/generics.md
+++ b/docs/syntax_and_semantics/generics.md
@@ -96,7 +96,7 @@ end
 
 We may define a Generic class with a variable number of arguments using the [splat operator](./operators.md#splats).
 
-Let's see an example where we define a Generic class called `Foo` and then we will use it with two type parameters `Int32` and `String`:
+Let's see an example where we define a Generic class called `Foo` and then we will use it with different number of type variables:
 
 ```crystal-play
 class Foo(*T)
@@ -106,10 +106,17 @@ class Foo(*T)
   end
 end
 
+# 2 type variables:
+# (explicitly specifying type variables)
 foo = Foo(Int32, String).new(42, "Life, the Universe, and Everything")
 
 puts typeof(foo) # => Foo(Int32, String)
 puts foo.content # => {42, "Life, the Universe, and Everything"}
+
+# 3 type variables:
+# (type variables inferred by the compiler)
+bar = Foo.new("Hello", ["Crystal", "!"], 140)
+puts typeof(bar) # => Foo(String, Array(String), Int32)
 ```
 
 In the following example we define classes by inheritance, specifying instances for the generic types:
@@ -146,14 +153,7 @@ class Parent(*T)
 end
 
 foo = Parent.new # => Error: can't infer the type parameter T for the generic class Parent(*T). Please provide it explicitly
-```
 
-```crystal
-class Parent(*T)
+class Foo < Parent # => Error: generic type arguments must be specified when inheriting Parent(*T)
 end
-
-class Foo < Parent
-end
-
-# => Error: generic type arguments must be specified when inheriting Parent(*T)
 ```

--- a/docs/syntax_and_semantics/generics.md
+++ b/docs/syntax_and_semantics/generics.md
@@ -101,6 +101,7 @@ When using Generics this is also possible, meaning a `class` can be defined with
 ```crystal
 class Foo(*T)
   getter content
+
   def initialize(*@content : *T)
   end
 end

--- a/docs/syntax_and_semantics/generics.md
+++ b/docs/syntax_and_semantics/generics.md
@@ -91,3 +91,43 @@ end
 class GenericChild(T) < Parent(T)
 end
 ```
+
+## Generics with variable number of arguments
+
+As we can read in [Splats and Tuples](./splats_and_tuples.md) a method _can receive a variable number of arguments_.
+
+When using Generics this is also possible, meaning a `class` can be defined with a variable number of arguments:
+
+```crystal
+class Foo(*T)
+  getter content
+  def initialize(*@content : *T)
+  end
+end
+
+foo = Foo.new(42, "Life, the Universe, and Everything")
+puts foo.content # => {42, "Life, the Universe, and Everything"}
+```
+
+We can also use it when defining a `class` by inheritance:
+
+```crystal
+class Parent(*T)
+end
+
+class StringChild < Parent(String)
+end
+
+class Int32StringChild < Parent(Int32, String)
+end
+```
+
+And if we need to instantiate a `class` with 0 arguments? In that case we may do:
+
+```crystal
+class Parent(*T)
+end
+
+class NoArgumentChild < Parent()
+end
+```

--- a/docs/syntax_and_semantics/generics.md
+++ b/docs/syntax_and_semantics/generics.md
@@ -94,11 +94,11 @@ end
 
 ## Generics with variable number of arguments
 
-As we can read in [Splats and Tuples](./splats_and_tuples.md) a method _can receive a variable number of arguments_.
+We may define a Generic class with a variable number of arguments using the [splat operator](./operators.md#splats).
 
-When using Generics this is also possible, meaning a `class` can be defined with a variable number of arguments:
+Let's see an example where we define a Generic class called `Foo` and then we will use it with two type parameters `Int32` and `String`:
 
-```crystal
+```crystal-play
 class Foo(*T)
   getter content
 
@@ -106,29 +106,54 @@ class Foo(*T)
   end
 end
 
-foo = Foo.new(42, "Life, the Universe, and Everything")
+foo = Foo(Int32, String).new(42, "Life, the Universe, and Everything")
+
+puts typeof(foo) # => Foo(Int32, String)
 puts foo.content # => {42, "Life, the Universe, and Everything"}
 ```
 
-We can also use it when defining a `class` by inheritance:
+In the following example we define classes by inheritance, specifying instances for the generic types:
 
 ```crystal
 class Parent(*T)
 end
 
+# We define `StringChild` inheriting from `Parent` class
+# using `String` for generic type argument:
 class StringChild < Parent(String)
 end
 
+# We define `Int32StringChild` inheriting from `Parent` class
+# using `Int32` and `String` for generic type arguments:
 class Int32StringChild < Parent(Int32, String)
 end
 ```
 
 And if we need to instantiate a `class` with 0 arguments? In that case we may do:
 
+```crystal-play
+class Parent(*T)
+end
+
+foo = Parent().new
+puts typeof(foo) # => Parent()
+```
+
+But we should not mistake 0 arguments with not specifying the generic type variables. The following examples will raise an error:
+
 ```crystal
 class Parent(*T)
 end
 
-class NoArgumentChild < Parent()
+foo = Parent.new # => Error: can't infer the type parameter T for the generic class Parent(*T). Please provide it explicitly
+```
+
+```crystal
+class Parent(*T)
 end
+
+class Foo < Parent
+end
+
+# => Error: generic type arguments must be specified when inheriting Parent(*T)
 ```

--- a/docs/syntax_and_semantics/generics.md
+++ b/docs/syntax_and_semantics/generics.md
@@ -110,13 +110,13 @@ end
 # (explicitly specifying type variables)
 foo = Foo(Int32, String).new(42, "Life, the Universe, and Everything")
 
-puts typeof(foo) # => Foo(Int32, String)
-puts foo.content # => {42, "Life, the Universe, and Everything"}
+p typeof(foo) # => Foo(Int32, String)
+p foo.content # => {42, "Life, the Universe, and Everything"}
 
 # 3 type variables:
 # (type variables inferred by the compiler)
 bar = Foo.new("Hello", ["Crystal", "!"], 140)
-puts typeof(bar) # => Foo(String, Array(String), Int32)
+p typeof(bar) # => Foo(String, Array(String), Int32)
 ```
 
 In the following example we define classes by inheritance, specifying instances for the generic types:
@@ -143,7 +143,7 @@ class Parent(*T)
 end
 
 foo = Parent().new
-puts typeof(foo) # => Parent()
+p typeof(foo) # => Parent()
 ```
 
 But we should not mistake 0 arguments with not specifying the generic type variables. The following examples will raise an error:
@@ -152,8 +152,8 @@ But we should not mistake 0 arguments with not specifying the generic type varia
 class Parent(*T)
 end
 
-foo = Parent.new # => Error: can't infer the type parameter T for the generic class Parent(*T). Please provide it explicitly
+foo = Parent.new # Error: can't infer the type parameter T for the generic class Parent(*T). Please provide it explicitly
 
-class Foo < Parent # => Error: generic type arguments must be specified when inheriting Parent(*T)
+class Foo < Parent # Error: generic type arguments must be specified when inheriting Parent(*T)
 end
 ```


### PR DESCRIPTION
After adding https://github.com/crystal-lang/crystal/pull/11906 to Crystal 1.4, it's a good time to add definitions and examples for "using splats in generics" to the Generics section.
The last example shows the _Support Generic nodes with no type variables_