### PR TITLE
Fix removing clipboard button when creating crystal-play component

### DIFF
--- a/docs/assets/crystal-play.js
+++ b/docs/assets/crystal-play.js
@@ -6,8 +6,10 @@ document.addEventListener("DOMContentLoaded", function() {
     var play = new CarcinPlay(code.innerText, wrapper, {language: "crystal"});
 
     // TODO: Enable clipboard from codemirror
-    var clipboardButton = parent.querySelector("button[data-clipboard-target");
-    parent.removeChild(clipboardButton);
+    var clipboardButton = parent.querySelector("button[data-clipboard-target]");
+    if (clipboardButton) {
+      parent.removeChild(clipboardButton);
+    }
 
     /*
     if(ClipboardJS.isSupported()){


### PR DESCRIPTION
When replacing a code component with the `crystal-play` component, the following error was thrown:
```
crystal-play.js:11 Uncaught TypeError: Failed to execute 'removeChild' on 'Node'
```
This error was stopping the execution making the others (if any) code snippets to not be replaced with the `crystal-play` component.

In this PR a typo in the query selector was fixed and we check if the clipboard button exists before removing it.
