### PR TITLE
Fix: increase specificity of .card CSS

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -26,28 +26,28 @@
     grid-gap: 1.5em;
     margin: 2em 0;
 }
-.card {
+.cards .card {
     display: block;
 }
-.card > h3 {
+.cards .card > h3 {
     margin: 0;
 }
-.card > p {
+.cards .card > p {
     color: var(--md-default-fg-color--light);
     margin: 0;
 }
-.card > ul {
-    display: flex !important;
+.cards .card > ul {
+    display: flex;
     flex-wrap: wrap;
     list-style: none;
     padding: 0;
     margin: 0;
 }
-.card > ul > li {
+.cards .card > ul > li {
     margin: 0;
 }
 
-.card > ul > li:not(:last-child)::after {
+.cards .card > ul > li:not(:last-child)::after {
     content: "·";
     margin: 0 0.3em;
 }


### PR DESCRIPTION
It seems otherwise we'd have to keep adding !important in more and more places as a game of whack-a-mole.
This time the override for margins of `li` and `ul` elements got disrupted.
This regressed in https://github.com/crystal-lang/crystal-book/pull/599

![Screenshot 2022-04-24 at 13-18-30 Welcome - Crystal](https://user-images.githubusercontent.com/371383/164974046-24be9edd-34d2-4343-8955-a5abb50c33c4.png)

Good: https://crystal-lang.org/reference/1.2/
Bad: https://crystal-lang.org/reference/1.4/

