### PR TITLE
Fix font size of crystal-play blocks

### DIFF
--- a/docs/assets/vendor/carcin-play/codemirror-theme.css
+++ b/docs/assets/vendor/carcin-play/codemirror-theme.css
@@ -6,6 +6,7 @@
   background-color: var(--md-code-bg-color);
   color: var(--md-code-fg-color);
   font-family: "Roboto Mono",SFMono-Regular,Consolas,Menlo,monospace;
+  font-size: 0.85em; /* https: //github.com/squidfunk/mkdocs-material/blob/master/src/assets/stylesheets/main/_typeset.scss#L209 */
 }
 
 .cm-s-mkdocs-material .CodeMirror-scrollbar-filler, .cm-s-mkdocs-material .CodeMirror-gutter-filler {


### PR DESCRIPTION
In this PR we fix the font size when using crystal-play code-blocks.
The size is the same as other code-blocks (define with ```crystal) in the book. 
Also using a smaller font makes the code-block fit well with the text.

## Before:
<img width="709" alt="Screen Shot 2022-05-04 at 10 14 54" src="https://user-images.githubusercontent.com/1175827/166689085-7a0a2867-728e-45bd-a585-c8d19f68539c.png">

## After:
<img width="703" alt="Screen Shot 2022-05-04 at 10 15 33" src="https://user-images.githubusercontent.com/1175827/166689132-275ff729-9593-4e5d-91ab-0795b3c821f3.png">

