### PR TITLE
Add note about type coercion of instance variables

### DIFF
--- a/docs/syntax_and_semantics/if_var_nil.md
+++ b/docs/syntax_and_semantics/if_var_nil.md
@@ -44,4 +44,4 @@ def greet
 end
 ```
 
-This is a byproduct of multi-threading in Crystal. Due to the existince of Fibers, Crystal does not know at compile-time whether the instance variable will still be non-`Nil` when the usage in the `if` branch is reached.
+This is a byproduct of multi-threading in Crystal. Due to the existence of Fibers, Crystal does not know at compile-time whether the instance variable will still be non-`Nil` when the usage in the `if` branch is reached.

--- a/docs/syntax_and_semantics/if_var_nil.md
+++ b/docs/syntax_and_semantics/if_var_nil.md
@@ -11,9 +11,9 @@ else
 end
 ```
 
-## Instsance Variables
+## Instance Variables
 
-Type restriction through `if var.nil?` only occurs with local variables. The type of an instance variable in a similar code example to the one above will still be nilable, and will throw a compile error since `greet` expects a `String` in the `unless` branch.
+Type restriction through `if var.nil?` only occurs with local variables. The type of an instance variable in a similar code example to the one above will still be nilable and will throw a compile error since `greet` expects a `String` in the `unless` branch.
 
 ```crystal
 class Person

--- a/docs/syntax_and_semantics/if_var_nil.md
+++ b/docs/syntax_and_semantics/if_var_nil.md
@@ -37,7 +37,7 @@ You can solve this by storing the value in a local variable first:
 def greet
   name = @name
   unless name.nil?
-    puts "Hello, #{name.upcase}" # Error: undefined method 'upcase' for Nil (compile-time type is (String | Nil))
+    puts "Hello, #{name.upcase}" # name will be String - no compile error
   else
     puts "Hello"
   end

--- a/docs/syntax_and_semantics/if_var_nil.md
+++ b/docs/syntax_and_semantics/if_var_nil.md
@@ -10,3 +10,38 @@ else
   # here a is Int32
 end
 ```
+
+## Instsance Variables
+
+Type restriction through `if var.nil?` only occurs with local variables. The type of an instance variable in a similar code example to the one above will still be nilable, and will throw a compile error since `greet` expects a `String` in the `unless` branch.
+
+```crystal
+class Person
+  property name : String?
+  
+  def greet
+    unless @name.nil?
+      puts "Hello, #{@name.upcase}" # Error: undefined method 'upcase' for Nil (compile-time type is (String | Nil))
+    else
+      puts "Hello"
+    end
+  end
+end
+
+Person.new.greet
+```
+
+You can solve this by storing the value in a local variable first:
+
+```crystal
+def greet
+  name = @name
+  unless name.nil?
+    puts "Hello, #{name.upcase}" # Error: undefined method 'upcase' for Nil (compile-time type is (String | Nil))
+  else
+    puts "Hello"
+  end
+end
+```
+
+This is a byproduct of multi-threading in Crystal. Due to the existince of Fibers, Crystal does not know at compile-time whether the instance variable will still be non-`Nil` when the usage in the `if` branch is reached.


### PR DESCRIPTION
This has tripped me up enough times that I assume others are experiencing the same issue, so I wanted to add more information to the page on type restriction through `if var.nil?`.