### PR TITLE
Fix display of `title=` at the top of code blocks

### DIFF
--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -195,26 +195,24 @@ Many projects use a custom spec helper file, usually named `spec/spec_helper.cr`
 
 This file is used to require `spec` and other includes like code from the project needed for every spec file. This is also a good place to define global helper methods that make writing specs easier and avoid code duplication.
 
-!!! example "spec/spec_helper.cr"
-    ```crystal
-    require "spec"
-    require "../src/my_project.cr"
+```crystal title="spec/spec_helper.cr"
+require "spec"
+require "../src/my_project.cr"
 
-    def create_test_object(name)
-      project = MyProject.new(option: false)
-      object = project.create_object(name)
-      object
-    end
-    ```
+def create_test_object(name)
+  project = MyProject.new(option: false)
+  object = project.create_object(name)
+  object
+end
+```
 
-!!! example "spec/my_project_spec.cr"
-    ```crystal
-    require "./spec_helper"
+```crystal title="spec/my_project_spec.cr"
+require "./spec_helper"
 
-    describe "MyProject::Object" do
-      it "is created" do
-        object = create_test_object(name)
-        object.should_not be_nil
-      end
-    end
-    ```
+describe "MyProject::Object" do
+  it "is created" do
+    object = create_test_object(name)
+    object.should_not be_nil
+  end
+end
+```

--- a/requirements.in
+++ b/requirements.in
@@ -3,5 +3,5 @@ mkdocs-material>=8.0.5
 mkdocs-literate-nav>=0.2
 mkdocs-section-index>=0.2.3
 mkdocs-redirects>=1.0.4
-mkdocs-code-validator>=0.1.2
+mkdocs-code-validator>=0.1.3
 mkdocs-simple-hooks>=0.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ mkdocs==1.3.0
     #   mkdocs-redirects
     #   mkdocs-section-index
     #   mkdocs-simple-hooks
-mkdocs-code-validator==0.1.2
+mkdocs-code-validator==0.1.3
     # via -r requirements.in
 mkdocs-literate-nav==0.4.1
     # via -r requirements.in


### PR DESCRIPTION
by bumping mkdocs-code-validator which was preventing titles from being recognized at all.
https://github.com/oprypin/mkdocs-code-validator/commit/2e37afbb44cbcf39f242ae98ee68650a82342f76

Also replace remaining old usages of titles.
