### PR TITLE
Switch syntax of admonitions to "markdown-callouts" extension

### DIFF
--- a/docs/database/transactions.md
+++ b/docs/database/transactions.md
@@ -159,8 +159,7 @@ db.transaction do |tx|
 end
 ```
 
-!!! note
-    After `commit` or `rollback` are used, the transaction is no longer usable. The connection is still open but any statement will be performed outside the context of the terminated transaction.
+NOTE: After `commit` or `rollback` are used, the transaction is no longer usable. The connection is still open but any statement will be performed outside the context of the terminated transaction.
 
 ## Nested transactions
 

--- a/docs/getting_started/README.md
+++ b/docs/getting_started/README.md
@@ -61,8 +61,7 @@ $ crystal hello_world.cr
 Hello World!
 ```
 
-!!! note
-    The main routine is simply the program itself. There's no need to define a "main" function or something similar.
+NOTE: The main routine is simply the program itself. There's no need to define a "main" function or something similar.
 
 Next you might want to start with the [Introduction Tour](../tutorials/basics/README.md) to get acquainted with the language.
 

--- a/docs/guides/ci/circleci.md
+++ b/docs/guides/ci/circleci.md
@@ -133,8 +133,7 @@ orbs:
 version: 2.1
 ```
 
-!!! note
-    The explicit `checkout` in the `pre-steps` is to have the `test-data/setup.sql` file available.
+NOTE: The explicit `checkout` in the `pre-steps` is to have the `test-data/setup.sql` file available.
 
 ## Caching
 

--- a/docs/guides/ci/gh-actions.md
+++ b/docs/guides/ci/gh-actions.md
@@ -23,16 +23,16 @@ jobs:
 
 To get started with [GitHub Actions](https://docs.github.com/en/actions/guides/about-continuous-integration#about-continuous-integration-using-github-actions), commit this YAML file into your Git repository under the directory `.github/workflows/`, push it to GitHub, and observe the Actions tab.
 
-!!! tip "Quickstart"
-    Check out [**Configurator for *install-crystal* action**](https://crystal-lang.github.io/install-crystal/configurator.html) to quickly get a config with the CI features you need. Or continue reading for more details.
+TIP: **Quickstart.**
+Check out [**Configurator for *install-crystal* action**](https://crystal-lang.github.io/install-crystal/configurator.html) to quickly get a config with the CI features you need. Or continue reading for more details.
 
 This runs on GitHub's [default](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) "latest Ubuntu" container. It downloads the source code from the repository itself (directly into the current directory), installs Crystal via [Crystal's official GitHub Action](https://github.com/crystal-lang/install-crystal), then runs the specs, assuming they are there in the `spec/` directory.
 
 If any step fails, the build will show up as failed, notify the author and, if it's a push, set the overall build status of the project to failing.
 
-!!! tip
-    For a healthier codebase, consider these flags for `crystal spec`:  
-    `--order=random` `--error-on-warnings`
+TIP:
+For a healthier codebase, consider these flags for `crystal spec`:  
+`--order=random` `--error-on-warnings`
 
 ### No specs?
 
@@ -168,8 +168,8 @@ The safe approach is to add the [actions/cache](https://github.com/actions/cache
         run: shards update
 ```
 
-!!! danger "Important"
-    You **must** use the separate [`key` and `restore-keys`](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key). With just a static key, the cache would save only the state after the very first run and then keep reusing it forever, regardless of any changes.
+DANGER: **Important.**
+You **must** use the separate [`key` and `restore-keys`](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key). With just a static key, the cache would save only the state after the very first run and then keep reusing it forever, regardless of any changes.
 
 But this saves us only the time spent *downloading* the repositories initially.
 

--- a/docs/guides/hosting/github.md
+++ b/docs/guides/hosting/github.md
@@ -10,8 +10,7 @@
 
 - Add the remote: (Be sure to replace `<YOUR-GITHUB-USERNAME>` and `<YOUR-REPOSITORY-NAME>` accordingly)
 
-    !!! note
-        If you like, feel free to replace `public` with `origin`, or a remote name of your choosing.
+    NOTE: If you like, feel free to replace `public` with `origin`, or a remote name of your choosing.
 
     ```console
     $ git remote add public https://github.com/<YOUR-GITHUB-NAME>/<YOUR-REPOSITORY-NAME>.git

--- a/docs/guides/static_linking.md
+++ b/docs/guides/static_linking.md
@@ -62,9 +62,9 @@ If you want to statically link dependencies, you need to have their static libra
 Most systems don't install static libraries by default, so you need to install them explicitly.
 First you have to know which libraries your program links against.
 
-!!! note
-    Static libraries have the file extension `.a` on POSIX and `.lib` on Windows.
-    Dynamic libraries have `.so` on Linux and most other POSIX platforms, `.dylib` on macOS and `.dll` on Windows.
+NOTE:
+Static libraries have the file extension `.a` on POSIX and `.lib` on Windows.
+Dynamic libraries have `.so` on Linux and most other POSIX platforms, `.dylib` on macOS and `.dll` on Windows.
 
 On most POSIX systems the tool `ldd` shows which dynamic libraries an executable links to. The equivalent
 on macOS is `otool -L`.
@@ -105,6 +105,6 @@ The individual libraries are `libpcre`, `libgc` and the rest is `musl` (`libc`).
 
 In order to link this program statically, we need static versions of these three libraries.
 
-!!! note
-    The `*-alpine` docker images ship with static versions of all libraries used by the standard library.
-    If your program links no other libraries then adding the `--static` flag to the build command is all you need to link fully statically.
+NOTE:
+The `*-alpine` docker images ship with static versions of all libraries used by the standard library.
+If your program links no other libraries then adding the `--static` flag to the build command is all you need to link fully statically.

--- a/docs/guides/writing_shards.md
+++ b/docs/guides/writing_shards.md
@@ -106,8 +106,7 @@ Most importantly, your README should explain:
 
 This explanation should include a few examples along with subheadings.
 
-!!! note
-    Be sure to replace all instances of `[your-github-name]` in the Crystal-generated README template with your GitHub/GitLab username. If you're using GitLab, you'll also want to change all instances of `github` with `gitlab`.
+NOTE: Be sure to replace all instances of `[your-github-name]` in the Crystal-generated README template with your GitHub/GitLab username. If you're using GitLab, you'll also want to change all instances of `github` with `gitlab`.
 
 #### Coding Style
 

--- a/docs/syntax_and_semantics/annotations/README.md
+++ b/docs/syntax_and_semantics/annotations/README.md
@@ -179,15 +179,13 @@ annotation_read
 
 Annotations can be read off of a [`TypeNode`](https://crystal-lang.org/api/Crystal/Macros/TypeNode.html), [`Def`](https://crystal-lang.org/api/Crystal/Macros/Def.html), or [`MetaVar`](https://crystal-lang.org/api/Crystal/Macros/MetaVar.html) using the `.annotation(type : TypeNode)` method.  This method return an [`Annotation`](https://crystal-lang.org/api/Crystal/Macros/Annotation.html) object representing the applied annotation of the supplied type.
 
-!!! note
-    If multiple annotations of the same type are applied, the `.annotation` method will return the _last_ one.
+NOTE: If multiple annotations of the same type are applied, the `.annotation` method will return the _last_ one.
 
 The [`@type`](../macros/#type-information) and [`@def`](../macros/#method-information) variables can be used to get a `TypeNode` or `Def` object to use the `.annotation` method on.  However, it is also possible to get `TypeNode`/`Def` types using other methods on `TypeNode`.  For example `TypeNode.all_subclasses` or `TypeNode.methods`, respectively.
 
 The `TypeNode.instance_vars` can be used to get an array of instance variable `MetaVar` objects that would allow reading annotations defined on those instance variables.
 
-!!! note
-    `TypeNode.instance_vars` currently only works in the context of an instance/class method.
+NOTE: `TypeNode.instance_vars` currently only works in the context of an instance/class method.
 
 ```crystal
 annotation MyClass

--- a/docs/syntax_and_semantics/as.md
+++ b/docs/syntax_and_semantics/as.md
@@ -29,8 +29,8 @@ If it is impossible for a type to be restricted by another type, a compile-time 
 1.as(String) # Compile-time error
 ```
 
-!!! note
-    You can't use `as` to convert a type to an unrelated type: `as` is not like a `cast` in other languages. Methods on integers, floats and chars are provided for these conversions. Alternatively, use pointer casts as explained below.
+NOTE:
+You can't use `as` to convert a type to an unrelated type: `as` is not like a `cast` in other languages. Methods on integers, floats and chars are provided for these conversions. Alternatively, use pointer casts as explained below.
 
 ## Converting between pointer types
 

--- a/docs/syntax_and_semantics/c_bindings/fun.md
+++ b/docs/syntax_and_semantics/c_bindings/fun.md
@@ -92,5 +92,4 @@ lib MyLib
 end
 ```
 
-!!! note
-    The C `char` type is `UInt8` in Crystal, so a `char*` or a `const char*` is `UInt8*`. The `Char` type in Crystal is a unicode codepoint so it is represented by four bytes, making it similar to an `Int32`, not to an `UInt8`. There's also the alias `LibC::Char` if in doubt.
+NOTE: The C `char` type is `UInt8` in Crystal, so a `char*` or a `const char*` is `UInt8*`. The `Char` type in Crystal is a unicode codepoint so it is represented by four bytes, making it similar to an `Int32`, not to an `UInt8`. There's also the alias `LibC::Char` if in doubt.

--- a/docs/syntax_and_semantics/documenting_code.md
+++ b/docs/syntax_and_semantics/documenting_code.md
@@ -6,10 +6,10 @@ preceding the definition of the respective feature.
 By default, all public methods, macros, types and constants are
 considered part of the API documentation.
 
-!!! tip
-    The compiler command [`crystal docs`](../using_the_compiler/#crystal-docs)
-    automatically extracts the API documentation and generates a website to
-    present it.
+TIP:
+The compiler command [`crystal docs`](../using_the_compiler/#crystal-docs)
+automatically extracts the API documentation and generates a website to
+present it.
 
 ## Association
 
@@ -46,9 +46,9 @@ def horns
 end
 ```
 
-!!! tip
-    It is generally advised to use descriptive, third person present tense:
-    `Returns the number of horns this unicorn has` (instead of an imperative `Return the number of horns this unicorn has`).
+TIP:
+It is generally advised to use descriptive, third person present tense:
+`Returns the number of horns this unicorn has` (instead of an imperative `Return the number of horns this unicorn has`).
 
 ## Markup
 
@@ -263,8 +263,7 @@ Some documentation specific to *id*'s usage within `Child`.
 Some documentation common to every *id*.
 ```
 
-!!! note
-    Inheriting documentation only works on _instance_, non-constructor methods.
+NOTE: Inheriting documentation only works on _instance_, non-constructor methods.
 
 ## A Complete Example
 

--- a/docs/syntax_and_semantics/literals/range.md
+++ b/docs/syntax_and_semantics/literals/range.md
@@ -10,8 +10,8 @@ A [Range](https://crystal-lang.org/api/Range.html) represents an interval betwee
 (0...5).to_a # => [0, 1, 2, 3, 4]
 ```
 
-!!! note
-    Range literals are often wrapped in parentheses, for example if it is meant to be used as the receiver of a call. `0..5.to_a` without parentheses would be semantically equivalent to `0..(5.to_a)` because method calls and other operators have higher precedence than the range literal.
+NOTE:
+Range literals are often wrapped in parentheses, for example if it is meant to be used as the receiver of a call. `0..5.to_a` without parentheses would be semantically equivalent to `0..(5.to_a)` because method calls and other operators have higher precedence than the range literal.
 
 An easy way to remember which one is inclusive and which one is exclusive it to think of the extra dot as if it pushes *y* further away, thus leaving it outside of the range.
 

--- a/docs/tutorials/basics/10_hello_world.md
+++ b/docs/tutorials/basics/10_hello_world.md
@@ -8,11 +8,11 @@ In Crystal this is pretty simple, maybe a little bit boring:
 puts "Hello World!"
 ```
 
-!!! tip
-    You can build and run code examples interactively in this tutorial by clicking the `Run` button (thanks to [carc.in](https://carc.in)).
-    The output is shown directly inline.
-
-    If you want to follow along locally, follow the [installation](https://crystal-lang.org/install/) and [getting started](../../getting_started/README.md) instructions.
+> TIP:
+> You can build and run code examples interactively in this tutorial by clicking the `Run` button (thanks to [carc.in](https://carc.in)).
+> The output is shown directly inline.
+>
+> If you want to follow along locally, follow the [installation](https://crystal-lang.org/install/) and [getting started](../../getting_started/README.md) instructions.
 
 !!! info inline end
     The name `puts` is short for “put string”.

--- a/docs/tutorials/basics/20_variables.md
+++ b/docs/tutorials/basics/20_variables.md
@@ -17,9 +17,9 @@ This program prints the string `Hello Penny!` three times to the standard output
 
 The name of a variable always starts with a lowercase [Unicode](https://en.wikipedia.org/wiki/Unicode) letter (or an underscore, but that's reserved for special use cases) and can otherwise consist of alphanumeric characters or underscores. As a typical convention, upper-case letters are avoided and names are written in [`snake_case`](https://en.wikipedia.org/wiki/Snake_case).
 
-!!! note
-    The kind of variables this lesson discusses is called *local variables*.
-    Other kinds will be introduced later. For now, we focus on local variables only.
+NOTE:
+The kind of variables this lesson discusses is called *local variables*.
+Other kinds will be introduced later. For now, we focus on local variables only.
 
 ## Type
 
@@ -33,8 +33,7 @@ message = "Hello Penny!"
 p! typeof(message)
 ```
 
-!!! note
-    [`p!`](https://crystal-lang.org/api/toplevel.html#p!(*exps)-macro) is similar to `puts` as it prints the value to the standard output, but it also prints the expression in code. This makes it a useful tool for inspecting the state of a Crystal program and debugging.
+NOTE: [`p!`](https://crystal-lang.org/api/toplevel.html#p!(*exps)-macro) is similar to `puts` as it prints the value to the standard output, but it also prints the expression in code. This makes it a useful tool for inspecting the state of a Crystal program and debugging.
 
 ## Reassigning a Value
 

--- a/docs/tutorials/basics/30_math.md
+++ b/docs/tutorials/basics/30_math.md
@@ -19,12 +19,12 @@ p! 100_000.0, typeof(100_000.0)
 
 Float values print with a decimal point. Integer values don't.
 
-!!! info
-    There are quite a few more numeric types, but most of them are intended only for special use cases such as binary protocols,
-    specific numeric algorithms, and performance optimization. You probably don't need them for everyday programs.
-
-    See [Integer literal reference](../../syntax_and_semantics/literals/integers.md) and [Float literal reference](../../syntax_and_semantics/literals/floats.md)
-    for a full reference on all primitive number types and alternative representations.
+> INFO:
+> There are quite a few more numeric types, but most of them are intended only for special use cases such as binary protocols,
+> specific numeric algorithms, and performance optimization. You probably don't need them for everyday programs.
+>
+> See [Integer literal reference](../../syntax_and_semantics/literals/integers.md) and [Float literal reference](../../syntax_and_semantics/literals/floats.md)
+> for a full reference on all primitive number types and alternative representations.
 
 ## Arithmetic
 
@@ -80,8 +80,7 @@ As you can see, the result of most of these operations between integer operands 
 The division operator (`/`) is an exception. It always returns a float value. The floor division operator (`//`) however returns an integer value, but it's obviously reduced to integer precision.
 An operation between integer and float operands always returns a float value. Otherwise, the return type is usually the type of the first operand.
 
-!!! info
-    A full list of operators is available in [the Operator reference](../../syntax_and_semantics/operators.md#arithmetic-operators).
+INFO: A full list of operators is available in [the Operator reference](../../syntax_and_semantics/operators.md#arithmetic-operators).
 
 #### Precedence
 
@@ -96,8 +95,7 @@ p! 4 + 5 * 2,
   (4 + 5) * 2
 ```
 
-!!! info
-    All the precedence rules are detailed in the [the Operator reference](../../syntax_and_semantics/operators.md#operator-precedence).
+INFO: All the precedence rules are detailed in the [the Operator reference](../../syntax_and_semantics/operators.md#operator-precedence).
 
 ### Number Methods
 
@@ -110,8 +108,7 @@ p! -5.abs,   # absolute value
   10.gcd(16) # greatest common divisor
 ```
 
-!!! info
-    A full list of numerical methods is available in [the Number API docs](https://crystal-lang.org/api/Number.html) (also check subtypes).
+INFO: A full list of numerical methods is available in [the Number API docs](https://crystal-lang.org/api/Number.html) (also check subtypes).
 
 ### Math Methods
 
@@ -127,8 +124,7 @@ p! Math.cos(1),     # cosine
   Math.sqrt(9)      # square root
 ```
 
-!!! info
-    A full list of math methods is available in [the Math API docs](https://crystal-lang.org/api/Math.html).
+INFO: A full list of math methods is available in [the Math API docs](https://crystal-lang.org/api/Math.html).
 
 ## Constants
 

--- a/docs/tutorials/basics/40_strings.md
+++ b/docs/tutorials/basics/40_strings.md
@@ -28,8 +28,8 @@ name = 6
 puts "Hello #{name}!"
 ```
 
-!!! note
-    An alternative to interpolation is concatenation. Instead of `"Hello #{name}!"` you could write `"Hello " + name + "!"`. But that's bulkier and has some gotchas with non-string types. Interpolation is generally preferred over concatenation.
+NOTE:
+An alternative to interpolation is concatenation. Instead of `"Hello #{name}!"` you could write `"Hello " + name + "!"`. But that's bulkier and has some gotchas with non-string types. Interpolation is generally preferred over concatenation.
 
 ## Escaping
 
@@ -47,8 +47,7 @@ There are other escape sequences: For example non-printable characters such as a
 puts "I say: \"Hello \\\n\tWorld!\""
 ```
 
-!!! tip
-    You can find more info on available escape sequences in the [string literal reference](../../syntax_and_semantics/literals/string.md#escaping).
+TIP: You can find more info on available escape sequences in the [string literal reference](../../syntax_and_semantics/literals/string.md#escaping).
 
 ### Alternative Delimiters
 
@@ -60,8 +59,7 @@ puts %(I say: "Hello World!")
 
 Escape sequences and interpolation still work the same way.
 
-!!! tip
-    You can find more info on alternative delimiters in the [string literal reference](../../syntax_and_semantics/literals/string.md#percent-string-literals).
+TIP: You can find more info on alternative delimiters in the [string literal reference](../../syntax_and_semantics/literals/string.md#percent-string-literals).
 
 ## Unicode
 
@@ -220,8 +218,7 @@ b = "Crystal is awesome".index("meh")
 p! b, typeof(b)
 ```
 
-!!! tip
-    We'll cover `nil` more deeply in the next lesson.
+TIP: We'll cover `nil` more deeply in the next lesson.
 
 ## Extracting Substrings
 
@@ -298,5 +295,4 @@ p! message.sub("World", "Crystal"),
   message.gsub("World", "Crystal")
 ```
 
-!!! tip
-    You can find more detailed info in the [string literal reference](../../syntax_and_semantics/literals/string.md) and [String API docs](https://crystal-lang.org/api/String.html).
+TIP: You can find more detailed info in the [string literal reference](../../syntax_and_semantics/literals/string.md) and [String API docs](https://crystal-lang.org/api/String.html).

--- a/docs/tutorials/basics/50_control_flow.md
+++ b/docs/tutorials/basics/50_control_flow.md
@@ -101,10 +101,10 @@ if message.starts_with?("Hello")
 end
 ```
 
-!!! note
-    Technically, this program still runs in a predefined order. The fixed message always matches and makes the condition truthy.
-    But let's assume we don't define the value of the message in the source code. It could just as well come from user input,
-    for example a chat client.
+NOTE:
+Technically, this program still runs in a predefined order. The fixed message always matches and makes the condition truthy.
+But let's assume we don't define the value of the message in the source code. It could just as well come from user input,
+for example a chat client.
 
 If the message has a value that does not start with `Hello`, the conditional branch skips, and the program prints nothing.
 
@@ -160,10 +160,10 @@ Try to remove the conditional or change the condition to `true`: a type error sh
 use a `Nil` value in that expression.
 With the proper condition, the compiler knows that `index` can't be `nil` inside the branch and it can be used as a numeric input.
 
-!!! tip
-    A shorter form for `if !index.nil?` is `if index`, which is mostly equivalent.
-    It only makes a difference if you wanted to tell apart whether a falsey value is `nil` or `false`
-    because the former condition matches for `false`, while the latter does not.
+TIP:
+A shorter form for `if !index.nil?` is `if index`, which is mostly equivalent.
+It only makes a difference if you wanted to tell apart whether a falsey value is `nil` or `false`
+because the former condition matches for `false`, while the latter does not.
 
 ### Else
 
@@ -277,8 +277,7 @@ until counter >= 10
 end
 ```
 
-!!! tip
-    You can find more details on these expressions in the language specification: [`while`](../../syntax_and_semantics/while.md) and [`until`](../../syntax_and_semantics/until.md).
+TIP: You can find more details on these expressions in the language specification: [`while`](../../syntax_and_semantics/while.md) and [`until`](../../syntax_and_semantics/until.md).
 
 ### Infinite loops
 
@@ -298,9 +297,9 @@ Such logic errors can be easy to miss and so it's very important to pay attentio
 A good practice for index variables (such as `counter` in our example) is to increment them at the beginning of the loop.
 That makes it harder to forget to update them.
 
-!!! tip
-    Fortunately, there are many features in the language that relieve the burden of writing loops manually
-    and also take care of ensuring valid breaking conditions. A few of them will be introduced in following lessons.
+TIP:
+Fortunately, there are many features in the language that relieve the burden of writing loops manually
+and also take care of ensuring valid breaking conditions. A few of them will be introduced in following lessons.
 
 In some cases, the intention is to really have an endless loop.
 An example would be a server that always repeats waiting for a connection, or
@@ -320,14 +319,14 @@ while true
 end
 ```
 
-!!! note
-    This example is not an interactive playground by choice because the playground can't
-    handle non self-terminating programs, and processing user input.
-    It would just time out and print an error.
-    You can compile and run this code with a local compiler, though.
-
-    To stop the program, hit <kbd>Ctrl+C</kbd>. This sends a signal to the process asking it
-    to exit.
+> NOTE:
+> This example is not an interactive playground by choice because the playground can't
+> handle non self-terminating programs, and processing user input.
+> It would just time out and print an error.
+> You can compile and run this code with a local compiler, though.
+>
+> To stop the program, hit <kbd>Ctrl+C</kbd>. This sends a signal to the process asking it
+> to exit.
 
 ### Skipping and Breaking
 

--- a/docs/tutorials/basics/60_methods.md
+++ b/docs/tutorials/basics/60_methods.md
@@ -16,9 +16,9 @@ say_hello
 say_hello() # syntactically equivalent method call with parentheses
 ```
 
-!!! tip
-    Method calls are unambiguously indicated by parentheses after the name, but they can be omitted. It would only be
-    necessary for disambiguation, for example, if `say_hello` was also a local variable.
+TIP:
+Method calls are unambiguously indicated by parentheses after the name, but they can be omitted. It would only be
+necessary for disambiguation, for example, if `say_hello` was also a local variable.
 
 ## Arguments
 
@@ -36,12 +36,12 @@ say_hello "World"
 say_hello "Crystal"
 ```
 
-!!! tip
-    Arguments at method calls are typically placed in parentheses, but it can often be omitted. `say_hello "World"`
-    and `say_hello("World")` are syntactically equivalent.
-
-    It's generally recommended to use parentheses because it avoids ambiguity. But they're often omitted if the
-    expression reads like natural language.
+> TIP:
+> Arguments at method calls are typically placed in parentheses, but it can often be omitted. `say_hello "World"`
+> and `say_hello("World")` are syntactically equivalent.
+>
+> It's generally recommended to use parentheses because it avoids ambiguity. But they're often omitted if the
+> expression reads like natural language.
 
 ### Default arguments
 

--- a/docs/using_the_compiler/README.md
+++ b/docs/using_the_compiler/README.md
@@ -47,8 +47,7 @@ The `--static` flag can be used to build a statically-linked executable:
 $ crystal build hello_world.cr --release --static
 ```
 
-!!! note
-    Building fully statical linked executables is currently only supported on Alpine Linux.
+NOTE: Building fully statical linked executables is currently only supported on Alpine Linux.
 
 More information about statically linking [can be found in the Static Linking guide](../guides/static_linking.md).
 
@@ -170,8 +169,7 @@ $ echo 'puts "Hello World"' | crystal eval
 Hello World!
 ```
 
-!!! note
-    When running interactively, stdin can usually be closed by typing the end of transmission character (`Ctrl+D`).
+NOTE: When running interactively, stdin can usually be closed by typing the end of transmission character (`Ctrl+D`).
 
 **Common options:**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,9 +74,10 @@ markdown_extensions:
   - pymdownx.highlight
   - pymdownx.magiclink
   - pymdownx.superfences
+  - pymdownx.snippets
+  - callouts
   - toc:
       permalink: true
-  - pymdownx.snippets
 
 extra_javascript:
   - assets/vendor/codemirror/codemirror.min.js

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 mkdocs>=1.2
+markdown-callouts>=0.2.0
 mkdocs-material>=8.0.5
 mkdocs-literate-nav>=0.2
 mkdocs-section-index>=0.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,10 +16,13 @@ jinja2==3.1.1
     #   mkdocs-material
 markdown==3.3.6
     # via
+    #   markdown-callouts
     #   mkdocs
     #   mkdocs-code-validator
     #   mkdocs-material
     #   pymdown-extensions
+markdown-callouts==0.2.0
+    # via -r requirements.in
 markupsafe==2.1.1
     # via jinja2
 mergedeep==1.3.4


### PR DESCRIPTION
The result is exactly equivalent, just different syntax -- one that doesn't look weird in vanilla Markdown parsers such as on GitHub.

https://github.com/oprypin/markdown-callouts