### PR TITLE
Document new annotation/macro features

### DIFF
--- a/docs/syntax_and_semantics/macros/README.md
+++ b/docs/syntax_and_semantics/macros/README.md
@@ -96,7 +96,7 @@ define_method :foo, 1
 
 ### parse_type
 
-While most AST nodes will be obtained via either manually passed arguments, hard coded values, or retrieved from either the [type](#type-information) or [method](#method-information) information helper variables. There may be some cases where the node you need is not directly accessible, such as if you use information from different contexts to construct the path to the desired type/constant.
+Most AST nodes are obtained via either manually passed arguments, hard coded values, or retrieved from either the [type](#type-information) or [method](#method-information) information helper variables. Yet there might be cases in which a node is not directly accessible, such as if you use information from different contexts to construct the path to the desired type/constant.
 
 In such cases the [`parse_type`](https://crystal-lang.org/api/Crystal/Macros.html#parse_type%28type_name%3AStringLiteral%29%3APath%7CGeneric%7CProcNotation%7CMetaclass-instance-method) macro method can help by parsing the provided [`StringLiteral`](https://crystal-lang.org/api/Crystal/Macros/StringLiteral.html) into something that can be resolved into the desired AST node.
 

--- a/docs/syntax_and_semantics/macros/README.md
+++ b/docs/syntax_and_semantics/macros/README.md
@@ -94,6 +94,25 @@ end
 define_method :foo, 1
 ```
 
+### parse_type
+
+While most AST nodes will be obtained via either manually passed arguments, hard coded values, or retrieved from either the [type](#type-information) or [method](#method-information) information helper variables. There may be some cases where the node you need is not directly accessible, such as if you use information from different contexts to construct the path to the desired type/constant.
+
+In such cases the [`parse_type`](https://crystal-lang.org/api/Crystal/Macros.html#parse_type%28type_name%3AStringLiteral%29%3APath%7CGeneric%7CProcNotation%7CMetaclass-instance-method) macro method can help by parsing the provided [`StringLiteral`](https://crystal-lang.org/api/Crystal/Macros/StringLiteral.html) into something that can be resolved into the desired AST node.
+
+```crystal
+MY_CONST = 1234
+
+struct Some::Namespace::Foo; end
+
+{{ parse_type("Some::Namespace::Foo").resolve.struct? }} # => true
+{{ parse_type("MY_CONST").resolve }}                     # => 1234
+
+{{ parse_type("MissingType").resolve }}   # Error: undefined constant MissingType
+```
+
+See the API docs for more examples.
+
 ## Modules and classes
 
 Modules, classes and structs can also be generated:

--- a/docs/syntax_and_semantics/macros/README.md
+++ b/docs/syntax_and_semantics/macros/README.md
@@ -108,7 +108,7 @@ struct Some::Namespace::Foo; end
 {{ parse_type("Some::Namespace::Foo").resolve.struct? }} # => true
 {{ parse_type("MY_CONST").resolve }}                     # => 1234
 
-{{ parse_type("MissingType").resolve }}   # Error: undefined constant MissingType
+{{ parse_type("MissingType").resolve }} # Error: undefined constant MissingType
 ```
 
 See the API docs for more examples.


### PR DESCRIPTION
* Document annotations on method parameters added in https://github.com/crystal-lang/crystal/pull/12044
* Document `parse_type` method added in https://github.com/crystal-lang/crystal/pull/11126

Depends on https://github.com/crystal-lang/crystal/pull/12446