### PR TITLE
Fix link to governance document

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -146,7 +146,7 @@ Our standards and expectations about working together as a community.
   </div>
   <div class="card" markdown="1">
 
-### [Governance document](https://crystal-lang.org/community/governance)
+### [Governance document](https://crystal-lang.org/community/governance.html)
 
 How we take the decisions that guide the language and its community.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,7 +55,7 @@ plugins:
         overview/hello_world.md: getting_started/README.md
         using_the_compiler/README.md: man/crystal/README.md
         the_shards_command/README.md: man/shards/README.md
-        governance.md: https://crystal-lang.org/community/governance
+        governance.md: https://crystal-lang.org/community/governance.html
         platform_support.md: syntax_and_semantics/platform_support.md
   - code-validator:
       enabled: !ENV [LINT, false]


### PR DESCRIPTION
The page URL for the website requires the `.html` suffix, it's not optional.
We should change that in the deployment, but for now this is the easiest fix to make the link work.