### PR TITLE
Clarify AND and OR semantics

### DIFF
--- a/docs/syntax_and_semantics/and.md
+++ b/docs/syntax_and_semantics/and.md
@@ -5,13 +5,12 @@ An `&&` (and) evaluates its left hand side. If it's *truthy*, it evaluates its r
 You can think an `&&` as syntax sugar of an `if`:
 
 ```crystal
-some_exp1 && some_exp2
+result = some_exp1 && some_exp2
 
 # The above is the same as:
-tmp = some_exp1
-if tmp
+result = if some_exp1
   some_exp2
 else
-  tmp
+  some_exp1
 end
 ```

--- a/docs/syntax_and_semantics/or.md
+++ b/docs/syntax_and_semantics/or.md
@@ -5,13 +5,12 @@ An `||` (or) evaluates its left hand side. If it's *falsey*, it evaluates its ri
 You can think an `||` as syntax sugar of an `if`:
 
 ```crystal
-some_exp1 || some_exp2
+result = some_exp1 || some_exp2
 
 # The above is the same as:
-tmp = some_exp1
-if tmp
-  tmp
-else
+result = if !some_exp1
   some_exp2
+else
+  some_exp1
 end
 ```


### PR DESCRIPTION
The description for AND was not correct if you expect "tmp" to have the same logical result as the former case. Update the documentation so that result variable contains the same result for all inputs and update the OR documentation so that, although the existing code worked, it now corresponds to that of the AND example and reads more clearly. The OR example would also have worked with the unless keyword, but since this section is not discussing unless, I chose to stick with "if !..."