### PR TITLE
Fix typo

### DIFF
--- a/docs/tutorials/basics/50_control_flow.md
+++ b/docs/tutorials/basics/50_control_flow.md
@@ -4,7 +4,7 @@
 
 ### Nil
 
-The most simplistic type is `Nil`. It has only a single value: `nil` and represents
+The simplest type is `Nil`. It has only a single value: `nil` and represents
 the absence of an actual value.
 
 Remember [`String#index` from last lesson](./40_strings.md#indexing-substrings)?


### PR DESCRIPTION
The word "simplistic" means treating a complex issue or problem as if it were much simpler than it really is. I think that what's called for here is just "simplest."