### PR TITLE
Add note about PCRE2 usage

### DIFF
--- a/docs/syntax_and_semantics/compile_time_flags.md
+++ b/docs/syntax_and_semantics/compile_time_flags.md
@@ -128,6 +128,7 @@ true
 | `preview_mt` | Enables multithreading preview. Introduced in 0.28.0 ([#7546](https://github.com/crystal-lang/crystal/pull/7546))
 | `strict_multi_assign` | Enable strict semantics for [one-to-many assignment](assignment.md#one-to-many-assignment). Introduced in 1.3.0 ([#11145](https://github.com/crystal-lang/crystal/pull/11145), [#11545](https://github.com/crystal-lang/crystal/pull/11545))
 | `skip_crystal_compiler_rt` | Exclude Crystal's native `compiler-rt` implementation.
+| `use_pcre2` | Use PCRE2 as regex engine (instead of legacy PCRE). Introduced in 1.7.0
 
 ### Compiler features
 

--- a/docs/syntax_and_semantics/literals/regex.md
+++ b/docs/syntax_and_semantics/literals/regex.md
@@ -11,6 +11,9 @@ A Regex is typically created with a regex literal using [PCRE](http://pcre.org/p
 /あ/
 ```
 
+> NOTE: The compiler expects the syntax of the original PCRE library. Support for the newer PCRE2 library at runtime was added in 1.7.0.
+> It can be opted-in with the compiler flag `-Duse_pcre2`.
+
 ## Escaping
 
 Regular expressions support the same [escape sequences as String literals](./string.md).


### PR DESCRIPTION
PCRE2 support was introduced in 1.7.0 as a opt-in preview feature.

cf. https://github.com/crystal-lang/crystal/issues/12790