### PR TITLE
Add section about `lib` function visibility in macro

### DIFF
--- a/docs/syntax_and_semantics/c_bindings/lib.md
+++ b/docs/syntax_and_semantics/c_bindings/lib.md
@@ -26,5 +26,5 @@ Lib functions are visible in the macro language anywhere in the program.
 lib LibFoo
   fun foo
 end
-{% if LibFoo.methods %} # => [fun foo]
+{{ LibFoo.methods }} # => [fun foo]
 ```

--- a/docs/syntax_and_semantics/c_bindings/lib.md
+++ b/docs/syntax_and_semantics/c_bindings/lib.md
@@ -26,5 +26,6 @@ Lib functions are visible in the macro language anywhere in the program.
 lib LibFoo
   fun foo
 end
+
 {{ LibFoo.methods }} # => [fun foo]
 ```

--- a/docs/syntax_and_semantics/c_bindings/lib.md
+++ b/docs/syntax_and_semantics/c_bindings/lib.md
@@ -17,3 +17,14 @@ Attributes are used to pass flags to the linker to find external libraries:
 * `@[Link(framework: "Cocoa")]` will pass `-framework Cocoa` to the linker (only useful in macOS).
 
 Attributes can be omitted if the library is implicitly linked, as in the case of libc.
+
+## Reflection
+
+Lib functions are visible in the macro language anywhere in the program.
+
+```crystal
+lib LibFoo
+  fun foo
+end
+{% if LibFoo.methods %} # => [fun foo]
+```

--- a/docs/syntax_and_semantics/c_bindings/lib.md
+++ b/docs/syntax_and_semantics/c_bindings/lib.md
@@ -20,7 +20,7 @@ Attributes can be omitted if the library is implicitly linked, as in the case of
 
 ## Reflection
 
-Lib functions are visible in the macro language anywhere in the program.
+Lib functions are visible in the macro language anywhere in the program using the method [`TypeNode#methods`](https://crystal-lang.org/api/Crystal/Macros/TypeNode.html#methods%3AArrayLiteral%28Def%29-instance-method):
 
 ```crystal
 lib LibFoo


### PR DESCRIPTION
cf. https://github.com/crystal-lang/crystal/pull/12848