### PR TITLE
Elaborate on type variable inference of generic class methods

### DIFF
--- a/docs/syntax_and_semantics/generics.md
+++ b/docs/syntax_and_semantics/generics.md
@@ -70,16 +70,18 @@ MyBox.nilable("foo") # : MyBox(String | Nil)
 In these examples, `T` is only inferred as a free variable, so the `T` of the receiver itself remains unbound. Thus it is an error to call other class methods where `T` cannot be inferred:
 
 ```crystal
-class Foo(T)
-  def initialize
+module Foo(T)
+  def self.foo
+    T
   end
 
-  def self.new(x : T)
-    new
+  def self.foo(x : T)
+    foo
   end
 end
 
-Foo.new(1) # Error: can't infer the type parameter T for the generic class Foo(T). Please provide it explicitly
+Foo.foo(1)        # Error: can't infer the type parameter T for the generic module Foo(T). Please provide it explicitly
+Foo(Int32).foo(1) # OK
 ```
 
 ## Generic structs and modules


### PR DESCRIPTION
Makes it clear that this feature is not exclusive to constructors (`.new`).

I believe that this is indeed intended behavior, as the standard library makes use of it for class methods other than `.new` already, even when the type variable is not part of a block parameter restriction (where type inference works slightly differently):

```crystal
struct Pointer(T)
  def self.malloc(size : Int, value : T)
    ptr = Pointer(T).malloc(size)
    size.times { |i| ptr[i] = value }
    ptr
  end
end

module Iterator(T)
  def self.of(element : T) 
    SingletonIterator(T).new(element) 
  end 
end
```