### PR TITLE
Clarfiy splats inside generic type restrictions

### DIFF
--- a/docs/syntax_and_semantics/type_restrictions.md
+++ b/docs/syntax_and_semantics/type_restrictions.md
@@ -315,7 +315,7 @@ foo(x: 1)        # => NamedTuple(x: Int32)
 foo()            # => NamedTuple()
 ```
 
-Additionally, splat restrictions may be used inside a generic type as well, to extract multiple type arguments at once:
+Additionally, single splat restrictions may be used inside a generic type as well, to extract multiple type arguments at once:
 
 ```crystal
 def foo(x : Proc(*T, Int32)) forall T


### PR DESCRIPTION
Unfortunately, `def foo(x : NamedTuple(**T)) forall T` is a syntax error at the moment.