### PR TITLE
Add `use_pcre` stdlib flag

### DIFF
--- a/docs/syntax_and_semantics/compile_time_flags.md
+++ b/docs/syntax_and_semantics/compile_time_flags.md
@@ -128,7 +128,8 @@ true
 | `preview_mt` | Enables multithreading preview. Introduced in 0.28.0 ([#7546](https://github.com/crystal-lang/crystal/pull/7546))
 | `strict_multi_assign` | Enable strict semantics for [one-to-many assignment](assignment.md#one-to-many-assignment). Introduced in 1.3.0 ([#11145](https://github.com/crystal-lang/crystal/pull/11145), [#11545](https://github.com/crystal-lang/crystal/pull/11545))
 | `skip_crystal_compiler_rt` | Exclude Crystal's native `compiler-rt` implementation.
-| `use_pcre2` | Use PCRE2 as regex engine (instead of legacy PCRE). Introduced in 1.7.0
+| `use_pcre2` | Use PCRE2 as regex engine (instead of legacy PCRE). Introduced in 1.7.0.
+| `use_pcre` | Use PCRE as regex engine (instead of PCRE2). Introduced in 1.8.0.
 
 ### Compiler features
 


### PR DESCRIPTION
PCRE is the default engine in 1.8.0 with fallback to PCRE if unavailable (https://github.com/crystal-lang/crystal/pull/12978).