### PR TITLE
Add section about Hash syntaxes in Crystal for Rubyists

### DIFF
--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -440,7 +440,7 @@ In Crystal, this is not the case. The hash rocket `=>` syntax is required to dec
 }
 ```
 
-However, the hash shorthand syntax in Ruby creates a [NamedTuple](https://crystal-lang.org/api/latest/NamedTuple.html) in Crystal.
+However, the hash shorthand syntax in Ruby creates a [`NamedTuple`](https://crystal-lang.org/api/NamedTuple.html) in Crystal.
 
 `NamedTuple`s and regular [`Tuple`s](https://crystal-lang.org/api/Tuple.html) have a fixed size, so these are best used for data structures that are known at compile time.
 

--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -431,7 +431,7 @@ However, the `Hash` shorthand syntax in Ruby creates a `NamedTuple` in Crystal.
 ```crystal
 # Creates a valid `Hash(Symbol, String)` in Crystal
 {
-  :key1 => "some value",
+  :key1      => "some value",
   :some_key2 => "second value",
 }
 

--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -406,7 +406,7 @@ end
 
 ### Hash syntax from Ruby to Crystal
 
-Crystal introduces a data type that is not available in Ruby, the NamedTuple.
+Crystal introduces a data type that is not available in Ruby, the [`NamedTuple`](https://crystal-lang.org/api/NamedTuple.html).
 
 Typically in Ruby you can define a hash with several syntaxes:
 
@@ -424,7 +424,9 @@ Typically in Ruby you can define a hash with several syntaxes:
 }
 ```
 
-In Crystal, this is not the case. The hash rocket `=>` syntax is required to declare a hash in Crystal.
+In Crystal, this is not the case. The `Hash` rocket `=>` syntax is required to declare a hash in Crystal.
+
+However, the `Hash` shorthand syntax in Ruby creates a `NamedTuple` in Crystal.
 
 ```crystal
 # Creates a valid `Hash(Symbol, String)` in Crystal
@@ -433,14 +435,12 @@ In Crystal, this is not the case. The hash rocket `=>` syntax is required to dec
   :some_key2 => "second value"
 }
 
-# Creates a NamedTuple in Crystal
+# Creates a `NamedTuple(Symbol, String)` in Crystal
 { 
   key1: "some value",
   some_key2: "second value"
 }
 ```
-
-However, the hash shorthand syntax in Ruby creates a [`NamedTuple`](https://crystal-lang.org/api/NamedTuple.html) in Crystal.
 
 `NamedTuple`s and regular [`Tuple`s](https://crystal-lang.org/api/Tuple.html) have a fixed size, so these are best used for data structures that are known at compile time.
 

--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -442,7 +442,7 @@ In Crystal, this is not the case. The hash rocket `=>` syntax is required to dec
 
 However, the hash shorthand syntax in Ruby creates a [NamedTuple](https://crystal-lang.org/api/latest/NamedTuple.html) in Crystal.
 
-Tuples are a fixed size, so these are best used for data structures that are known at compile time.
+NamedTuples and regular [Tuples](https://crystal-lang.org/api/latest/Tuple.html) are a fixed size, so these are best used for data structures that are known at compile time.
 
 ### Pseudo Constants
 

--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -439,7 +439,8 @@ In Crystal, this is not the case. The hash rocket `=>` syntax is required to dec
   some_key2: "second value"
 }
 ```
-However, the hash shorthand syntax in Ruby creates a Tuple in Crystal, specifically a [NamedTuple](https://crystal-lang.org/api/latest/NamedTuple.html).
+
+However, the hash shorthand syntax in Ruby creates a [NamedTuple](https://crystal-lang.org/api/latest/NamedTuple.html) in Crystal.
 
 Tuples are a fixed size, so these are best used for data structures that are known at compile time.
 

--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -427,7 +427,7 @@ Typically in Ruby you can define a hash with several syntaxes:
 In Crystal, this is not the case. The hash rocket `=>` syntax is required to declare a hash in Crystal.
 
 ```crystal
-# Creates a valid hash in Crystal
+# Creates a valid `Hash(Symbol, String)` in Crystal
 {
   :key1 => "some value",
   :some_key2 => "second value"

--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -436,7 +436,7 @@ However, the `Hash` shorthand syntax in Ruby creates a `NamedTuple` in Crystal.
 }
 
 # Creates a `NamedTuple(key1: String, some_key2: String)` in Crystal
-{ 
+{
   key1:      "some value",
   some_key2: "second value",
 }

--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -442,7 +442,7 @@ In Crystal, this is not the case. The hash rocket `=>` syntax is required to dec
 
 However, the hash shorthand syntax in Ruby creates a [NamedTuple](https://crystal-lang.org/api/latest/NamedTuple.html) in Crystal.
 
-NamedTuples and regular [Tuples](https://crystal-lang.org/api/latest/Tuple.html) are a fixed size, so these are best used for data structures that are known at compile time.
+`NamedTuple`s and regular [`Tuple`s](https://crystal-lang.org/api/Tuple.html) have a fixed size, so these are best used for data structures that are known at compile time.
 
 ### Pseudo Constants
 

--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -404,6 +404,46 @@ private def method
 end
 ```
 
+### Hash syntax from Ruby to Crystal
+
+Crystal introduces a data type that is not available in Ruby, the Tuple.
+
+Typically in Ruby you can define a hash with several syntaxes:
+
+```ruby
+# A valid ruby hash declaration
+{ 
+  key1: "some value",
+  some_key2: "second value"
+}
+
+# This syntax in ruby is shorthand for the hash rocket => syntax
+{
+  :key1 => "some value",
+  :some_key2 => "second value"
+}
+```
+
+In Crystal, this is not the case. The hash rocket `=>` syntax is required to declare a hash in Crystal.
+
+```crystal
+# Creates a valid hash in Crystal
+{
+  :key1 => "some value",
+  :some_key2 => "second value"
+}
+
+# Creates a NamedTuple in Crystal
+{ 
+  key1: "some value",
+  some_key2: "second value"
+}
+```
+However, the hash shorthand syntax in Ruby creates a Tuple in Crystal, specifically a [NamedTuple](https://crystal-lang.org/api/latest/NamedTuple.html).
+
+Tuples are a fixed size, so these are best used for data structures that are known at compile time.
+
+
 ### Pseudo Constants
 
 Crystal provides a few pseudo-constants which provide reflective data about the source code being executed.

--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -406,7 +406,7 @@ end
 
 ### Hash syntax from Ruby to Crystal
 
-Crystal introduces a data type that is not available in Ruby, the Tuple.
+Crystal introduces a data type that is not available in Ruby, the NamedTuple.
 
 Typically in Ruby you can define a hash with several syntaxes:
 

--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -437,7 +437,7 @@ However, the `Hash` shorthand syntax in Ruby creates a `NamedTuple` in Crystal.
 
 # Creates a `NamedTuple(key1: String, some_key2: String)` in Crystal
 { 
-  key1: "some value",
+  key1:      "some value",
   some_key2: "second value",
 }
 ```

--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -432,7 +432,7 @@ However, the `Hash` shorthand syntax in Ruby creates a `NamedTuple` in Crystal.
 # Creates a valid `Hash(Symbol, String)` in Crystal
 {
   :key1 => "some value",
-  :some_key2 => "second value"
+  :some_key2 => "second value",
 }
 
 # Creates a `NamedTuple(key1: String, some_key2: String)` in Crystal

--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -438,7 +438,7 @@ However, the `Hash` shorthand syntax in Ruby creates a `NamedTuple` in Crystal.
 # Creates a `NamedTuple(key1: String, some_key2: String)` in Crystal
 { 
   key1: "some value",
-  some_key2: "second value"
+  some_key2: "second value",
 }
 ```
 

--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -435,7 +435,7 @@ However, the `Hash` shorthand syntax in Ruby creates a `NamedTuple` in Crystal.
   :some_key2 => "second value"
 }
 
-# Creates a `NamedTuple(Symbol, String)` in Crystal
+# Creates a `NamedTuple(key1: String, some_key2: String)` in Crystal
 { 
   key1: "some value",
   some_key2: "second value"

--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -444,7 +444,6 @@ However, the hash shorthand syntax in Ruby creates a [NamedTuple](https://crysta
 
 Tuples are a fixed size, so these are best used for data structures that are known at compile time.
 
-
 ### Pseudo Constants
 
 Crystal provides a few pseudo-constants which provide reflective data about the source code being executed.


### PR DESCRIPTION
This adds an explicit section about the shorthand hash syntax from Ruby defining a NamedTuple in Crystal to help avoid some syntax confusion between the languages.