### PR TITLE
Adds basic info about shard.override.yml file to `shards` command page

### DIFF
--- a/docs/man/shards/README.md
+++ b/docs/man/shards/README.md
@@ -131,7 +131,7 @@ Prints the version of the shard.
 
 A `shard.override.yml` file allows overriding the source and restriction of dependencies. An alternative location can be configured with the env var `SHARDS_OVERRIDE`.
 
-The file contains a YAML document with a single dependencies key. It has the same semantics as in shard.yml. Dependency configuration takes precedence over the configuration in shard.yml or any dependency’s shard.yml.
+The file contains a YAML document with a single `dependencies` key. It has the same semantics as in `shard.yml`. Dependency configuration takes precedence over the configuration in `shard.yml` or any dependency’s `shard.yml`.
 
 Use cases are local working copies, forcing a specific dependency version despite mismatching constraints, fixing a dependency, checking compatibility with unreleased dependency versions.
 

--- a/docs/man/shards/README.md
+++ b/docs/man/shards/README.md
@@ -126,3 +126,22 @@ shards version [<path>]
 ```
 
 Prints the version of the shard.
+
+## Fixing Dependency Version Conflicts
+
+A `shard.override.yml` file allows overriding the source and restriction of dependencies. An alternative location can be configured with the env var SHARDS_OVERRIDE.
+
+The file contains a YAML document with a single dependencies key. It has the same semantics as in shard.yml. Dependency configuration takes precedence over the configuration in shard.yml or any dependency’s shard.yml.
+
+Use cases are local working copies, forcing a specific dependency version despite mismatching constraints, fixing a dependency, checking compatibility with unreleased dependency versions.
+
+Example file contents
+
+```yaml
+dependencies:
+  # Assuming we have a conflict with the version of the Redis shard
+  # This will override any specified version and use the `master` branch instead
+  redis:
+    github: jgaskins/redis
+    branch: master
+```

--- a/docs/man/shards/README.md
+++ b/docs/man/shards/README.md
@@ -129,7 +129,7 @@ Prints the version of the shard.
 
 ## Fixing Dependency Version Conflicts
 
-A `shard.override.yml` file allows overriding the source and restriction of dependencies. An alternative location can be configured with the env var SHARDS_OVERRIDE.
+A `shard.override.yml` file allows overriding the source and restriction of dependencies. An alternative location can be configured with the env var `SHARDS_OVERRIDE`.
 
 The file contains a YAML document with a single dependencies key. It has the same semantics as in shard.yml. Dependency configuration takes precedence over the configuration in shard.yml or any dependency’s shard.yml.
 


### PR DESCRIPTION
The title says it all, I basically took the man page info and just added an example. This should make it a lot easier for users to find.