### PR TITLE
Rework section about relational operators

### DIFF
--- a/docs/syntax_and_semantics/case.md
+++ b/docs/syntax_and_semantics/case.md
@@ -25,7 +25,7 @@ else
 end
 ```
 
-For comparing an expression against a `case`'s value the *case subsumption operator* `===` is used. It is defined as a method on [`Object`](https://crystal-lang.org/api/Object.html#%3D%3D%3D%28other%29-instance-method) and can be overridden by subclasses to provide meaningful semantics in case statements. For example, [`Class`](https://crystal-lang.org/api/Class.html#%3D%3D%3D%28other%29-instance-method) defines case subsumption as when an object is an instance of that class, [`Regex`](https://crystal-lang.org/api/Regex.html#%3D%3D%3D%28other%3AString%29-instance-method) as when the value matches the regular expression and [`Range`](https://crystal-lang.org/api/Range.html#%3D%3D%3D%28value%29-instance-method) as when the value is included in that range.
+For comparing an expression against a `case`'s subject, the compiler uses the [*case subsumption operator* `===`](./operators.md#subsumption). It is defined as a method on [`Object`](https://crystal-lang.org/api/Object.html#%3D%3D%3D%28other%29-instance-method) and can be overridden by subclasses to provide meaningful semantics in case statements. For example, [`Class`](https://crystal-lang.org/api/Class.html#%3D%3D%3D%28other%29-instance-method) defines case subsumption as when an object is an instance of that class, [`Regex`](https://crystal-lang.org/api/Regex.html#%3D%3D%3D%28other%3AString%29-instance-method) as when the value matches the regular expression and [`Range`](https://crystal-lang.org/api/Range.html#%3D%3D%3D%28value%29-instance-method) as when the value is included in that range.
 
 If a `when`'s expression is a type, `is_a?` is used. Additionally, if the case expression is a variable or a variable assignment the type of the variable is restricted:
 

--- a/docs/syntax_and_semantics/case.md
+++ b/docs/syntax_and_semantics/case.md
@@ -25,7 +25,7 @@ else
 end
 ```
 
-For comparing an expression against a `case`'s value the *case equality operator* `===` is used. It is defined as a method on [`Object`](https://crystal-lang.org/api/Object.html#%3D%3D%3D%28other%29-instance-method) and can be overridden by subclasses to provide meaningful semantics in case statements. For example, [`Class`](https://crystal-lang.org/api/Class.html#%3D%3D%3D%28other%29-instance-method) defines case equality as when an object is an instance of that class, [`Regex`](https://crystal-lang.org/api/Regex.html#%3D%3D%3D%28other%3AString%29-instance-method) as when the value matches the regular expression and [`Range`](https://crystal-lang.org/api/Range.html#%3D%3D%3D%28value%29-instance-method) as when the value is included in that range.
+For comparing an expression against a `case`'s value the *case subsumption operator* `===` is used. It is defined as a method on [`Object`](https://crystal-lang.org/api/Object.html#%3D%3D%3D%28other%29-instance-method) and can be overridden by subclasses to provide meaningful semantics in case statements. For example, [`Class`](https://crystal-lang.org/api/Class.html#%3D%3D%3D%28other%29-instance-method) defines case subsumption as when an object is an instance of that class, [`Regex`](https://crystal-lang.org/api/Regex.html#%3D%3D%3D%28other%3AString%29-instance-method) as when the value matches the regular expression and [`Range`](https://crystal-lang.org/api/Range.html#%3D%3D%3D%28value%29-instance-method) as when the value is included in that range.
 
 If a `when`'s expression is a type, `is_a?` is used. Additionally, if the case expression is a variable or a variable assignment the type of the variable is restricted:
 

--- a/docs/syntax_and_semantics/operators.md
+++ b/docs/syntax_and_semantics/operators.md
@@ -194,7 +194,7 @@ Three base operators test equality:
 * `=~`: Checks whether the value of the first operand matches the value of the
 second operand with pattern matching.
 * `===`: Checks whether the left hand operand matches the right hand operand in
-  [case equality](case.md). This operator is applied in `case ... when`
+  [case subsumption](case.md). This operator is applied in `case ... when`
   conditions.
 
 The first two operators also have inversion operators (`!=` and `!~`) whose
@@ -210,7 +210,7 @@ proven faster than equality).
 | `!=` | not equals | `1 != 2` | yes | left |
 | `=~` | pattern match | `"foo" =~ /fo/` | yes | left |
 | `!~` | no pattern match | `"foo" !~ /fo/` | yes | left |
-| `===` | [case equality](case.md) | `/foo/ === "foo"` | yes | left |
+| `===` | [case subsumption](case.md) | `/foo/ === "foo"` | yes | left |
 
 #### Comparison
 

--- a/docs/syntax_and_semantics/operators.md
+++ b/docs/syntax_and_semantics/operators.md
@@ -224,7 +224,7 @@ take care themselves.
 Inequality operators describe the order between values.
 
 The **three-way comparison operator** `<=>` (also known as *spaceship operator*)
-expresses the total order between two elements expressed by the sign of its
+expresses the order between two elements expressed by the sign of its
 return value.
 
 | Operator | Description | Example | Overloadable | Associativity |

--- a/docs/syntax_and_semantics/operators.md
+++ b/docs/syntax_and_semantics/operators.md
@@ -189,7 +189,7 @@ ones.
 <span id="equality-and-comparison" />
 
 Relational operators test a relation between two values.
-They include *equality* and *inequalities* and *subsumption*.
+They include *equality*, *inequalities*, and *subsumption*.
 
 #### Equality
 


### PR DESCRIPTION
The main purpose is to separate the pattern matching and case subsumption operators (`=~`, `!~` and `===`) from the equality operators (`==`, `!=`). They are *not* about equality. The case subsumption operator should also not be called *case equality* because it's misleading. 

The entire group of operators including equality, subsumption and inequalities is called relational operators.

In the process of this restructuring I've also reworded and enhanced the descriptions for these operators with the purpose of adding clarity and filling gaps. Also added some references to related features in the standard library.

The result is still a bit thin in some areas (especially regarding pattern matching and case subsumption) but I'm not sure about some of the specific details myself. We'll need to figure that out sometime.