### PR TITLE
Improve Modules page readability

### DIFF
--- a/docs/syntax_and_semantics/generics.md
+++ b/docs/syntax_and_semantics/generics.md
@@ -1,6 +1,6 @@
 # Generics
 
-Generics allow you to parameterize a type based on other type. Consider a Box type:
+Generics allow you to parameterize a type based on another type. Generics provide type-polymorphism. Consider a Box type:
 
 ```crystal
 class MyBox(T)
@@ -48,9 +48,9 @@ string_box = MyBox.new("hello") # : MyBox(String)
 
 In the above code we didn't have to specify the type arguments of `MyBox`, the compiler inferred them following this process:
 
-* The compiler generates a `MyBox.new(value : T)` method, which has no explicitly defined free variables, from `MyBox#initialize(@value : T)`
-* The `T` in `MyBox.new(value : T)` isn't bound to a type yet, and `T` is a type parameter of `MyBox`, so the compiler binds it to the type of the given argument
-* The compiler-generated `MyBox.new(value : T)` calls `MyBox(T)#initialize(@value : T)`, where `T` is now bound
+- The compiler generates a `MyBox.new(value : T)` method, which has no explicitly defined free variables, from `MyBox#initialize(@value : T)`
+- The `T` in `MyBox.new(value : T)` isn't bound to a type yet, and `T` is a type parameter of `MyBox`, so the compiler binds it to the type of the given argument
+- The compiler-generated `MyBox.new(value : T)` calls `MyBox(T)#initialize(@value : T)`, where `T` is now bound
 
 In this way generic types are less tedious to work with. Note that the `#initialize` method itself does not need to specify any free variables for this to work.
 

--- a/docs/syntax_and_semantics/modules.md
+++ b/docs/syntax_and_semantics/modules.md
@@ -2,8 +2,8 @@
 
 Modules serve two purposes:
 
-* as namespaces for defining other types, methods and constants
-* as partial types that can be mixed in other types
+- as namespaces for defining other types, methods and constants
+- as partial types that can be mixed in other types
 
 An example of a module as a namespace:
 
@@ -17,6 +17,8 @@ Curses::Window.new
 ```
 
 Library authors are advised to put their definitions inside a module to avoid name clashes. The standard library usually doesn't have a namespace as its types and methods are very common, to avoid writing long names.
+
+## `extend` and `include`
 
 To use a module as a partial type you use `include` or `extend`.
 


### PR DESCRIPTION
I had to look for the difference between extend and include earlier today. I missed it the first time I opened the Modules documentation because it didn't have its own headline.

This change will improve scannability significantly