### PR TITLE
Add devenv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+source_url "https://raw.githubusercontent.com/cachix/devenv/d1f7b48e35e6dee421cfd0f51481d17f77586997/direnvrc" "sha256-YBzqskFZxmNb3kYVoKD9ZixoPXJh1C9ZvTLGFRkauZ0="
+
+use devenv

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -35,7 +35,7 @@ jobs:
           key: pip-${{ hashFiles('requirements.txt') }}
           restore-keys: pip-
       - name: Install dependencies
-        run: make deps
+        run: pip install -r requirements.txt
       - name: Determine a version for API doc links
         shell: bash -x {0}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 site/
 .venv/
+
+# Devenv
+.devenv*
+devenv.local.nix
+.pre-commit-config.yaml

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@
 
 OUTPUT_DIR ?= ./site ## Build directory (default: ./site)
 
-MKDOCS ?= .venv/bin/mkdocs
-PIP ?= .venv/bin/pip
+MKDOCS ?= mkdocs
 
 DOCS_FILES := $(shell find docs -type f)
 
@@ -11,21 +10,13 @@ DOCS_FILES := $(shell find docs -type f)
 build: ## Build website into build directory
 build: $(OUTPUT_DIR)
 
-$(OUTPUT_DIR): $(DOCS_FILES) $(MKDOCS) mkdocs.yml
+$(OUTPUT_DIR): $(DOCS_FILES) mkdocs.yml
 	$(MKDOCS) build -d $(OUTPUT_DIR) --strict
 
 .PHONY: serve
 serve: ## Run live-preview server
-serve: $(MKDOCS) mkdocs.yml
+serve: mkdocs.yml
 	$(MKDOCS) serve
-
-deps: $(MKDOCS)
-
-$(MKDOCS): $(PIP) requirements.txt
-	$(PIP) install -q --no-deps -r requirements.txt && touch $(MKDOCS)
-
-$(PIP):
-	python3 -m venv .venv
 
 .PHONY: vendor
 vendor: ## Install assets from external sources
@@ -60,16 +51,12 @@ docs/assets/vendor/ansi_up/%:
 clean: ## Remove build directory
 	rm -rf $(OUTPUT_DIR)
 
-.PHONY: clean_deps
-clean_deps: ## Remove .venv directory
-	rm -rf .venv
-
 .PHONY: clean_vendor
 clean_vendor: ## Remove docs/assets/vendor directory
 	rm -rf docs/assets/vendor
 
 .PHONY: clean_all
-clean_all: clean clean_deps clean_vendor
+clean_all: clean clean_vendor
 
 .PHONY: format_api_docs_links
 format_api_docs_links:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,59 @@ Build into the `site` directory (some functionality won't work if opening the fi
 $ make build
 ```
 
+### devenv environment
+
+This project includes configuration for a reproducible environment via [devenv.sh](https://devenv.sh/)
+with integrated pre-commit checks.
+
+Live preview (at http://127.0.0.1:8000):
+
+```console
+$ devenv up
+Building shell ...
+pre-commit-hooks.nix: hooks up to date
+17:37:13 system  | serve.1 started (pid=6507)
+17:37:13 serve.1 | INFO     -  Building documentation...
+17:37:13 serve.1 | INFO     -  Cleaning site directory
+17:37:16 serve.1 | INFO     -  Documentation built in 2.64 seconds
+17:37:16 serve.1 | INFO     -  [17:37:16] Watching paths for changes: 'docs', 'mkdocs.yml'
+17:37:16 serve.1 | INFO     -  [17:37:16] Serving on http://127.0.0.1:8000/reference/latest/
+````
+
+Build the site:
+
+```console
+$ devenv shell build
+Building shell ...
+pre-commit-hooks.nix: hooks up to date
+rm -rf ./site
+mkdocs build -d ./site  --strict
+INFO     -  Cleaning site directory
+INFO     -  Building documentation to directory: ./site
+INFO     -  Documentation built in 2.43 seconds
+```
+
+Enter the development shell and build the site from there:
+
+```console
+$ devenv shell
+Building shell ...
+Entering shell ...
+
+pre-commit-hooks.nix: hooks up to date
+$(devenv) make build
+mkdocs build -d ./site  --strict
+INFO     -  Cleaning site directory
+INFO     -  Building documentation to directory: ./site
+INFO     -  Documentation built in 2.43 seconds
+```
+
+Run pre-commit checks on the entire repository:
+
+```console
+$ devenv ci
+```
+
 ### Adding a page
 
 To add a page, create a Markdown file in the desired location. Then, add a link in the `SUMMARY.md` file which acts as the navigation for the language reference.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Thank you very much!
 ```console
 $ git clone https://github.com/crystal-lang/crystal-book
 $ cd crystal-book
+$ pip install -r requirements.txt
 ```
 
 Live preview (at http://127.0.0.1:8000):

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,138 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1683288106,
+        "narHash": "sha256-8/yuP6gWLhK8tRCtyqY5QnTq9GF7pCWpZyyZ08lXFwM=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "c4006ccba1b3e4533de462cee5933e0ccf5f1d6a",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1683475240,
+        "narHash": "sha256-sy6MYoCaIZsOenYplbzVXI4Ce9Bp/vIOpuFa97+a6wc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e040aab15638aaf8d0786894851a2b1ca09a7baf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1678872516,
+        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1682596858,
+        "narHash": "sha256-Hf9XVpqaGqe/4oDGr30W8HlsWvJXtMsEPHDqHZA6dDg=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "fb58866e20af98779017134319b5663b8215d912",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,28 @@
+{ pkgs, ... }:
+
+{
+  enterShell = ''
+    pip install -q -q --no-deps -r requirements.txt
+    '';
+
+  packages = [
+    pkgs.gnumake
+  ];
+
+  languages.python = {
+    enable = true;
+    venv.enable = true;
+  };
+
+  scripts = {
+    "build".exec = "make clean build";
+  };
+
+  processes = {
+    serve.exec = "make serve";
+  };
+
+  pre-commit.hooks = {
+    markdownlint.enable = true;
+  };
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,3 @@
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable

--- a/docs/syntax_and_semantics/operators.md
+++ b/docs/syntax_and_semantics/operators.md
@@ -109,6 +109,8 @@ The compiler transforms it to an `if` expression.
 This list is sorted by precedence, so upper entries bind stronger than lower
 ones.
 
+<!-- markdownlint-disable no-space-in-code -->
+
 | Category | Operators |
 |---|---|
 | Index accessors | `[]`, `[]?` |
@@ -127,6 +129,8 @@ ones.
 | Conditional | `?:` |
 | Assignment | `=`, `[]=`, `+=`, `&+=`, `-=`, `&-=`, `*=`, `&*=`, `/=`, `//=`, `%=`, `|=`, `&=`,`^=`,`**=`,`<<=`,`>>=`, `||=`, `&&=` |
 | Splat | `*`, `**` |
+
+<!-- markdownlint-enable no-space-in-code -->
 
 ## List of operators
 


### PR DESCRIPTION
This sets up a reproducible development environment via [devenv.sh](https://devenv.sh).
Using it is completely optional, but I've come to like it as a tool that ensures the working environment is consistent and functional.
Usage instructions are added to the readme.

The first two commits are independent preconditions:

* markdownlint-cli@0.34.0 complains about spaces inside code span elements. As a mitigation this test is deactivated for the affected code.
* Resolution of python dependencies has been removed from the Makefile. That was a rather odd thing and has been bugging me for some time. We shouldn't dictate the use of pip and venv for python dependencies. The makefile should only require that `mkdocs` is available. Previously it was impossible to install dependencies in a different way (which the devenv setup needs, for example).