### PR TITLE
Fix `Time.local` instead of `Time.now` in example

### DIFF
--- a/docs/syntax_and_semantics/default_values_named_arguments_splats_tuples_and_overloading.md
+++ b/docs/syntax_and_semantics/default_values_named_arguments_splats_tuples_and_overloading.md
@@ -148,7 +148,7 @@ def plan(begin begin_time, end end_time)
   puts "Planning between #{begin_time} and #{end_time}"
 end
 
-plan begin: Time.now, end: 2.days.from_now
+plan begin: Time.local, end: 2.days.from_now
 ```
 
 The second use case is making a method parameter more readable inside a method body:


### PR DESCRIPTION
`syntax_and_semantics/default_values_named_arguments_splats_tuples_and_overloading.html#external-names` gives an example using non-existent function `Time.now`. Replaced with `Time.local`.

Thank you @Blacksmoke16 for pointing it out and encouraging me to make a small PR! :smiley: 