### PR TITLE
Upgrade MkDocs version, related updates

### DIFF
--- a/docs/syntax_and_semantics/annotations/README.md
+++ b/docs/syntax_and_semantics/annotations/README.md
@@ -194,7 +194,7 @@ Annotations can be read off of a [`TypeNode`](https://crystal-lang.org/api/Cryst
 
 NOTE: If multiple annotations of the same type are applied, the `.annotation` method will return the *last* one.
 
-The [`@type`](../macros/#type-information) and [`@def`](../macros/#method-information) variables can be used to get a `TypeNode` or `Def` object to use the `.annotation` method on.  However, it is also possible to get `TypeNode`/`Def` types using other methods on `TypeNode`.  For example `TypeNode.all_subclasses` or `TypeNode.methods`, respectively.
+The [`@type`](../macros/README.md#type-information) and [`@def`](../macros/README.md#method-information) variables can be used to get a `TypeNode` or `Def` object to use the `.annotation` method on.  However, it is also possible to get `TypeNode`/`Def` types using other methods on `TypeNode`.  For example `TypeNode.all_subclasses` or `TypeNode.methods`, respectively.
 
 TIP: Checkout the [`parse_type`](../macros/README.md#parse_type) method for a more advanced way to obtain a `TypeNode`.
 

--- a/docs/syntax_and_semantics/documenting_code.md
+++ b/docs/syntax_and_semantics/documenting_code.md
@@ -7,7 +7,7 @@ By default, all public methods, macros, types and constants are
 considered part of the API documentation.
 
 TIP:
-The compiler command [`crystal docs`](../man/crystal/#crystal-docs)
+The compiler command [`crystal docs`](../man/crystal/README.md#crystal-docs)
 automatically extracts the API documentation and generates a website to
 present it.
 

--- a/hooks.py
+++ b/hooks.py
@@ -8,10 +8,7 @@ version = os.getenv('CRYSTAL_VERSION', 'master')
 
 
 def on_page_markdown(markdown, page, **kwargs):
-    path = page.file.src_path
-
-    for bad in re.findall(r'\[\w.*?\]\((?!http)([^ )]*?(?:\.html|/)(?:#[^ )]*?)?)\)', markdown):
-        log.warning(f"Documentation file '{path}' contains an internal link that doesn't end with .md: '{bad}'")
+    path = page.file.src_uri
 
     for bad in re.findall(r'\]\(((?:https?://(?:www\.)?crystal-lang\.org/reference)?/[^ )]*?)\)', markdown):
         log.warning(f"Documentation file '{path}' contains an absolute link to the site itself: '{bad}'")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,14 @@ theme:
     - navigation.footer
     - navigation.tabs
 
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+
+exclude_docs: |
+  SUMMARY.md
+
 extra_css:
   - assets/vendor/codemirror/codemirror.min.css
   - assets/style.css
@@ -85,7 +93,10 @@ markdown_extensions:
   - pymdownx.highlight
   - pymdownx.magiclink
   - pymdownx.superfences
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      check_paths: true
+      base_path:
+        - !relative $config_dir
   - callouts
   - toc:
       permalink: true

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-mkdocs>=1.2
+mkdocs>=1.5.0
 markdown-callouts>=0.2.0
 mkdocs-material>=8.0.5
 mkdocs-literate-nav>=0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile requirements.in
 #
-certifi==2023.5.7
+certifi==2023.7.22
     # via requests
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
-click==8.1.3
+click==8.1.6
     # via mkdocs
 colorama==0.4.6
     # via mkdocs-material
@@ -20,7 +20,7 @@ jinja2==3.1.2
     # via
     #   mkdocs
     #   mkdocs-material
-markdown==3.3.7
+markdown==3.4.4
     # via
     #   markdown-callouts
     #   mkdocs
@@ -29,11 +29,13 @@ markdown==3.3.7
     #   pymdown-extensions
 markdown-callouts==0.3.0
     # via -r requirements.in
-markupsafe==2.1.2
-    # via jinja2
+markupsafe==2.1.3
+    # via
+    #   jinja2
+    #   mkdocs
 mergedeep==1.3.4
     # via mkdocs
-mkdocs==1.4.3
+mkdocs==1.5.1
     # via
     #   -r requirements.in
     #   mkdocs-code-validator
@@ -46,11 +48,11 @@ mkdocs-code-validator==0.1.3
     # via -r requirements.in
 mkdocs-literate-nav==0.6.0
     # via -r requirements.in
-mkdocs-material==9.1.15
+mkdocs-material==9.1.21
     # via -r requirements.in
 mkdocs-material-extensions==1.1.1
     # via mkdocs-material
-mkdocs-redirects==1.2.0
+mkdocs-redirects==1.2.1
     # via -r requirements.in
 mkdocs-section-index==0.3.5
     # via -r requirements.in
@@ -58,28 +60,32 @@ mkdocs-simple-hooks==0.1.5
     # via -r requirements.in
 packaging==23.1
     # via mkdocs
+pathspec==0.11.2
+    # via mkdocs
+platformdirs==3.10.0
+    # via mkdocs
 pygments==2.15.1
     # via mkdocs-material
-pymdown-extensions==10.0.1
+pymdown-extensions==10.1
     # via
     #   mkdocs-code-validator
     #   mkdocs-material
 python-dateutil==2.8.2
     # via ghp-import
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   mkdocs
     #   pymdown-extensions
     #   pyyaml-env-tag
 pyyaml-env-tag==0.1
     # via mkdocs
-regex==2023.5.5
+regex==2023.6.3
     # via mkdocs-material
 requests==2.31.0
     # via mkdocs-material
 six==1.16.0
     # via python-dateutil
-urllib3==2.0.2
+urllib3==2.0.4
     # via requests
 watchdog==3.0.0
     # via mkdocs


### PR DESCRIPTION
* Use new native link validation, making some code obsolete.
* Fix a few links that are recognized as invalid.
* Enable validation for missing paths in pymdownx.snippets.
* Exclude SUMMARY.html from the built site.
