### PR TITLE
Add new unreachable options to compiler manual

### DIFF
--- a/docs/man/crystal/README.md
+++ b/docs/man/crystal/README.md
@@ -419,6 +419,8 @@ Options:
 
 * `-D FLAG`, `--define FLAG`: Define a compile-time flag
 * `-f FORMAT`, `--format FORMAT`: Output format `text` (default) or `json`
+* `--tallies`: Print reachable methods and their call counts as well.
+* `--check`: Exit with error if there is any unreachable code.
 * `--error-trace`: Show full error trace
 * `-h`, `--help`: Show this message
 * `-i PATH`, `--include PATH`: Include path

--- a/docs/man/crystal/README.md
+++ b/docs/man/crystal/README.md
@@ -422,7 +422,7 @@ The output is a list of lines with columns separated by tab.
 Options:
 
 * `-D FLAG`, `--define FLAG`: Define a compile-time flag
-* `-f FORMAT`, `--format FORMAT`: Output format `text` (default) or `json`
+* `-f FORMAT`, `--format FORMAT`: Output format `text` (default), `json`, or `csv`
 * `--tallies`: Print reachable methods and their call counts as well.
 * `--check`: Exit with error if there is any unreachable code.
 * `--error-trace`: Show full error trace

--- a/docs/man/crystal/README.md
+++ b/docs/man/crystal/README.md
@@ -411,9 +411,13 @@ Show methods that are never called.
 crystal tool unreachable [options] [programfile]
 ```
 
-The output is a list of lines with columns separated by tab. The first column is
-the location of the def, the second column its reference name and the third
-column is the length in lines.
+The output is a list of lines with columns separated by tab.
+
+* tally (only with `--tallies` option; otherwise skipped)
+* location of the def (pathname plus line and column)
+* reference name
+* length in lines
+* annotations
 
 Options:
 

--- a/docs/man/crystal/README.md
+++ b/docs/man/crystal/README.md
@@ -411,13 +411,15 @@ Show methods that are never called.
 crystal tool unreachable [options] [programfile]
 ```
 
-The output is a list of lines with columns separated by tab.
+The text output is a list of lines with columns separated by tab.
 
-* tally (only with `--tallies` option; otherwise skipped)
-* location of the def (pathname plus line and column)
-* reference name
-* length in lines
-* annotations
+Output fields:
+
+* `count`: sum of all calls to this method (only with `--tallies` option; otherwise skipped)
+* `location`: pathname, line and column, all separated by colon
+* `name`
+* `lines`: length of the def in lines
+* `annotations`
 
 Options:
 


### PR DESCRIPTION
Updates the manual with respect to the changes from

* https://github.com/crystal-lang/crystal/pull/13930
* https://github.com/crystal-lang/crystal/pull/13927
* https://github.com/crystal-lang/crystal/pull/13929
* https://github.com/crystal-lang/crystal/pull/13926
* https://github.com/crystal-lang/crystal/pull/13969