### PR TITLE
Run `deploy config` workflow only when a release branch is created

### DIFF
--- a/.github/workflows/deploy-config.yml
+++ b/.github/workflows/deploy-config.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: Deploy config
-    if: github.repository == 'crystal-lang/crystal-book'
+    if: github.repository == 'crystal-lang/crystal-book' && startsWith(github.ref_name, "release/")
     runs-on: ubuntu-latest
     steps:
       - name: Download source


### PR DESCRIPTION
There's no need to regenerate config every time a new branch is created. Only release branches are relevant. Other branches do not deploy.