### PR TITLE
Set `edit_uri` to point to deployed branch

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -44,6 +44,9 @@ jobs:
           fi
       - name: Populate sample version of Crystal
         run: crystal --version | tee crystal-version.txt
+      - name: Set edit_uri branch
+        run: |
+          sed -i -e 's#^edit_uri:.*#edit_uri: https://github.com/${{ github.repository }}/edit/${{ github.ref_name }}/docs/#' mkdocs.yml
       - name: Build book
         run: LINT=true make build
       - name: Configure AWS Credentials


### PR DESCRIPTION
Currently, `edit_uri` always points to the master branch. This is confusing when you're on a release branch because the contents may differ. Release branches (especially the latest one) is the main deployed version and you won't see the master deployment unless you explicitly chose the "nightly" version.

Example for confusion: https://github.com/crystal-lang/crystal/pull/11876#issuecomment-1902599532