### PR TITLE
Add a "view source" link that correctly points to the current branch

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -46,6 +46,9 @@ jobs:
         run: crystal --version | tee crystal-version.txt
       - name: Build book
         run: LINT=true make build
+      - name: Override branch for "view source"
+        run: |
+          find site -type f -name '*.html' -exec sed -i -e 's#/raw/master/docs/#/blob/${{ github.ref_name }}/docs/#' '{}' '+'
       - name: Configure AWS Credentials
         if: github.event_name == 'push' && steps.branch.outputs.branch != null && github.repository == 'crystal-lang/crystal-book'
         uses: aws-actions/configure-aws-credentials@v2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ theme:
   logo: assets/crystal-circ.svg
   custom_dir: overrides
   features:
+    - content.action.view
     - content.action.edit
     - navigation.footer
     - navigation.tabs


### PR DESCRIPTION
Each page has an "edit page" link which points people to the master branch despite it not being the actual current source of this page.

But now we also add a "view source" link will point to the actual used source.

---

* Closes https://github.com/crystal-lang/crystal-book/pull/740 according to [comment](https://github.com/crystal-lang/crystal-book/pull/740#issuecomment-1904411631)