### PR TITLE
Add compile time flag `solaris`

### DIFF
--- a/docs/syntax_and_semantics/compile_time_flags.md
+++ b/docs/syntax_and_semantics/compile_time_flags.md
@@ -81,7 +81,8 @@ The operating system is derived from the third component of a the target triple.
 | `linux`   | Linux
 | `netbsd`  | NetBSD
 | `openbsd` | OpenBSD
-| `unix` *(derived)* | UNIX-like (BSD, Darwin, Linux)
+| `solaris` | Solaris/illumos
+| `unix` *(derived)* | UNIX-like (BSD, Darwin, Linux, Solaris)
 | `windows` | Windows
 
 #### ABI


### PR DESCRIPTION
Follow-up to #750 which added Solaris to *Platform Support*, but we als got a new compiler flag.