### PR TITLE
Reorganize compile time flags for the compiler

### DIFF
--- a/docs/syntax_and_semantics/compile_time_flags.md
+++ b/docs/syntax_and_semantics/compile_time_flags.md
@@ -126,6 +126,9 @@ true
 
 ### Stdlib features
 
+These flags enable or disable features in the standard library when building a
+Crystal program.
+
 | Flag name | Description |
 |-----------|-------------|
 | `gc_none` | Disables garbage collection ([#5314](https://github.com/crystal-lang/crystal/pull/5314))
@@ -142,18 +145,27 @@ true
 
 ### Compiler features
 
+These flags enable or disable compiler features when building a Crystal program.
+
 | Flag name | Description |
 |-----------|-------------|
-| `without_ffi`     | Build the compiler without `libffi`
-| `without_interpreter`  | Build the compiler without interpreter support
-| `without_playground` | Build the compiler without playground (`crystal play`)
-| `i_know_what_im_doing` | Safety guard against involuntarily building the compiler
 | `no_number_autocast` | Will not [autocast](autocasting.md#number-autocasting) numeric expressions, only literals |
 | `no_restrictions_augmenter` | Disable enhanced restrictions augmenter. Introduced in 1.5 ([#12103](https://github.com/crystal-lang/crystal/pull/12103)).
 | `preview_dll` | Enable dynamic linking on Windows; experimental |
 | `preview_overload_order` | Enable more robust ordering between def overloads. Introduced in 1.6 ([#10711](https://github.com/crystal-lang/crystal/issues/10711)).
 | `preview_win32_delay_load` | Delay-load all DLLs on Windows; experimental |
 | `strict_multi_assign` | Enable strict semantics for [one-to-many assignment](assignment.md#one-to-many-assignment). Introduced in 1.3.0 ([#11145](https://github.com/crystal-lang/crystal/pull/11145), [#11545](https://github.com/crystal-lang/crystal/pull/11545))
+
+### Compiler build features
+
+These flags enable or disable features when building the Crystal compiler.
+
+| Flag name | Description |
+|-----------|-------------|
+| `without_ffi`     | Build the compiler without `libffi`
+| `without_interpreter`  | Build the compiler without interpreter support
+| `without_playground` | Build the compiler without playground (`crystal play`)
+| `i_know_what_im_doing` | Safety guard against involuntarily building the compiler
 
 ### User code features
 

--- a/docs/syntax_and_semantics/compile_time_flags.md
+++ b/docs/syntax_and_semantics/compile_time_flags.md
@@ -131,7 +131,6 @@ true
 | `gc_none` | Disables garbage collection ([#5314](https://github.com/crystal-lang/crystal/pull/5314))
 | `debug_raise` | Debugging flag for `raise` logic. Prints the backtrace before raising.
 | `preview_mt` | Enables multithreading preview. Introduced in 0.28.0 ([#7546](https://github.com/crystal-lang/crystal/pull/7546))
-| `strict_multi_assign` | Enable strict semantics for [one-to-many assignment](assignment.md#one-to-many-assignment). Introduced in 1.3.0 ([#11145](https://github.com/crystal-lang/crystal/pull/11145), [#11545](https://github.com/crystal-lang/crystal/pull/11545))
 | `skip_crystal_compiler_rt` | Exclude Crystal's native `compiler-rt` implementation.
 | `use_libiconv` | Use `libiconv` instead of the `iconv` system library
 | `use_pcre2` | Use PCRE2 as regex engine (instead of legacy PCRE). Introduced in 1.7.0.
@@ -154,6 +153,7 @@ true
 | `preview_dll` | Enable dynamic linking on Windows; experimental |
 | `preview_overload_order` | Enable more robust ordering between def overloads. Introduced in 1.6 ([#10711](https://github.com/crystal-lang/crystal/issues/10711)).
 | `preview_win32_delay_load` | Delay-load all DLLs on Windows; experimental |
+| `strict_multi_assign` | Enable strict semantics for [one-to-many assignment](assignment.md#one-to-many-assignment). Introduced in 1.3.0 ([#11145](https://github.com/crystal-lang/crystal/pull/11145), [#11545](https://github.com/crystal-lang/crystal/pull/11545))
 
 ### User code features
 

--- a/docs/syntax_and_semantics/compile_time_flags.md
+++ b/docs/syntax_and_semantics/compile_time_flags.md
@@ -138,6 +138,8 @@ true
 | `use_pcre` | Use PCRE as regex engine (instead of PCRE2). Introduced in 1.8.0.
 | `win7`     | Use Win32 WinNT API for Windows 7
 | `without_iconv` | Do not link `iconv`/`libiconv`
+| `without_openssl` | Build without OpenSSL support
+| `without_zlib` | Build without Zlib support
 
 ### Compiler features
 
@@ -145,8 +147,6 @@ true
 |-----------|-------------|
 | `without_ffi`     | Build the compiler without `libffi`
 | `without_interpreter`  | Build the compiler without interpreter support
-| `without_openssl` | Build the compiler without OpenSSL support
-| `without_zlib` | Build the compiler without Zlib support
 | `without_playground` | Build the compiler without playground (`crystal play`)
 | `i_know_what_im_doing` | Safety guard against involuntarily building the compiler
 | `no_number_autocast` | Will not [autocast](autocasting.md#number-autocasting) numeric expressions, only literals |


### PR DESCRIPTION
This change separates flags that you pass to the compiler when building a Crystal program from flags you pass for building the compiler specifically.

Also moves some incorrectly categorized flags between compiler and stdlib features.