### PR TITLE
Add page *Release Policy*

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -118,7 +118,7 @@ Instructions on how to use the compiler and tools.
 
 Announcements about the language development.
 
-* [Release Notes](https://crystal-lang.org/blog/#release_notes)
+* [Release Notes](https://crystal-lang.org/releases)
 * [Release Policy](project/release-policy.md)
 * [Crystal Blog](https://crystal-lang.org/blog)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,7 +114,7 @@ Instructions on how to use the compiler and tools.
   </div>
   <div class="card" markdown="1">
 
-### Project News
+### Project and Releases Information
 
 Announcements about the language development.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,11 +114,12 @@ Instructions on how to use the compiler and tools.
   </div>
   <div class="card" markdown="1">
 
-### Developer News
+### Project News
 
 Announcements about the language development.
 
 * [Release Notes](https://crystal-lang.org/blog/#release_notes)
+* [Release Policy](project/release-policy.md)
 * [Crystal Blog](https://crystal-lang.org/blog)
 
   </div>

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -102,7 +102,6 @@
         * [Uninitialized variable declaration](syntax_and_semantics/declare_var.md)
     * [Compile-time flags](syntax_and_semantics/compile_time_flags.md)
         * [Cross-compilation](syntax_and_semantics/cross-compilation.md)
-        * [Platform Support](syntax_and_semantics/platform_support.md)
     * [C bindings](syntax_and_semantics/c_bindings/README.md)
         * [lib](syntax_and_semantics/c_bindings/lib.md)
         * [fun](syntax_and_semantics/c_bindings/fun.md)
@@ -150,3 +149,5 @@
     * [Using the Compiler](man/crystal/README.md)
     * [The Shards Command](man/shards/README.md)
     * [Required libraries](man/required_libraries.md)
+    * [Platform Support](syntax_and_semantics/platform_support.md)
+    * [Release Policy](project/release-policy.md)

--- a/docs/project/release-policy.md
+++ b/docs/project/release-policy.md
@@ -1,0 +1,43 @@
+# Release Policy
+
+Crystal releases have a version indicated by a major, minor and patch number.
+
+The current major branch number is `1`.
+
+New features are added in minor releases (`1.x.0`) which are regularly scheduled every three months.
+
+Patch releases contain only important bug fixes and are released when necessary.
+They usually only appear for the latest minor branch.
+
+New releases are announced at [crystal-lang.org/releases](https://crystal-lang.org/releases) ([RSS feed](https://crystal-lang.org/releases)).
+
+There are currently no plans for a new major release.
+
+## Backwards compatibility
+
+Minor and patch releases are backwards compatible: Well-defined behaviours and documented APIs in a given version
+will continue working on future versions within the same major branch.
+
+As a result, migrating to a new minor release is usually seamless.
+
+### Reservations
+
+Although we expect the vast majority of programs to remain compatible over time,
+it is impossible to guarantee that no future change will break any program.
+Under some unlikely circumstances, we may introduce changes that break existing code.
+Rest assured we are commited to keep the impact as minimal as possible.
+
+* Security: a security issue in the implementation may arise whose resolution requires backwards incompatible changes. We reserve the right to address such security issues.
+
+* Bugs: if an API has undesired behaviour, a program that depends on the buggy behaviour may break if the bug is fixed. We reserve the right to fix such bugs.
+
+* Compiler front-end: improvements may be done to the compiler, introducing new warnings for ambiguous modes and providing more detailed error messages. Those can lead to compilation errors (when building with `--error-on-warnings`) or tooling failures when asserting on specific error messages (although one should avoid such). We reserve the right to do such improvements.
+
+* Feature additions: When introducing new features into the language or core library, there can be collisions with the names of types, methods, etc. defined in user code. We reserve the right to add new names when necessary.
+
+The changelog and release notes highlight any changes that have a considerable potential for breaking existing code, even if it uses experimental, undocumented or unsupported features.
+
+### Experimental features
+
+The only exception to the compatibility guarantees are experimental features, which are explicitly designated as such with the [`@[Experimental]`](https://crystal-lang.org/api/Experimental.html) annotation.
+There is no compatibility guarantee until they are stabilized (at which point the annotation is dropped).


### PR DESCRIPTION
Resolves https://github.com/crystal-lang/crystal/issues/14481

The content is heavily based on [hexdocs.pm/elixir/compatibility-and-deprecations.html](https://hexdocs.pm/elixir/compatibility-and-deprecations.html), which is a great summary especially concerning backwards compatibility and matches the intentions of the Crystal project (as far as I'm concerned).