### PR TITLE
Add flag for `avr` architecture

### DIFF
--- a/docs/syntax_and_semantics/compile_time_flags.md
+++ b/docs/syntax_and_semantics/compile_time_flags.md
@@ -50,6 +50,7 @@ The target architecture is the first component of the target triple.
 | Flag name | Description |
 |-----------|-------------|
 | `aarch64` | AArch64 architecture
+| `avr`     | AVR architecture
 | `arm`     | ARM architecture
 | `i386`    | x86 architecture (32-bit)
 | `wasm32`  | WebAssembly


### PR DESCRIPTION
This was added in https://github.com/crystal-lang/crystal/pull/14393