### PR TITLE
Mention which types are valid for type restriction on `rescue`

### DIFF
--- a/docs/syntax_and_semantics/exception_handling.md
+++ b/docs/syntax_and_semantics/exception_handling.md
@@ -67,6 +67,8 @@ end
 # Output: Rescued MyException
 ```
 
+Valid type restrictions are subclasses of `::Exception`, module types and unions of these.
+
 And to access it, use a syntax similar to type restrictions:
 
 ```crystal


### PR DESCRIPTION
Module types were added in https://github.com/crystal-lang/crystal/pull/14552