### PR TITLE
Promote `aarch64-darwin` to Tier 1

### DIFF
--- a/docs/syntax_and_semantics/platform_support.md
+++ b/docs/syntax_and_semantics/platform_support.md
@@ -19,6 +19,7 @@ and drop into *Tier 2*.
 
 | Target | Description | Supported versions | Comment |
 | ------ | ----------- | ------------------ | ------- |
+| `aarch64-darwin` | Aarch64 macOS<br> (Apple Silicon) | 11+ | :material-selection-marked-circle: tests<br> :material-checkbox-marked-circle: builds
 | `x86_64-darwin` | x64 macOS<br> (Intel) | 11+<br> *(testing only on 11; expected to work on 10.7+)* | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds
 | `x86_64-linux-gnu` | x64 Linux | kernel 4.14+, GNU libc 2.26+<br> *(expected to work on kernel 2.6.18+)* | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds
 | `x86_64-linux-musl` | x64 Linux | kernel 4.14+, MUSL libc 1.2+<br> *(expected to work on kernel 2.6.18+)* | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds
@@ -34,7 +35,6 @@ Details are described in the *Comment* column.
 
 | Target | Description | Supported versions | Comment |
 | ------ | ----------- | ------------------ | ------- |
-| `aarch64-darwin` | Aarch64 macOS<br> (Apple Silicon) | 11+ | :material-selection-ellipse: tests<br> :material-checkbox-marked-circle: builds
 | `aarch64-linux-gnu` | Aarch64 Linux | GNU libc 2.26+ | :material-checkbox-marked-circle: tests<br> :material-selection-ellipse: builds
 | `aarch64-linux-musl` | Aarch64 Linux | MUSL libc 1.2+ | :material-checkbox-marked-circle: tests<br> :material-selection-ellipse: builds
 | `arm-linux-gnueabihf` | Aarch32 Linux<br> (hardfloat) | GNU libc 2.26+ | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds

--- a/docs/syntax_and_semantics/platform_support.md
+++ b/docs/syntax_and_semantics/platform_support.md
@@ -19,8 +19,8 @@ and drop into *Tier 2*.
 
 | Target | Description | Supported versions | Comment |
 | ------ | ----------- | ------------------ | ------- |
-| `aarch64-darwin` | Aarch64 macOS<br> (Apple Silicon) | 11+ | :material-selection-marked-circle: tests<br> :material-checkbox-marked-circle: builds
-| `x86_64-darwin` | x64 macOS<br> (Intel) | 11+<br> *(testing only on 11; expected to work on 10.7+)* | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds
+| `aarch64-darwin` | Aarch64 macOS<br> (Apple Silicon) | 11+ *(testing only on 14)* | :material-selection-circle: tests<br> :material-checkbox-marked-circle: builds
+| `x86_64-darwin` | x64 macOS<br> (Intel) | 11+<br> *(testing only on 13; expected to work on 10.7+)* | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds
 | `x86_64-linux-gnu` | x64 Linux | kernel 4.14+, GNU libc 2.26+<br> *(expected to work on kernel 2.6.18+)* | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds
 | `x86_64-linux-musl` | x64 Linux | kernel 4.14+, MUSL libc 1.2+<br> *(expected to work on kernel 2.6.18+)* | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds
 


### PR DESCRIPTION
Since https://github.com/crystal-lang/crystal/pull/14833 we have automated tests for `aarch64-darwin` in CI.
That was the only thing missing for Tier 1, so now we can promote it.