### PR TITLE
Update range section of operators page to specify inclusivity

### DIFF
--- a/docs/syntax_and_semantics/operators.md
+++ b/docs/syntax_and_semantics/operators.md
@@ -292,7 +292,7 @@ literals.
 
 | Operator | Description | Example | Overloadable |
 |---|---|---|---|
-| `..` | range | `1..10` | no |
+| `..` | inclusive range | `1..10` | no |
 | `...` | exclusive range | `1...10` | no |
 
 ### Splats


### PR DESCRIPTION
Exclusive range is labelled explicitly, but `..` isn't.