### PR TITLE
Updates module inclusion / inheritance example

### DIFF
--- a/docs/syntax_and_semantics/modules.md
+++ b/docs/syntax_and_semantics/modules.md
@@ -147,8 +147,8 @@ class Two
   include B
 end
 
-class Three < Two
-  include A
+class Three < One
+  include B
 end
 ```
 
@@ -175,8 +175,8 @@ two = Two.new
 three = Three.new
 
 new_array = Array(A).new
-new_array << one   # Ok, One inherits module A
-new_array << three # Ok, Three includes module A
+new_array << one   # Ok, One includes module A
+new_array << three # Ok, Three inherits module A
 
-new_array << two # Error, because Two does not inherit module A
+new_array << two # Error, because Two neither inherits nor includes module A
 ```


### PR DESCRIPTION
Currently, `Three` inherits `Two`, and thus B, but it simply includes `A`, just like `One`.

The explanation is not consequent with this, as both `One` and `Three` simply `include A`.

```cr
new_array << one   # Ok, One inherits module A
new_array << three # Ok, Three includes module A
```

The changes should reflect the difference between directly including a module, and inheriting the inclusion from a class.