### PR TITLE
Add examples on "stacking" and "overriding" certain macro hooks

### DIFF
--- a/docs/syntax_and_semantics/macros/hooks.md
+++ b/docs/syntax_and_semantics/macros/hooks.md
@@ -131,11 +131,12 @@ A definition of the `method_missing` macro hook overrides any previous definitio
 macro method_missing(name)
   {% puts "I didnt run! :(" %}
 end
+
 class Example
   macro method_missing(name)
     {% puts "I didnt run! :(" %}
   end
-  
+
   macro method_missing(name)
     {% puts "I am the only one that will run!" %}
   end

--- a/docs/syntax_and_semantics/macros/hooks.md
+++ b/docs/syntax_and_semantics/macros/hooks.md
@@ -132,16 +132,16 @@ class Example
   end
   
   macro method_missing(name)
-    {% puts "I am the only one that will run! :D" %}
+    {% puts "I am the only one that will run!" %}
   end
 end
 
 macro method_missing(name)
-  {% puts "I am the only one that will run! :D 2" %}
+  {% puts "I am the only one that will run!" %}
 end
 
-Example.new.call_a_missing_method # => I am the only one that will run! :D
+Example.new.call_a_missing_method # => I am the only one that will run!
 
-call_a_missing_method # => I am the only one that will run! :D 2
+call_a_missing_method # => I am the only one that will run!
 ```
 

--- a/docs/syntax_and_semantics/macros/hooks.md
+++ b/docs/syntax_and_semantics/macros/hooks.md
@@ -107,7 +107,7 @@ The `print_methods` macro will be run as soon as it is encountered - and will pr
 Depending on the macro hook used, a hook can either be stacked or overridden. 
 
 ## Stacking
-When stacked a hook is executed multiple times in it's defined context for every time the hook is defined. Consider the following example:
+When stacked, a hook is executed multiple times in it's defined context for as many times as the hook is defined. Consider the following example:
 ```crystal
 # Stack the top-level finished macro
 macro finished

--- a/docs/syntax_and_semantics/macros/hooks.md
+++ b/docs/syntax_and_semantics/macros/hooks.md
@@ -103,3 +103,45 @@ Foo.new.bar
 ```
 
 The `print_methods` macro will be run as soon as it is encountered - and will print an empty list as there are no methods defined at that point. Once the second declaration of `Foo` is compiled the `finished` macro will be run, which will print `[bar]`.
+
+Depending on the macro hook used, a hook can either be stacked or overridden. 
+
+## Stacking
+When stacked a hook is executed multiple times in it's defined context for every time the hook is defined. Consider the following example:
+```crystal
+# Stack the top-level finished macro
+macro finished
+  {% puts "I will execute!" %}
+end
+
+macro finished
+  {% puts "I will also execute!" %}
+end
+```
+In the above example, both `finished` macros will execute. Stacking works for the following hooks: `inherited`, `included`, `extended`, `method_added`, `finished`
+
+## Overriding
+Overriding can only be used with the `method_missing` macro. This will only execute the last defined macro `method_missing` in a context. For example:
+```crystal
+macro method_missing(name)
+  {% puts "I didnt run! :(" %}
+end
+class Example
+  macro method_missing(name)
+    {% puts "I didnt run! :(" %}
+  end
+  
+  macro method_missing(name)
+    {% puts "I am the only one that will run! :D" %}
+  end
+end
+
+macro method_missing(name)
+  {% puts "I am the only one that will run! :D 2" %}
+end
+
+Example.new.call_a_missing_method # => I am the only one that will run! :D
+
+call_a_missing_method # => I am the only one that will run! :D 2
+```
+

--- a/docs/syntax_and_semantics/macros/hooks.md
+++ b/docs/syntax_and_semantics/macros/hooks.md
@@ -107,7 +107,7 @@ The `print_methods` macro will be run as soon as it is encountered - and will pr
 Depending on the macro hook used, a hook can either be stacked or overridden. 
 
 ## Stacking
-When stacked, a hook is executed multiple times in its defined context for as many times as the hook is defined. Consider the following example:
+When stacked, a hook is executed multiple times in its defined context for as many times as the hook is defined. Hooks executed in this way will execute in order of definition. Consider the following example:
 ```crystal
 # Stack the top-level finished macro
 macro finished

--- a/docs/syntax_and_semantics/macros/hooks.md
+++ b/docs/syntax_and_semantics/macros/hooks.md
@@ -107,7 +107,7 @@ The `print_methods` macro will be run as soon as it is encountered - and will pr
 Depending on the macro hook used, a hook can either be stacked or overridden. 
 
 ## Stacking
-When stacked, a hook is executed multiple times in it's defined context for as many times as the hook is defined. Consider the following example:
+When stacked, a hook is executed multiple times in its defined context for as many times as the hook is defined. Consider the following example:
 ```crystal
 # Stack the top-level finished macro
 macro finished
@@ -121,7 +121,7 @@ end
 In the above example, both `finished` macros will execute. Stacking works for the following hooks: `inherited`, `included`, `extended`, `method_added`, `finished`
 
 ## Overriding
-Overriding can only be used with the `method_missing` macro. This will only execute the last defined macro `method_missing` in a context. For example:
+A definition of the `method_missing` macro hook overrides any previous definition of this hook in the same context. Only the last defined macro executes. For example:
 ```crystal
 macro method_missing(name)
   {% puts "I didnt run! :(" %}

--- a/docs/syntax_and_semantics/macros/hooks.md
+++ b/docs/syntax_and_semantics/macros/hooks.md
@@ -104,10 +104,12 @@ Foo.new.bar
 
 The `print_methods` macro will be run as soon as it is encountered - and will print an empty list as there are no methods defined at that point. Once the second declaration of `Foo` is compiled the `finished` macro will be run, which will print `[bar]`.
 
-Depending on the macro hook used, a hook can either be stacked or overridden. 
+Depending on the macro hook used, a hook can either be stacked or overridden.
 
 ## Stacking
+
 When stacked, a hook is executed multiple times in its defined context for as many times as the hook is defined. Hooks executed in this way will execute in order of definition. Consider the following example:
+
 ```crystal
 # Stack the top-level finished macro
 macro finished
@@ -118,10 +120,13 @@ macro finished
   {% puts "I will also execute!" %}
 end
 ```
+
 In the above example, both `finished` macros will execute. Stacking works for the following hooks: `inherited`, `included`, `extended`, `method_added`, `finished`
 
 ## Overriding
+
 A definition of the `method_missing` macro hook overrides any previous definition of this hook in the same context. Only the last defined macro executes. For example:
+
 ```crystal
 macro method_missing(name)
   {% puts "I didnt run! :(" %}
@@ -144,4 +149,3 @@ Example.new.call_a_missing_method # => I am the only one that will run!
 
 call_a_missing_method # => I am the only one that will run!
 ```
-


### PR DESCRIPTION
We can "stack" (not sure what else to call it) certain macro hooks like `finished` but something like `method_missing` will override previous macro hooks in the same context. Feel free to rename or whatever. 👍🏻