### PR TITLE
Remove mentions of `-Dpreview_dll`

### DIFF
--- a/docs/guides/static_linking.md
+++ b/docs/guides/static_linking.md
@@ -60,9 +60,9 @@ macOS doesn't [officially support fully static linking](https://developer.apple.
 
 Windows doesn't support fully static linking because the Win32 libraries are not available as static libraries.
 
-Currently, static linking is the default mode of linking on Windows, and dynamic linking can be opted in via the `-Dpreview_dll` compile-time flag. In order to distinguish static libraries from DLL import libraries, when the compiler searches for a library `foo.lib` in a given directory, `foo-static.lib` will be attempted first while linking statically, and `foo-dynamic.lib` will be attempted first while linking dynamically. The official Windows packages are distributed with both static and DLL import libraries for all third-party dependencies, except for LLVM.
+In order to distinguish static libraries from DLL import libraries, when the compiler searches for a library `foo.lib` in a given directory, `foo-static.lib` will be attempted first while linking statically, and `foo-dynamic.lib` will be attempted first while linking dynamically. The official Windows MSVC packages are distributed with both static and DLL import libraries for all third-party dependencies, except for LLVM, which is only available as an import library.
 
-Static linking implies using the static version of Microsoft's C runtime library (`/MT`), and dynamic linking implies the dynamic version (`/MD`); extra C libraries should be built with this in mind to avoid linker warnings about mixing CRT versions. There is currently no way to use the dynamic CRT while linking statically.
+Static linking implies using the static version of Microsoft's Universal C Runtime (`/MT`), and dynamic linking implies the dynamic version (`/MD`); extra C libraries should be built with this in mind to avoid linker warnings about mixing CRT versions. There is currently no way to use the dynamic CRT while linking statically.
 
 ## Identifying Static Dependencies
 

--- a/docs/syntax_and_semantics/compile_time_flags.md
+++ b/docs/syntax_and_semantics/compile_time_flags.md
@@ -153,7 +153,6 @@ These flags enable or disable compiler features when building a Crystal program.
 |-----------|-------------|
 | `no_number_autocast` | Will not [autocast](autocasting.md#number-autocasting) numeric expressions, only literals |
 | `no_restrictions_augmenter` | Disable enhanced restrictions augmenter. Introduced in 1.5 ([#12103](https://github.com/crystal-lang/crystal/pull/12103)).
-| `preview_dll` | Enable dynamic linking on Windows; experimental |
 | `preview_overload_order` | Enable more robust ordering between def overloads. Introduced in 1.6 ([#10711](https://github.com/crystal-lang/crystal/issues/10711)).
 | `preview_win32_delay_load` | Delay-load all DLLs on Windows; experimental |
 | `strict_multi_assign` | Enable strict semantics for [one-to-many assignment](assignment.md#one-to-many-assignment). Introduced in 1.3.0 ([#11145](https://github.com/crystal-lang/crystal/pull/11145), [#11545](https://github.com/crystal-lang/crystal/pull/11545))


### PR DESCRIPTION
Dynamic linking has been the default for MSVC since Crystal 1.12.0 (crystal-lang/crystal#14292).