### PR TITLE
[CI] Refactor `Validate Flags` workflow

### DIFF
--- a/.github/workflows/validate-content.yml
+++ b/.github/workflows/validate-content.yml
@@ -1,8 +1,14 @@
 name: Validate content
 on:
   push:
+    paths:
+    - docs/syntax_and_semantics/compile_time_flags.md
+    - .github/workflows/validate-content.yml
   pull_request:
     branches: [master, release/*]
+    paths:
+    - docs/syntax_and_semantics/compile_time_flags.md
+    - .github/workflows/validate-content.yml
   schedule:
     - cron: '0 5 * * 1'  # Every Monday 5 AM UTC
 

--- a/.github/workflows/validate-content.yml
+++ b/.github/workflows/validate-content.yml
@@ -23,6 +23,8 @@ jobs:
         uses: crystal-lang/install-crystal@v1
         with:
           crystal: nightly
+      - run: echo "${{ github.base_ref }}"
+      - run: echo "${{ startsWith(github.base_ref, 'release/') }}"
       - name: Download crystal repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/validate-content.yml
+++ b/.github/workflows/validate-content.yml
@@ -24,5 +24,12 @@ jobs:
         uses: crystal-lang/install-crystal@v1
         with:
           crystal: nightly
+      - name: Download crystal repo
+        uses: actions/checkout@v4
+        with:
+          repository: crystal-lang/crystal
+          path: crystal
       - name: Run test script
         run: scripts/validate-flags.sh
+        env:
+          STDLIB_SRC: ./crystal/src

--- a/.github/workflows/validate-content.yml
+++ b/.github/workflows/validate-content.yml
@@ -23,8 +23,6 @@ jobs:
         uses: crystal-lang/install-crystal@v1
         with:
           crystal: nightly
-      - run: echo "${{ github.base_ref }}"
-      - run: echo "${{ startsWith(github.base_ref, 'release/') }}"
       - name: Download crystal repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/validate-content.yml
+++ b/.github/workflows/validate-content.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           repository: crystal-lang/crystal
           path: crystal
+          # If the PR goes against a release branch, we checkout that same release
+          # branch in the Crystal repo (names are identical).
+          ref: ${{ (startsWith(github.base_ref, 'release/') && github.base_ref) || 'master' }}
       - name: Run test script
         run: scripts/validate-flags.sh
         env:

--- a/.github/workflows/validate-content.yml
+++ b/.github/workflows/validate-content.yml
@@ -9,14 +9,7 @@ on:
 jobs:
   validate-flags:
     name: Validate flags
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-          - os: macos-latest
-          - os: windows-latest
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Download source
         uses: actions/checkout@v4

--- a/scripts/validate-flags.sh
+++ b/scripts/validate-flags.sh
@@ -3,8 +3,12 @@
 set -eu
 
 CRYSTAL=${CRYSTAL:-crystal}
-CRYSTAL_PATH="$($CRYSTAL env CRYSTAL_PATH)"
-STDLIB_SRC="${CRYSTAL_PATH#*:}" # stdlib source directory is the last entry in CRYSTAL_PATH
+if [ -z "${STDLIB_SRC-}" ]; then
+  CRYSTAL_PATH="$($CRYSTAL env CRYSTAL_PATH)"
+  STDLIB_SRC="${CRYSTAL_PATH#*:}" # stdlib source directory is the last entry in CRYSTAL_PATH
+fi
+
+echo "Validating flags for stdlib source ${STDLIB_SRC} ($(cat "${STDLIB_SRC}/VERSION"))"
 
 filter_missing() {
   missing=0

--- a/scripts/validate-flags.sh
+++ b/scripts/validate-flags.sh
@@ -1,6 +1,6 @@
-#! /bin/sh
+#! /bin/bash
 
-set -eu
+set -eu -o pipefail
 
 CRYSTAL=${CRYSTAL:-crystal}
 if [ -z "${STDLIB_SRC-}" ]; then


### PR DESCRIPTION
* Check out the Crystal repo associated with the target branch (`release/1.14` for `release/1.14`).
* Run workflow only on `ubuntu-latest`. There's no reason to run this on different platforms. `crystal tool flags` operates on the raw source code and does not take platform differences into account.
* Run workflow only when `docs/syntax_and_semantics/compile_time_flags.md` is changed to avoid noise in unrelated PRs