### PR TITLE
`crystal tool format` with Crystal 1.15.0-dev

### DIFF
--- a/docs/syntax_and_semantics/annotations/README.md
+++ b/docs/syntax_and_semantics/annotations/README.md
@@ -38,7 +38,7 @@ end
 
 def method2(
   @[MyAnnotation]
-  bar
+  bar,
 )
 end
 

--- a/docs/syntax_and_semantics/block_forwarding.md
+++ b/docs/syntax_and_semantics/block_forwarding.md
@@ -49,7 +49,7 @@ end
 Or, combining the `&` and `->` syntaxes:
 
 ```crystal
-twice &->{ puts "Hello" }
+twice &-> { puts "Hello" }
 ```
 
 Or:

--- a/docs/syntax_and_semantics/c_bindings/callbacks.md
+++ b/docs/syntax_and_semantics/c_bindings/callbacks.md
@@ -99,7 +99,7 @@ lib LibFoo
   fun execute_callback
 end
 
-LibFoo.store_callback ->{ raise "OH NO!" }
+LibFoo.store_callback -> { raise "OH NO!" }
 LibFoo.execute_callback
 ```
 

--- a/docs/syntax_and_semantics/closures.md
+++ b/docs/syntax_and_semantics/closures.md
@@ -4,7 +4,7 @@ Captured blocks and proc literals closure local variables and `self`. This is be
 
 ```crystal
 x = 0
-proc = ->{ x += 1; x }
+proc = -> { x += 1; x }
 proc.call # => 1
 proc.call # => 2
 x         # => 2
@@ -15,7 +15,7 @@ Or with a proc returned from a method:
 ```crystal
 def counter
   x = 0
-  ->{ x += 1; x }
+  -> { x += 1; x }
 end
 
 proc = counter
@@ -76,7 +76,7 @@ This also happens with regular proc literals, even if it's evident that the proc
 
 ```crystal
 x = 1
-->{ x = "hello" }
+-> { x = "hello" }
 
 x = 'a'
 x # : Int32 | String | Char

--- a/docs/syntax_and_semantics/default_values_named_arguments_splats_tuples_and_overloading.md
+++ b/docs/syntax_and_semantics/default_values_named_arguments_splats_tuples_and_overloading.md
@@ -22,7 +22,7 @@ def foo(
   # These are the named parameters:
   a, b, c = 2,
   # This is the double splat parameter:
-  **options
+  **options,
 )
 end
 ```

--- a/docs/syntax_and_semantics/if_var.md
+++ b/docs/syntax_and_semantics/if_var.md
@@ -47,7 +47,7 @@ if @@a
 end
 
 a = nil
-closure = ->{ a = "foo" }
+closure = -> { a = "foo" }
 
 if a
   # here `a` can be nil

--- a/docs/syntax_and_semantics/literals/proc.md
+++ b/docs/syntax_and_semantics/literals/proc.md
@@ -4,7 +4,7 @@ A [Proc](https://crystal-lang.org/api/Proc.html) represents a function pointer w
 
 ```crystal
 # A proc without parameters
-->{ 1 } # Proc(Int32)
+-> { 1 } # Proc(Int32)
 
 # A proc with one parameter
 ->(x : Int32) { x.to_s } # Proc(Int32, String)

--- a/docs/syntax_and_semantics/type_restrictions.md
+++ b/docs/syntax_and_semantics/type_restrictions.md
@@ -324,5 +324,5 @@ end
 
 foo(->(x : Int32, y : Int32) { x + y }) # => Tuple(Int32, Int32)
 foo(->(x : Bool) { x ? 1 : 0 })         # => Tuple(Bool)
-foo(->{ 1 })                            # => Tuple()
+foo(-> { 1 })                           # => Tuple()
 ```


### PR DESCRIPTION
Crystal nightly has a couple new formatter rules enabled: https://github.com/crystal-lang/crystal/pull/14718
The changes are backwards-compatible, so Crystal 1.14.0 won't complain about the new format.