### PR TITLE
Add `format_code_blocks`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ clean_all: clean clean_vendor
 format_api_docs_links:
 	echo $(DOCS_FILES) | xargs sed -i -E -e 's@\bhttps?://(www\.)?crystal-lang\.org/api/([0-9]+(\.[0-9]+)+|latest|master)/([^ )]+\.html)\b@https://crystal-lang.org/api/\4@g'
 
+.PHONY: format_code_blocks
+format_code_blocks:
+	NO_COLOR=1 LINT=true make clean build 2>&1 | ./scripts/format-code-blocks.cr
+
 .PHONY: help
 help: ## Show this help
 	@echo

--- a/scripts/format-code-block.cr
+++ b/scripts/format-code-block.cr
@@ -1,0 +1,23 @@
+#!/usr/bin/env crystal
+#
+# This script parses output from `mkdocs build --strict` to find ill-formatted
+# code blocks and applies the updated formatting (from the formatter STDOUT).
+
+io = STDIN
+docs_path = Path["docs"]
+
+loop do
+  line = io.gets || exit
+  line.starts_with?("WARNING -  In file") || next
+  filename = line[/(?<=')[^']+(?=')/]? || next
+  filename = docs_path / filename
+
+  io.gets # skip -------- Input --------
+
+  input = IO::Delimited.new(io, "\n-------- Output --------\n").gets_to_end
+  output = IO::Delimited.new(io, "formatting 'STDIN' produced changes\n").gets_to_end
+
+  original_content = File.read(filename)
+  content = original_content.sub input, output
+  File.write(filename, content)
+end


### PR DESCRIPTION
Adds a script that parses output from `mkdocs build --strict` to find ill-formatted code blocks and apply the updated formatting (from the formatter STDOUT).

This was used to create #794