### PR TITLE
Add latest versions of libraries from repology

### DIFF
--- a/docs/man/required_libraries.md
+++ b/docs/man/required_libraries.md
@@ -15,23 +15,23 @@ which may be part of the C library or standalone libraries. On most platforms al
 
 | Library | Description | License |
 |---------|-------------|---------|
-| [glibc][glibc] | standard C library for Linux <br>**Supported versions:** GNU libc 2.26+ | [LGPL](https://www.gnu.org/licenses/lgpl-3.0.en.html) |
-| [musl libc][musl-libc] | standard C library for Linux <br>**Supported versions:** MUSL libc 1.2+ | [MIT](https://git.musl-libc.org/cgit/musl/tree/COPYRIGHT) |
-| [FreeBSD libc][freebsd-libc] | standard C library for FreeBSD <br>**Supported versions:** 12+ | [BSD](https://www.freebsd.org/copyright/freebsd-license/) |
+| [glibc][glibc] | standard C library for Linux <br>**Supported versions:** GNU libc 2.26+ [![latest packaged version(s)](https://repology.org/badge/latest-versions/glibc.svg?header=latest)](https://repology.org/project/glibc/versions) | [LGPL](https://www.gnu.org/licenses/lgpl-3.0.en.html) |
+| [musl libc][musl-libc] | standard C library for Linux <br>**Supported versions:** MUSL libc 1.2+ [![latest packaged version(s)](https://repology.org/badge/latest-versions/musl.svg?header=latest)](https://repology.org/project/musl/versions) | [MIT](https://git.musl-libc.org/cgit/musl/tree/COPYRIGHT) |
+| [FreeBSD libc][freebsd-libc] | standard C library for FreeBSD <br>**Supported versions:** 12+ [![latest packaged version(s)](https://repology.org/badge/latest-versions/freebsd.svg?header=latest)](https://repology.org/project/freebsd/versions) | [BSD](https://www.freebsd.org/copyright/freebsd-license/) |
 | [NetBSD libc][netbsd-libc] | standard C library for NetBSD | [BSD](http://www.netbsd.org/about/redistribution.html) |
-| [OpenBSD libc][openbsd-libc] | standard C library for OpenBSD <br>**Supported versions:** 6+ | [BSD](https://www.openbsd.org/policy.html) |
+| [OpenBSD libc][openbsd-libc] | standard C library for OpenBSD <br>**Supported versions:** 6+ [![latest packaged version(s)](https://repology.org/badge/latest-versions/openbsd.svg?header=latest)](https://repology.org/project/openbsd/versions) | [BSD](https://www.openbsd.org/policy.html) |
 | [Dragonfly libc][dragonfly-libc] | standard C library for DragonflyBSD | [BSD](https://www.dragonflybsd.org/docs/developer/DragonFly_BSD_License/) |
 | [macOS libsystem][macos-libsystem] | standard C library for macOS <br>**Supported versions:** 11+ | [Apple](https://github.com/apple-oss-distributions/Libsystem/blob/main/APPLE_LICENSE) |
 | [MSVCRT][msvcrt] | standard C library for MSVC compiler (Windows) | |
-| [WASI][wasi] | WebAssembly System Interface | [Apache v2 and others](https://github.com/WebAssembly/wasi-libc/blob/main/LICENSE) |
+| [WASI][wasi] | WebAssembly System Interface <br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/wasi-libc.svg?header=latest)](https://repology.org/project/wasi-libc/versions) | [Apache v2 and others](https://github.com/WebAssembly/wasi-libc/blob/main/LICENSE) |
 | [bionic libc][bionic-libc] | C library for Android | [BSD-like](https://android.googlesource.com/platform/bionic/+/refs/heads/master/libc/NOTICE) |
 
 ### Other runtime libraries
 
 | Library | Description | License |
 |---------|-------------|---------|
-| [Boehm GC][libgc] | The Boehm-Demers-Weiser conservative garbage collector. Performs automatic memory management.<br>**Supported versions:** 8.2.0+; earlier versions require a patch for MT support | [MIT-style](https://github.com/ivmai/bdwgc/blob/master/LICENSE) |
-| [Libevent][libevent] | An event notification library. Implements concurrency features such as [`Fiber`](https://crystal-lang.org/api/Fiber.html) and the event loop on POSIX platforms. Not used on Windows. | [Modified BSD](https://github.com/libevent/libevent/blob/master/LICENSE) |
+| [Boehm GC][libgc] | The Boehm-Demers-Weiser conservative garbage collector. Performs automatic memory management.**Supported versions:** 8.2.0+; earlier versions require a patch for MT support <br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/boehm-gc.svg?header=latest)](https://repology.org/project/boehm-gc/versions) | [MIT-style](https://github.com/ivmai/bdwgc/blob/master/LICENSE) |
+| [Libevent][libevent] | An event notification library. Implements concurrency features such as [`Fiber`](https://crystal-lang.org/api/Fiber.html) and the event loop on POSIX platforms. Not used on Windows. <br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/llvm.svg?header=latest)](https://repology.org/project/llvm/versions) | [Modified BSD](https://github.com/libevent/libevent/blob/master/LICENSE) |
 | [compiler-rt builtins][compiler-rt] | Provides optimized implementations for low-level routines required by code generation, such as integer multiplication. Several of these routines are ported to Crystal directly. | [MIT / UIUC][compiler-rt] |
 
 ## Optional standard library dependencies
@@ -45,8 +45,8 @@ PCRE2 support was added in Crystal 1.7 and it's the default since 1.8 (see [Rege
 
 | Library | Description | License |
 |---------|-------------|---------|
-| [PCRE2][libpcre] | Perl Compatible Regular Expressions, version 2.<br>**Supported versions:** all (recommended: 10.36+) | [BSD](http://www.pcre.org/licence.txt) |
-| [PCRE][libpcre] | Perl Compatible Regular Expressions. | [BSD](http://www.pcre.org/licence.txt) |
+| [PCRE2][libpcre] | Perl Compatible Regular Expressions, version 2.<br>**Supported versions:** all (recommended: 10.36+) <br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/pcre2.svg?header=latest)](https://repology.org/project/pcre2/versions) | [BSD](http://www.pcre.org/licence.txt) |
+| [PCRE][libpcre] | Perl Compatible Regular Expressions. [![latest packaged version(s)](https://repology.org/badge/latest-versions/pcre.svg?header=latest)](https://repology.org/project/pcre/versions) | [BSD](http://www.pcre.org/licence.txt) |
 
 ### Big Numbers
 
@@ -54,8 +54,8 @@ Implementations for `Big` types such as [`BigInt`](https://crystal-lang.org/api/
 
 | Library | Description | License |
 |---------|-------------|---------|
-| [GMP][libgmp] | GNU multiple precision arithmetic library. | [LGPL v3+ / GPL v2+](https://gmplib.org/manual/Copying) |
-| [MPIR][libmpir] | Multiple Precision Integers and Rationals, forked from GMP. Used on Windows. | [GPL-3.0](https://github.com/wbhart/mpir/blob/master/COPYING) and [LGPL-3.0](https://github.com/wbhart/mpir/blob/master/COPYING.LIB) |
+| [GMP][libgmp] | GNU multiple precision arithmetic library. <br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/gmp.svg?header=latest)](https://repology.org/project/gmp/versions) | [LGPL v3+ / GPL v2+](https://gmplib.org/manual/Copying) |
+| [MPIR][libmpir] | Multiple Precision Integers and Rationals, forked from GMP. Used on Windows. <br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/mpir.svg?header=latest)](https://repology.org/project/mpir/versions) | [GPL-3.0](https://github.com/wbhart/mpir/blob/master/COPYING) and [LGPL-3.0](https://github.com/wbhart/mpir/blob/master/COPYING.LIB) |
 
 ### Internationalization conversion
 
@@ -64,7 +64,7 @@ Using a standalone library over the system library implementation can be enforce
 
 | Library | Description | License |
 |---------|-------------|---------|
-| [libiconv][libiconv-gnu] (GNU) | Internationalization conversion library. | [LGPL-3.0](https://www.gnu.org/licenses/lgpl.html) |
+| [libiconv][libiconv-gnu] (GNU) | Internationalization conversion library. <br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/libiconv.svg?header=latest)](https://repology.org/project/libiconv/versions) | [LGPL-3.0](https://www.gnu.org/licenses/lgpl.html) |
 
 ### TLS
 
@@ -74,17 +74,17 @@ Both `OpenSSL` and `LibreSSL` are supported and the bindings automatically detec
 
 | Library | Description | License |
 |---------|-------------|---------|
-| [OpenSSL][openssl] | Implementation of the SSL and TLS protocols <br>**Supported versions:** 1.1.0+–3.3+ | [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)](https://www.openssl.org/source/license.html) |
-| [LibreSSL][libressl] | Implementation of the SSL and TLS protocols; forked from OpenSSL in 2014 <br>**Supported versions:** 2.0–4.0+ | [ISC / OpenSSL / SSLeay](https://github.com/libressl-portable/openbsd/blob/master/src/lib/libssl/LICENSE) |
+| [OpenSSL][openssl] | Implementation of the SSL and TLS protocols <br>**Supported versions:** 1.1.0+–3.3+ [![latest packaged version(s)](https://repology.org/badge/latest-versions/openssl.svg?header=latest)](https://repology.org/project/openssl/versions) | [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)](https://www.openssl.org/source/license.html) |
+| [LibreSSL][libressl] | Implementation of the SSL and TLS protocols; forked from OpenSSL in 2014 <br>**Supported versions:** 2.0–4.0+ [![latest packaged version(s)](https://repology.org/badge/latest-versions/libressl.svg?header=latest)](https://repology.org/project/libressl/versions) | [ISC / OpenSSL / SSLeay](https://github.com/libressl-portable/openbsd/blob/master/src/lib/libssl/LICENSE) |
 
 ### Other stdlib libraries
 
 | Library | Description | License |
 |---------|-------------|---------|
-| [LibXML2][libxml2] | XML parser developed for the Gnome project. Implements the [`XML`](https://crystal-lang.org/api/XML.html) module. | [MIT](https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/Copyright) |
-| [LibYAML][libyaml] | YAML parser and emitter library. Implements the [`YAML`](https://crystal-lang.org/api/YAML.html) module. | [MIT](https://github.com/yaml/libyaml/blob/master/License) |
-| [zlib][zlib] | Lossless data compression library. Implements the [`Compress`](https://crystal-lang.org/api/Compress.html) module. May be disabled with the `-Dwithout_zlib` compile-time flag. | [zlib](http://zlib.net/zlib_license.html) |
-| [LLVM][libllvm] | Target-independent code generator and optimizer. Implements the [`LLVM`](https://crystal-lang.org/api/LLVM.html) API. <br>**Supported versions:** LLVM 8-19 (aarch64 requires LLVM 13+) | [Apache v2 with LLVM exceptions](https://llvm.org/docs/DeveloperPolicy.html#new-llvm-project-license-framework) |
+| [LibXML2][libxml2] | XML parser developed for the Gnome project. Implements the [`XML`](https://crystal-lang.org/api/XML.html) module. <br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/libxml2.svg?header=latest)](https://repology.org/project/libxml2/versions) | [MIT](https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/Copyright) |
+| [LibYAML][libyaml] | YAML parser and emitter library. Implements the [`YAML`](https://crystal-lang.org/api/YAML.html) module. <br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/libyaml.svg?header=latest)](https://repology.org/project/libyaml/versions) | [MIT](https://github.com/yaml/libyaml/blob/master/License) |
+| [zlib][zlib] | Lossless data compression library. Implements the [`Compress`](https://crystal-lang.org/api/Compress.html) module. May be disabled with the `-Dwithout_zlib` compile-time flag. <br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/zlib.svg?header=latest)](https://repology.org/project/zlib/versions) | [zlib](http://zlib.net/zlib_license.html) |
+| [LLVM][libllvm] | Target-independent code generator and optimizer. Implements the [`LLVM`](https://crystal-lang.org/api/LLVM.html) API. <br>**Supported versions:** LLVM 8-19 (aarch64 requires LLVM 13+) [![latest packaged version(s)](https://repology.org/badge/latest-versions/llvm.svg?header=latest)](https://repology.org/project/llvm/versions)| [Apache v2 with LLVM exceptions](https://llvm.org/docs/DeveloperPolicy.html#new-llvm-project-license-framework) |
 
 ## Compiler dependencies
 
@@ -94,7 +94,7 @@ In addition to the [core runtime dependencies](#core-runtime-dependencies), thes
 |---------|-------------|---------|
 | [PCRE2][libpcre] | See above. | |
 | [LLVM][libllvm] | See above. | [Apache v2 with LLVM exceptions](https://llvm.org/docs/DeveloperPolicy.html#new-llvm-project-license-framework) |
-| [libffi][libffi] | Foreign function interface. Used for implementing binary interfaces in the interpreter. May be disabled with the `-Dwithout_interpreter` compile-time flag. | [MIT](https://github.com/libffi/libffi/blob/master/LICENSE) |
+| [libffi][libffi] | Foreign function interface. Used for implementing binary interfaces in the interpreter. May be disabled with the `-Dwithout_interpreter` compile-time flag. <br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/libffi.svg?header=latest)](https://repology.org/project/libffi/versions) | [MIT](https://github.com/libffi/libffi/blob/master/LICENSE) |
 
 [bionic-libc]: https://android.googlesource.com/platform/bionic/+/refs/heads/master/libc/
 [compiler-rt]: https://compiler-rt.llvm.org/


### PR DESCRIPTION
For many libraries we're already tracking which versions we support. This PR adds in the most recent version of each project from repology, for comparison.
The main purpose is as an internal to keep this page up to date. I suppose it als provides useful value to readers though.
Alternatively, we could consider arranging the repologoy references somehow else without exposing the publicly.

I suppose a downside is when looking at older versions of this page, the repology versions will still point to the current most recent ones, which could create the illusion that our supported version ranges were dragging behind, even though they might've been very much up to date at the time of release. I don't think this is a major issue though, just wanted to mention it.