### PR TITLE
Add the missing `previous_def` keyword into "Available keywords" section.

### DIFF
--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -382,16 +382,16 @@ Crystal added some new keywords, these can still be used as method names, but ne
 #### Available keywords
 
 ```text
-abstract   do       if                nil?           select          union
-alias      else     in                of             self            unless
-as         elsif    include           out            sizeof          until
-as?        end      instance_sizeof   pointerof      struct          verbatim
-asm        ensure   is_a?             private        super           when
-begin      enum     lib               protected      then            while
-break      extend   macro             require        true            with
-case       false    module            rescue         type            yield
-class      for      next              responds_to?   typeof
-def        fun      nil               return         uninitialized
+abstract   do       if                nil?            return      uninitialized
+alias      else     in                of              select      union
+as         elsif    include           out             self        unless
+as?        end      instance_sizeof   pointerof       sizeof      until
+asm        ensure   is_a?             previous_def    struct      verbatim
+begin      enum     lib               private         super       when
+break      extend   macro             protected       then        while
+case       false    module            require         true        with
+class      for      next              rescue          type        yield
+def        fun      nil               responds_to?    typeof
 ```
 
 ### Private methods


### PR DESCRIPTION
The `previous_def` keyword was missing in the [Available keywords](https://crystal-lang.org/reference/1.14/crystal_for_rubyists/index.html#available-keywords) section.

There are the sources where this keyword was used :
- https://crystal-lang.org/reference/1.14/syntax_and_semantics/methods_and_instance_variables.html#redefining-methods-and-previous_def
- https://crystal-lang.org/reference/1.14/crystal_for_rubyists/metaprogramming_help.html#crystal-approach-to-alias_method