### PR TITLE
Fix markdown escape pipe character in table cell

### DIFF
--- a/docs/syntax_and_semantics/operators.md
+++ b/docs/syntax_and_semantics/operators.md
@@ -120,14 +120,14 @@ ones.
 | Additive | `+`, `&+`, `-`, `&-` |
 | Shift | `<<`, `>>` |
 | Binary AND | `&` |
-| Binary OR/XOR | `\|`,`^` |
+| Binary OR/XOR | <code>\|</code>,`^` |
 | Equality and Subsumption | `==`, `!=`, `=~`, `!~`, `===` |
 | Comparison | `<`, `<=`, `>`, `>=`, `<=>` |
 | Logical AND | `&&` |
-| Logical OR | `\|\|` |
+| Logical OR | <code>\|\|</code> |
 | Range | `..`, `...` |
 | Conditional | `?:` |
-| Assignment | `=`, `[]=`, `+=`, `&+=`, `-=`, `&-=`, `*=`, `&*=`, `/=`, `//=`, `%=`, `\|=`, `&=`,`^=`,`**=`,`<<=`,`>>=`, `\|\|=`, `&&=` |
+| Assignment | `=`, `[]=`, `+=`, `&+=`, `-=`, `&-=`, `*=`, `&*=`, `/=`, `//=`, `%=`, <code>\|=</code>, `&=`,`^=`,`**=`,`<<=`,`>>=`, <code>\|\|=</code>, `&&=` |
 | Splat | `*`, `**` |
 
 <!-- markdownlint-enable no-space-in-code -->
@@ -185,7 +185,7 @@ ones.
 | Operator | Description | Example | Overloadable | Associativity |
 |---|---|---|---|---|
 | `&` | binary AND | `1 & 2` | yes | left |
-| `\|` | binary OR | `1 \| 2` | yes | left |
+| <code>\|</code> | binary OR | <code>1 \| 2</code> | yes | left |
 | `^` | binary XOR | `1 ^ 2` | yes | left |
 
 ### Relational operators
@@ -283,7 +283,7 @@ For instance, `a == b <= c` is equivalent to `a == b && b <= c`, while `a <= b =
 | Operator | Description | Example | Overloadable | Associativity |
 |---|---|---|---|---|
 | `&&` | [logical AND](and.md) | `true && false` | no | left |
-| `\|\|` | [logical OR](or.md) | `true \|\| false` | no | left |
+| <code>\|\|</code> | [logical OR](or.md) | <code>true \|\| false</code> | no | left |
 
 ### Range
 
@@ -362,13 +362,13 @@ The receiver can't be anything else than a variable or call.
 | `/=` | division *and* assignment | `i /= 1` | no | right |
 | `//=` | floor division *and* assignment | `i //= 1` | no | right |
 | `%=` | modulo *and* assignment | `i %= 1` | yes | right |
-| `\|=` | binary or *and* assignment | `i \|= 1` | no | right |
+| <code>\|=</code> | binary or *and* assignment | <code>i \|= 1</code> | no | right |
 | `&=` | binary and *and* assignment | `i &= 1` | no | right |
 | `^=` | binary xor *and* assignment | `i ^= 1` | no | right |
 | `**=` | exponential *and* assignment | `i **= 1` | no | right |
 | `<<=` | left shift *and* assignment | `i <<= 1` | no | right |
 | `>>=` | right shift *and* assignment | `i >>= 1` | no | right |
-| `\|\|=` | logical or *and* assignment | `i \|\|= true` | no | right |
+| <code>\|\|=</code> | logical or *and* assignment | <code>i \|\|= true</code> | no | right |
 | `&&=` | logical and *and* assignment | `i &&= true` | no | right |
 
 ### Index Accessors


### PR DESCRIPTION
There is some disagreement between Markdown parsers about escaping pipe characters (`|`) inside a table cell. Python-markdown, which is used by our site generator mkdocs, considers a pipe inside a code span as escaped (`` `|` ``) (https://github.com/Python-Markdown/markdown/issues/436). Most other Markdown parsers, including ones used in tooling (such as markdownlint) require explicit escaping (`` `\|` ``). Python-markdown would render the backslash:

![grafik](https://github.com/user-attachments/assets/5e58f743-aa5d-47c4-a916-f54ee2d7bd38)

This is a known interoperability issue based on different implementations of a Markdown parser (https://github.com/mkdocs/mkdocs/issues/2761). There's no expectation for this to get fixed somewhow, so we can only apply a workaround to use code that different parsers agree upon: This patch replaces backticks with HTML `<code>` tags, for which all parsers require escaping the pipe character.

