### PR TITLE
Fix typos

### DIFF
--- a/docs/guides/hosting/gitlab.md
+++ b/docs/guides/hosting/gitlab.md
@@ -82,7 +82,7 @@ A badge is just a link with an image. So let's create a link to our pipeline and
 
 In the *Badges* section of the *General* settings, we'll first add a release badge. The link is: `https://gitlab.com/<YOUR-GITLAB-USERNAME>/<YOUR-REPOSITORY-NAME>/pipelines` and the *Badge Image URL* is: `https://gitlab.com/<YOUR-GITLAB-USERNAME>/<YOUR-REPOSITORY-NAME>/badges/master/pipeline.svg`.
 
-And now if the pipleline has finished we'll have docs and we can link to them with a generic badge from `shields.io`.
+And now if the pipeline has finished we'll have docs and we can link to them with a generic badge from `shields.io`.
 
 * Link: `https://<YOUR-GITLAB-USERNAME>.gitlab.io/<YOUR-REPOSITORY-NAME>`
 * Image: `https://img.shields.io/badge/docs-available-brightgreen.svg`

--- a/docs/project/release-policy.md
+++ b/docs/project/release-policy.md
@@ -25,7 +25,7 @@ As a result, migrating to a new minor release is usually seamless.
 Although we expect the vast majority of programs to remain compatible over time,
 it is impossible to guarantee that no future change will break any program.
 Under some unlikely circumstances, we may introduce changes that break existing code.
-Rest assured we are commited to keep the impact as minimal as possible.
+Rest assured we are committed to keep the impact as minimal as possible.
 
 * Security: a security issue in the implementation may arise whose resolution requires backwards incompatible changes. We reserve the right to address such security issues.
 

--- a/docs/syntax_and_semantics/annotations/README.md
+++ b/docs/syntax_and_semantics/annotations/README.md
@@ -14,7 +14,7 @@ The annotation can then be applied to various items, including:
 * Instance and class methods
 * Instance variables
 * Classes, structs, enums, and modules
-* Method and macro parameters (though the latter are currently unaccessable)
+* Method and macro parameters (though the latter are currently inaccessible)
 
 ```crystal
 annotation MyAnnotation
@@ -65,7 +65,7 @@ An annotation could be used to designate a property as an ORM column. The name a
 Data can be stored within an annotation.
 
 ```crystal
-annotation MyAnnotaion
+annotation MyAnnotation
 end
 
 # The fields can either be a key/value pair

--- a/docs/syntax_and_semantics/literals/string.md
+++ b/docs/syntax_and_semantics/literals/string.md
@@ -162,7 +162,7 @@ In this case, leading whitespace is not included in the resulting string.
 ## Heredoc
 
 A *here document* or *heredoc* can be useful for writing strings spanning over multiple lines.
-A heredoc is denoted by `<<-` followed by an heredoc identifier which is an alphanumeric sequence starting with a letter (and may include underscores). The heredoc starts in the following line and ends with the next line that contains *only* the heredoc identifier, optionally preceeded by whitespace.
+A heredoc is denoted by `<<-` followed by an heredoc identifier which is an alphanumeric sequence starting with a letter (and may include underscores). The heredoc starts in the following line and ends with the next line that contains *only* the heredoc identifier, optionally preceded by whitespace.
 
 ```crystal
 <<-XML

--- a/docs/syntax_and_semantics/operators.md
+++ b/docs/syntax_and_semantics/operators.md
@@ -36,7 +36,7 @@ A few operators are defined directly by the compiler and cannot be redefined
 in user code. Examples for this are the inversion operator `!`, the assignment
 operator `=`, [combined assignment operators](#combined-assignments) such as
 `||=` and [range operators](#range). Whether a method can be redefined is
-indicated by the colum *Overloadable* in the below operator tables.
+indicated by the column *Overloadable* in the below operator tables.
 
 ### Unary operators
 

--- a/docs/syntax_and_semantics/platform_support.md
+++ b/docs/syntax_and_semantics/platform_support.md
@@ -30,7 +30,7 @@ and drop into *Tier 2*.
 
 Tier 2 platforms can be thought of as “expected to work”.
 
-The requirements for *Tier 1* may be partially fulfilled, but are lacking in some way that prevents a solid gurantee.
+The requirements for *Tier 1* may be partially fulfilled, but are lacking in some way that prevents a solid guarantee.
 Details are described in the *Comment* column.
 
 | Target | Description | Supported versions | Comment |
@@ -81,4 +81,4 @@ The compiler can target these platforms but there is no support for the standard
 
 !!! note
     Big thanks go to the Rust team for putting together such a clear [document on Rust's platform support](https://forge.rust-lang.org/platform-support.html)
-    that we used as insipration for ours.
+    that we used as inspiration for ours.


### PR DESCRIPTION
Corrected spelling errors in multiple markdown files including:

  - docs/syntax\_and\_semantics/operators.md (colum → column)
  - docs/project/release-policy.md (commited → committed)
  - docs/syntax\_and\_semantics/platform\_support.md (gurantee → guarantee, insipration → inspiration)
  - docs/guides/hosting/gitlab.md (pipleline → pipeline)
  - docs/syntax\_and\_semantics/literals/string.md (preceeded → preceded)
  - docs/syntax\_and\_semantics/annotations/README.md (Annotaion → Annotation, unaccessable → inaccessible)
