### PR TITLE
Bump support for `aarch64-windows-gnu`

### DIFF
--- a/docs/syntax_and_semantics/platform_support.md
+++ b/docs/syntax_and_semantics/platform_support.md
@@ -57,7 +57,7 @@ Most typically, some parts of the standard library are not supported completely.
 | `x86_64-windows-msvc` | x64 Windows (MSVC) | 7+ | :material-circle-slice-7: tests<br> :material-checkbox-marked-circle: builds |
 | `x86_64-windows-gnu` | x64 Windows (MinGW-w64) | 7+, MSYS2 `UCRT64` / `MINGW64` / `CLANG64` environment | :material-circle-slice-7: tests<br> :material-checkbox-marked-circle: builds |
 | `aarch64-windows-msvc` | ARM64 Windows (MSVC) | 11+ | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds |
-| `aarch64-windows-gnu` | ARM64 Windows (MinGW-w64) | 11+, MSYS2 `CLANGARM64` environment | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds |
+| `aarch64-windows-gnu` | ARM64 Windows (MinGW-w64) | 11+, MSYS2 `CLANGARM64` environment | :material-circle-slice-7: tests<br> :material-checkbox-marked-circle: builds |
 | `aarch64-linux-android` | aarch64 Android  | Bionic C runtime, API level 24+ | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds |
 | `x86_64-unknown-dragonfly` | x64 DragonFlyBSD | | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds |
 | `x86_64-unknown-netbsd` | x64 NetBSD | | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds |


### PR DESCRIPTION
Since crystal-lang/crystal#15794, we're running tests on `aarch64-windows-gnu` and produce release builds