### PR TITLE
Fix use valid regex literals in example

### DIFF
--- a/docs/syntax_and_semantics/literals/regex.md
+++ b/docs/syntax_and_semantics/literals/regex.md
@@ -28,8 +28,8 @@ Regular expressions support the same [escape sequences as String literals](./str
 /\r/         # carriage return
 /\t/         # tab
 /\v/         # vertical tab
-/\NNN/       # octal ASCII character
-/\xNN/       # hexadecimal ASCII character
+/\N88/       # octal ASCII character
+/\xFF/       # hexadecimal ASCII character
 /\x{FFFF}/   # hexadecimal unicode character
 /\x{10FFFF}/ # hexadecimal unicode character
 ```


### PR DESCRIPTION
Newer versions of libpcre2 error when a regular expression contains an invalid escape sequence.
Previously this was apparently ignored.
Two examples for using escape sequences in regex literals are affected because they use a pattern-like syntax. This change replaces that with 

```cr
Regex.new("\\xNN") # ArgumentError: invalid regex: digits missing after \x or in \x{} or \o{} or \N{U+} at 2
```

Our format linter for Crystal code blocks caught this using the recent nightly builds of Crystal ([example](https://github.com/crystal-lang/crystal-book/actions/runs/18992294918/job/54247125200)).

The latest upgrade for the Crystal build image in distribution-scripts rolled out in https://github.com/crystal-lang/crystal/pull/16301 affects the recent nightly builds.
https://github.com/crystal-lang/distribution-scripts/pull/378 upgraded the base image from Alpine Linux 3.20 to 3.22 and the package repository ships with an upgrade for libpcre2 from version 10.43-r0 to 10.46-r0.
libpcre2 version 10.45 introduced this change: https://github.com/PCRE2Project/pcre2/blob/master/ChangeLog#L220