### PR TITLE
Fixed code in documenting_code.md

### DIFF
--- a/docs/syntax_and_semantics/documenting_code.md
+++ b/docs/syntax_and_semantics/documenting_code.md
@@ -248,7 +248,7 @@ lib LibFoo
   # Documentation for FooEnum
   enum FooEnum
     Member1
-    Member1
+    Member2
     Member3
   end
 


### PR DESCRIPTION
It's just the name of one of the enums that is duplicated