### PR TITLE
Remove backspace regex example

### DIFF
--- a/docs/syntax_and_semantics/literals/regex.md
+++ b/docs/syntax_and_semantics/literals/regex.md
@@ -21,7 +21,6 @@ Regular expressions support the same [escape sequences as String literals](./str
 ```crystal
 /\//         # slash
 /\\/         # backslash
-/\b/         # backspace
 /\e/         # escape
 /\f/         # form feed
 /\n/         # newline


### PR DESCRIPTION
Removed backspace regex example from documentation. \b is a word boundary in PCRE2 regular expressions.