### PR TITLE
Drop `enterShell` command from `devenv.nix`

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -1,10 +1,6 @@
 { pkgs, ... }:
 
 {
-  enterShell = ''
-    pip install -q -q --no-deps -r requirements.txt
-    '';
-
   packages = [
     pkgs.gnumake
   ];


### PR DESCRIPTION
This is unnecessary because the python language integration with `venv.enabled` already takes care of installing dependencies.