### PR TITLE
[CI] Fix lint workflow to use `prek` instead of `pre-commit`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download source
-        uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-      - uses: cachix/cachix-action@v16
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31
+        with:
+          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/e99215c1a21cab2a995a3d01fe20d5714addea27.tar.gz # nixpkgs-unstable@2026-03-06 (with devenv 2.0)
+      - uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16
         with:
           name: devenv
       - name: Install devenv.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           name: devenv
       - name: Install devenv.sh
-        run: nix profile install nixpkgs#devenv
+        run: nix profile add nixpkgs#devenv
       - run: git fetch origin ${{ github.base_ref || 'master' }}
       - run: devenv shell -- prek run --from-ref "origin/${{ github.base_ref || 'master' }}" --to-ref HEAD

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ on:
 permissions: {}
 
 jobs:
-  pre-commit:
+  prek:
     runs-on: ubuntu-latest
     steps:
       - name: Download source
@@ -23,4 +23,4 @@ jobs:
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
       - run: git fetch origin ${{ github.base_ref || 'master' }}
-      - run: devenv shell -- pre-commit run --from-ref "origin/${{ github.base_ref || 'master' }}" --to-ref HEAD
+      - run: devenv shell -- prek run --from-ref "origin/${{ github.base_ref || 'master' }}" --to-ref HEAD


### PR DESCRIPTION
Also pins actions and nixpkgs