### PR TITLE
[CI] Adapt `Lint` workflow to run full tests on infra update

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,11 +38,11 @@ jobs:
       - name: Run prek on all files
         id: run_full
         run: prek run --all-files
-        shell: devenv --profile lint shell bash -- -e {0}
+        shell: devenv shell bash -- -e {0}
         if: ${{ github.event_name == 'workflow_dispatch' || steps.test_full_run.outputs.test_full_run == 'true' }}
       - name: Run prek hooks for changes against target branch (${{ github.base_ref || 'master' }})
         run: prek run --from-ref "origin/${TARGET_BRANCH}" --to-ref HEAD
-        shell: devenv --profile lint shell bash -- -e {0}
+        shell: devenv shell bash -- -e {0}
         if: "${{ steps.run_full.outcome == 'skipped' }}"
     env:
       TARGET_BRANCH: "${{ github.base_ref || 'master' }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: Lint
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 permissions: {}
 
@@ -22,5 +23,26 @@ jobs:
           name: devenv
       - name: Install devenv.sh
         run: nix profile add nixpkgs#devenv
-      - run: git fetch origin ${{ github.base_ref || 'master' }}
-      - run: devenv shell -- prek run --from-ref "origin/${{ github.base_ref || 'master' }}" --to-ref HEAD
+      - name: "Download target branch: ${{ github.base_ref || 'master' }}"
+        run: git fetch origin "${TARGET_BRANCH}"
+      - name: Check whether to run full test on all files
+        id: test_full_run
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        run: |
+          # Trigger full run if devenv.lock or this workflow file changed
+          if git diff --quiet "origin/${TARGET_BRANCH}" HEAD -- devenv.lock .github/workflows/lint.yml; then
+            echo "test_full_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "test_full_run=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Run prek on all files
+        id: run_full
+        run: prek run --all-files
+        shell: devenv --profile lint shell bash -- -e {0}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.test_full_run.outputs.test_full_run == 'true' }}
+      - name: Run prek hooks for changes against target branch (${{ github.base_ref || 'master' }})
+        run: prek run --from-ref "origin/${TARGET_BRANCH}" --to-ref HEAD
+        shell: devenv --profile lint shell bash -- -e {0}
+        if: "${{ steps.run_full.outcome == 'skipped' }}"
+    env:
+      TARGET_BRANCH: "${{ github.base_ref || 'master' }}"


### PR DESCRIPTION
When updating the linting tools, we should run a full tests against the entire repo content.
This detects linting issues reported by new tool versions even in files that are not changed in the current diff.

Changes to `devenv.lock` may contain updates to the linting tools, so we use that as a reference.

Same as https://github.com/crystal-lang/crystal/pull/16682