### PR TITLE
[CI] Drop standalone markdownlint job

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -59,18 +59,3 @@ jobs:
       - name: Deploy book
         if: github.event_name == 'push' && steps.branch.outputs.branch != null && github.repository == 'crystal-lang/crystal-book'
         run: aws s3 sync ./site s3://crystal-book/reference/${{ steps.branch.outputs.branch }} --delete
-
-  lint:
-    name: Check style issues
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download source
-        uses: actions/checkout@v6
-      - name: Install Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-      - name: Install dependencies
-        run: npm install -g markdownlint-cli@0.32.1
-      - name: Check Markdown style
-        run: markdownlint docs


### PR DESCRIPTION
We run an up-to-date version of markdownlint in the lint workflow.