### PR TITLE
Enable Markdownlint config `table-column-style.aligned_delimiter`

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -21,3 +21,6 @@ no-bare-urls: false
 
 fenced-code-language: false
 commands-show-output: false
+
+table-column-style:
+  aligned_delimiter: true

--- a/docs/database/connection_pool.md
+++ b/docs/database/connection_pool.md
@@ -34,7 +34,7 @@ If a connection can't be created, or if a connection loss occurs while the state
 The behavior of the pool can be configured from a set of parameters that can appear as query string in the connection URI.
 
 | Name | Default value |
-| :--- | :--- |
+| :--- | :------------ |
 | initial\_pool\_size | 1 |
 | max\_pool\_size | 0 \(unlimited\) |
 | max\_idle\_pool\_size | 1 |


### PR DESCRIPTION
This formatter option requires the line of dashes between the table header and body to have delimiters aligned to the delimiters in the header.
We're already using this style almost everywhere, so it seems reasonable to set this configuration.