### PR TITLE
Reformat markdown links as refs

### DIFF
--- a/docs/man/required_libraries.md
+++ b/docs/man/required_libraries.md
@@ -15,18 +15,18 @@ which may be part of the C library or standalone libraries. On most platforms al
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [glibc][glibc]<br>[![latest packaged version(s)][repology:glibc.svg]][repology:glibc/versions] | standard C library for Linux <br>**Supported versions:** GNU libc 2.26+ | [LGPL 3.0] |
-| [musl libc][musl-libc]<br>[![latest packaged version(s)][repology:musl.svg]][repology:musl/versions] | standard C library for Linux <br>**Supported versions:** MUSL libc 1.2+ | [MIT][musl-copyright] |
-| [FreeBSD libc][freebsd-libc]<br>[![latest packaged version(s)][repology:freebsd.svg]][repology:freebsd/versions] | standard C library for FreeBSD <br>**Supported versions:** 12+ | [BSD][freebsd-license] |
-| [NetBSD libc][netbsd-libc] | standard C library for NetBSD | [BSD][netbsd-license] |
-| [OpenBSD libc][openbsd-libc]<br>[![latest packaged version(s)][repology:openbsd.svg]][repology:openbsd/versions] | standard C library for OpenBSD <br>**Supported versions:** 6+ | [BSD][openbsd-policy] |
-| [Dragonfly libc][dragonfly-libc] | standard C library for DragonflyBSD | [BSD][dragonfly-license] |
-| [macOS libsystem][macos-libsystem] | standard C library for macOS <br>**Supported versions:** 11+ | [Apple][APPLE_LICENSE] |
-| [MSVCRT][msvcrt] | standard C library for Visual Studio 2013 or below | |
-| [UCRT][ucrt] | Universal CRT for Windows / Visual Studio 2015+ | [MIT subset available][MIT-windows] |
-| [WASI][wasi]<br>[![latest packaged version(s)][repology:wasi-libc.svg]][repology:wasi-libc/versions] | WebAssembly System Interface | [Apache v2 and others][wasi-license] |
-| [bionic libc][bionic-libc] | C library for Android <br>**Supported versions:** ABI Level 24+ | [BSD-like][android-notice] |
-| [illumos libc][illumos-libc] | System library for Illumos | [CDDL] |
+| [glibc]<br>[![latest packaged version(s)][repology:glibc.svg]][repology:glibc/versions] | standard C library for Linux <br>**Supported versions:** GNU libc 2.26+ | [LGPL 3.0] |
+| [musl libc]<br>[![latest packaged version(s)][repology:musl.svg]][repology:musl/versions] | standard C library for Linux <br>**Supported versions:** MUSL libc 1.2+ | [MIT][musl-copyright] |
+| [FreeBSD libc]<br>[![latest packaged version(s)][repology:freebsd.svg]][repology:freebsd/versions] | standard C library for FreeBSD <br>**Supported versions:** 12+ | [BSD][freebsd-license] |
+| [NetBSD libc] | standard C library for NetBSD | [BSD][netbsd-license] |
+| [OpenBSD libc]<br>[![latest packaged version(s)][repology:openbsd.svg]][repology:openbsd/versions] | standard C library for OpenBSD <br>**Supported versions:** 6+ | [BSD][openbsd-policy] |
+| [Dragonfly libc] | standard C library for DragonflyBSD | [BSD][dragonfly-license] |
+| [macOS libsystem] | standard C library for macOS <br>**Supported versions:** 11+ | [Apple][APPLE_LICENSE] |
+| [MSVCRT] | standard C library for Visual Studio 2013 or below | |
+| [UCRT] | Universal CRT for Windows / Visual Studio 2015+ | [MIT subset available][MIT-windows] |
+| [WASI]<br>[![latest packaged version(s)][repology:wasi-libc.svg]][repology:wasi-libc/versions] | WebAssembly System Interface | [Apache v2 and others][wasi-license] |
+| [bionic libc] | C library for Android <br>**Supported versions:** ABI Level 24+ | [BSD-like][android-notice] |
+| [illumos libc] | System library for Illumos | [CDDL] |
 
 [repology:glibc/versions]: https://repology.org/project/glibc/versions
 [repology:glibc.svg]: https://repology.org/badge/latest-versions/glibc.svg?header=latest
@@ -55,9 +55,9 @@ which may be part of the C library or standalone libraries. On most platforms al
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [Boehm GC][libgc]<br>[![latest packaged version(s)][repology:boehm-gc.svg]][repology:boehm-gc/versions] | The Boehm-Demers-Weiser conservative garbage collector. Performs automatic memory management.<br>**Supported versions:** 8.2.0+; earlier versions require a patch for MT support | [MIT-style][bdwgc-license] |
-| [Libevent][libevent]<br>[![latest packaged version(s)][repology:llvm.svg]][repology:llvm/versions] | An event notification library. Implements the event loop on OpenBSD, NetBSD, DragonflyBSD and Solaris by default and on other Unix-like systems with `-Devloop=libevent` ([availability][RFC0009]). Never used on Windows or WASI. | [Modified BSD][libevent-license] |
-| [compiler-rt builtins][compiler-rt] | Provides optimized implementations for low-level routines required by code generation, such as integer multiplication. Several of these routines are ported to Crystal directly. | [MIT / UIUC][compiler-rt] |
+| [Boehm GC]<br>[![latest packaged version(s)][repology:boehm-gc.svg]][repology:boehm-gc/versions] | The Boehm-Demers-Weiser conservative garbage collector. Performs automatic memory management.<br>**Supported versions:** 8.2.0+; earlier versions require a patch for MT support | [MIT-style][bdwgc-license] |
+| [Libevent]<br>[![latest packaged version(s)][repology:llvm.svg]][repology:llvm/versions] | An event notification library. Implements the event loop on OpenBSD, NetBSD, DragonflyBSD and Solaris by default and on other Unix-like systems with `-Devloop=libevent` ([availability][RFC0009]). Never used on Windows or WASI. | [Modified BSD][libevent-license] |
+| [compiler-rt builtins] | Provides optimized implementations for low-level routines required by code generation, such as integer multiplication. Several of these routines are ported to Crystal directly. | [MIT / UIUC][compiler-rt builtins] |
 
 [repology:boehm-gc/versions]: https://repology.org/project/boehm-gc/versions
 [repology:boehm-gc.svg]: https://repology.org/badge/latest-versions/boehm-gc.svg?header=latest
@@ -83,8 +83,8 @@ PCRE2 support was added in Crystal 1.7 and it's the default since 1.8 (see [Rege
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [PCRE2][libpcre]<br>[![latest packaged version(s)][repology:pcre2.svg]][repology:pcre2/versions] | Perl Compatible Regular Expressions, version 2.<br>**Supported versions:** all (recommended: 10.36+) | [BSD][pcre-license] |
-| [PCRE][libpcre]<br>[![latest packaged version(s)][repology:pcre.svg]][repology:pcre/versions] | Perl Compatible Regular Expressions. | [BSD][pcre-license] |
+| [PCRE2]<br>[![latest packaged version(s)][repology:pcre2.svg]][repology:pcre2/versions] | Perl Compatible Regular Expressions, version 2.<br>**Supported versions:** all (recommended: 10.36+) | [BSD][pcre-license] |
+| [PCRE][PCRE2]<br>[![latest packaged version(s)][repology:pcre.svg]][repology:pcre/versions] | Perl Compatible Regular Expressions. | [BSD][pcre-license] |
 
 [repology:pcre2/versions]: https://repology.org/project/pcre2/versions
 [repology:pcre2.svg]: https://repology.org/badge/latest-versions/pcre2.svg?header=latest
@@ -101,8 +101,8 @@ Implementations for `Big` types such as [`BigInt`][BigInt].
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [GMP][libgmp]<br>[![latest packaged version(s)][repology:gmp.svg]][repology:gmp/versions] | GNU multiple precision arithmetic library. | [LGPL v3+ / GPL v2+][gmp-license] |
-| [MPIR][libmpir]<br>[![latest packaged version(s)][repology:mpir.svg]][repology:mpir/versions] | Multiple Precision Integers and Rationals, forked from GMP. Used on Windows MSVC. | [GPL-3.0][mpir-copying] and [LGPL-3.0][mpir-copying.lib] |
+| [GMP]<br>[![latest packaged version(s)][repology:gmp.svg]][repology:gmp/versions] | GNU multiple precision arithmetic library. | [LGPL v3+ / GPL v2+][gmp-license] |
+| [MPIR]<br>[![latest packaged version(s)][repology:mpir.svg]][repology:mpir/versions] | Multiple Precision Integers and Rationals, forked from GMP. Used on Windows MSVC. | [GPL-3.0][mpir-copying] and [LGPL-3.0][mpir-copying.lib] |
 
 [repology:gmp/versions]: https://repology.org/project/gmp/versions
 [repology:gmp.svg]: https://repology.org/badge/latest-versions/gmp.svg?header=latest
@@ -120,7 +120,7 @@ Using a standalone library over the system library implementation can be enforce
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [libiconv][libiconv-gnu] (GNU)<br>[![latest packaged version(s)][repology:libiconv.svg]][repology:libiconv/versions] | Internationalization conversion library. | [LGPL 3.0] |
+| [libiconv] (GNU)<br>[![latest packaged version(s)][repology:libiconv.svg]][repology:libiconv/versions] | Internationalization conversion library. | [LGPL 3.0] |
 
 [repology:libiconv/versions]: https://repology.org/project/libiconv/versions
 [repology:libiconv.svg]: https://repology.org/badge/latest-versions/libiconv.svg?header=latest
@@ -137,7 +137,7 @@ Both `OpenSSL` and `LibreSSL` are supported and the bindings automatically detec
 | Library | Description | License |
 | ------- | ----------- | ------- |
 | [OpenSSL][openssl.org]<br>[![latest packaged version(s)][repology:openssl.svg]][repology:openssl/versions] | Implementation of the SSL and TLS protocols <br>**Supported versions:** 1.1.1+–3.4+ | [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)] |
-| [LibreSSL][libressl]<br>[![latest packaged version(s)][repology:libressl.svg]][repology:libressl/versions] | Implementation of the SSL and TLS protocols; forked from OpenSSL in 2014 <br>**Supported versions:** 3.0–4.0+ | [ISC / OpenSSL / SSLeay] |
+| [LibreSSL]<br>[![latest packaged version(s)][repology:libressl.svg]][repology:libressl/versions] | Implementation of the SSL and TLS protocols; forked from OpenSSL in 2014 <br>**Supported versions:** 3.0–4.0+ | [ISC / OpenSSL / SSLeay] |
 
 [repology:openssl/versions]: https://repology.org/project/openssl/versions
 [repology:openssl.svg]: https://repology.org/badge/latest-versions/openssl.svg?header=latest
@@ -151,9 +151,9 @@ Both `OpenSSL` and `LibreSSL` are supported and the bindings automatically detec
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [LibXML2][libxml2]<br>[![latest packaged version(s)][repology:libxml2.svg]][repology:libxml2/versions] | XML parser developed for the Gnome project. Implements the [`XML`][XML] module.<br>**Supported versions:** LibXML2 2.9–2.14 | [MIT][gnome-license] |
-| [LibYAML][libyaml]<br>[![latest packaged version(s)][repology:libyaml.svg]][repology:libyaml/versions] | YAML parser and emitter library. Implements the [`YAML`][YAML] module. | [MIT][yaml-license] |
-| [zlib][zlib]<br>[![latest packaged version(s)][repology:zlib.svg]][repology:zlib/versions] | Lossless data compression library. Implements the [`Compress`][Compress] module. May be disabled with the `-Dwithout_zlib` compile-time flag. | [zlib][zlib-license] |
+| [LibXML2]<br>[![latest packaged version(s)][repology:libxml2.svg]][repology:libxml2/versions] | XML parser developed for the Gnome project. Implements the [`XML`][XML] module.<br>**Supported versions:** LibXML2 2.9–2.14 | [MIT][gnome-license] |
+| [LibYAML]<br>[![latest packaged version(s)][repology:libyaml.svg]][repology:libyaml/versions] | YAML parser and emitter library. Implements the [`YAML`][YAML] module. | [MIT][yaml-license] |
+| [zlib]<br>[![latest packaged version(s)][repology:zlib.svg]][repology:zlib/versions] | Lossless data compression library. Implements the [`Compress`][Compress] module. May be disabled with the `-Dwithout_zlib` compile-time flag. | [zlib][zlib-license] |
 | [LLVM][libllvm]<br>[![latest packaged version(s)][repology:llvm.svg]][repology:llvm/versions] | Target-independent code generator and optimizer. Implements the [`LLVM`][LLVM] API. <br>**Supported versions:** LLVM 8-22 (aarch64 requires LLVM 13+) | [Apache v2 with LLVM exceptions] |
 
 [repology:libxml2/versions]: https://repology.org/project/libxml2/versions
@@ -179,10 +179,10 @@ In addition to the [core runtime dependencies](#core-runtime-dependencies), thes
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [PCRE2][libpcre] | See [*Regular expression engine*] | |
+| [PCRE2] | See [*Regular expression engine*] | |
 | [LLVM][libllvm] | See [*Other stdlib libraries*] | [Apache v2 with LLVM exceptions] |
-| [libffi][libffi]<br>[![latest packaged version(s)][repology:libffi.svg]][repology:libffi/versions] | Foreign function interface. Used for implementing binary interfaces in the interpreter. May be disabled with the `-Dwithout_interpreter` compile-time flag. | [MIT][ffi-license] |
-| [libxml2][libxml2] | Optional dependency for docs sanitizer. May be disabled with the `-Dwithout_libxml2` compile-time flag. See [*Other stdlib libraries*] | [MIT][gnome-license] |
+| [libffi]<br>[![latest packaged version(s)][repology:libffi.svg]][repology:libffi/versions] | Foreign function interface. Used for implementing binary interfaces in the interpreter. May be disabled with the `-Dwithout_interpreter` compile-time flag. | [MIT][ffi-license] |
+| [libxml2] | Optional dependency for docs sanitizer. May be disabled with the `-Dwithout_libxml2` compile-time flag. See [*Other stdlib libraries*] | [MIT][gnome-license] |
 
 [*Other stdlib libraries*]: #other-stdlib-libraries
 [*Regular expression engine*]: #regular-expression-engine
@@ -192,29 +192,29 @@ In addition to the [core runtime dependencies](#core-runtime-dependencies), thes
 
 [ffi-license]: https://github.com/libffi/libffi/blob/master/LICENSE
 
-[bionic-libc]: https://android.googlesource.com/platform/bionic/+/refs/heads/master/libc/
-[compiler-rt]: https://compiler-rt.llvm.org/
-[dragonfly-libc]: http://gitweb.dragonflybsd.org/dragonfly.git/tree/refs/heads/master:/lib/libc
-[freebsd-libc]: https://svn.freebsd.org/base/head/lib/libc/
+[bionic libc]: https://android.googlesource.com/platform/bionic/+/refs/heads/master/libc/
+[compiler-rt builtins]: https://compiler-rt.llvm.org/
+[Dragonfly libc]: http://gitweb.dragonflybsd.org/dragonfly.git/tree/refs/heads/master:/lib/libc
+[FreeBSD libc]: https://svn.freebsd.org/base/head/lib/libc/
 [glibc]: https://www.gnu.org/software/libc/
-[illumos-libc]: https://code.illumos.org/plugins/gitiles/illumos-gate
-[libevent]: https://libevent.org/
+[illumos libc]: https://code.illumos.org/plugins/gitiles/illumos-gate
+[Libevent]: https://libevent.org/
 [libffi]: https://sourceware.org/libffi/
-[libgc]: https://github.com/ivmai/bdwgc
-[libgmp]: https://gmplib.org/
-[libiconv-gnu]: https://www.gnu.org/software/libiconv/
+[Boehm GC]: https://github.com/ivmai/bdwgc
+[GMP]: https://gmplib.org/
+[libiconv]: https://www.gnu.org/software/libiconv/
 [libllvm]: https://llvm.org/
-[libmpir]: https://github.com/wbhart/mpir
-[libpcre]: http://www.pcre.org/
-[libressl]: https://www.libressl.org/
-[libxml2]: http://xmlsoft.org/
-[libyaml]: https://pyyaml.org/wiki/LibYAML
-[macos-libsystem]: https://github.com/apple-oss-distributions/Libsystem
-[msvcrt]: https://web.archive.org/web/20150630135610/https://msdn.microsoft.com/en-us/library/abx4dbyh.aspx
-[musl-libc]: https://musl.libc.org/
-[netbsd-libc]: http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/?only_with_tag=MAIN
-[openbsd-libc]: http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/lib/libc/
+[MPIR]: https://github.com/wbhart/mpir
+[PCRE2]: http://www.pcre.org/
+[LibreSSL]: https://www.libressl.org/
+[LibXML2]: http://xmlsoft.org/
+[LibYAML]: https://pyyaml.org/wiki/LibYAML
+[macOS libsystem]: https://github.com/apple-oss-distributions/Libsystem
+[MSVCRT]: https://web.archive.org/web/20150630135610/https://msdn.microsoft.com/en-us/library/abx4dbyh.aspx
+[musl libc]: https://musl.libc.org/
+[NetBSD libc]: http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/?only_with_tag=MAIN
+[OpenBSD libc]: http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/lib/libc/
 [openssl.org]: https://www.openssl.org/
-[ucrt]: https://learn.microsoft.com/en-us/cpp/windows/universal-crt-deployment?view=msvc-170
-[wasi]: https://wasi.dev/
+[UCRT]: https://learn.microsoft.com/en-us/cpp/windows/universal-crt-deployment?view=msvc-170
+[WASI]: https://wasi.dev/
 [zlib]: http://zlib.net/

--- a/docs/man/required_libraries.md
+++ b/docs/man/required_libraries.md
@@ -15,16 +15,16 @@ which may be part of the C library or standalone libraries. On most platforms al
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [glibc]<br>[![latest packaged version(s)][repology:glibc.svg]][repology:glibc/versions] | standard C library for Linux <br>**Supported versions:** GNU libc 2.26+ | [LGPL 3.0] |
-| [musl libc]<br>[![latest packaged version(s)][repology:musl.svg]][repology:musl/versions] | standard C library for Linux <br>**Supported versions:** MUSL libc 1.2+ | [MIT][musl-copyright] |
-| [FreeBSD libc]<br>[![latest packaged version(s)][repology:freebsd.svg]][repology:freebsd/versions] | standard C library for FreeBSD <br>**Supported versions:** 12+ | [BSD][freebsd-license] |
+| [glibc]<br>[![latest packaged version(s)][r:glibc]][r:glibc/v] | standard C library for Linux <br>**Supported versions:** GNU libc 2.26+ | [LGPL 3.0] |
+| [musl libc]<br>[![latest packaged version(s)][r:musl]][r:musl/v] | standard C library for Linux <br>**Supported versions:** MUSL libc 1.2+ | [MIT][musl-copyright] |
+| [FreeBSD libc]<br>[![latest packaged version(s)][r:freebsd]][r:freebsd/v] | standard C library for FreeBSD <br>**Supported versions:** 12+ | [BSD][freebsd-license] |
 | [NetBSD libc] | standard C library for NetBSD | [BSD][netbsd-license] |
-| [OpenBSD libc]<br>[![latest packaged version(s)][repology:openbsd.svg]][repology:openbsd/versions] | standard C library for OpenBSD <br>**Supported versions:** 6+ | [BSD][openbsd-policy] |
+| [OpenBSD libc]<br>[![latest packaged version(s)][r:openbsd]][r:openbsd/v] | standard C library for OpenBSD <br>**Supported versions:** 6+ | [BSD][openbsd-policy] |
 | [Dragonfly libc] | standard C library for DragonflyBSD | [BSD][dragonfly-license] |
 | [macOS libsystem] | standard C library for macOS <br>**Supported versions:** 11+ | [Apple][APPLE_LICENSE] |
 | [MSVCRT] | standard C library for Visual Studio 2013 or below | |
 | [UCRT] | Universal CRT for Windows / Visual Studio 2015+ | [MIT subset available][MIT-windows] |
-| [WASI]<br>[![latest packaged version(s)][repology:wasi-libc.svg]][repology:wasi-libc/versions] | WebAssembly System Interface | [Apache v2 and others][wasi-license] |
+| [WASI]<br>[![latest packaged version(s)][r:wasi-libc]][r:wasi-libc/v] | WebAssembly System Interface | [Apache v2 and others][wasi-license] |
 | [bionic libc] | C library for Android <br>**Supported versions:** ABI Level 24+ | [BSD-like][android-notice] |
 | [illumos libc] | System library for Illumos | [CDDL] |
 
@@ -44,8 +44,8 @@ which may be part of the C library or standalone libraries. On most platforms al
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [Boehm GC]<br>[![latest packaged version(s)][repology:boehm-gc.svg]][repology:boehm-gc/versions] | The Boehm-Demers-Weiser conservative garbage collector. Performs automatic memory management.<br>**Supported versions:** 8.2.0+; earlier versions require a patch for MT support | [MIT-style][bdwgc-license] |
-| [Libevent]<br>[![latest packaged version(s)][repology:llvm.svg]][repology:llvm/versions] | An event notification library. Implements the event loop on OpenBSD, NetBSD, DragonflyBSD and Solaris by default and on other Unix-like systems with `-Devloop=libevent` ([availability][RFC0009]). Never used on Windows or WASI. | [Modified BSD][libevent-license] |
+| [Boehm GC]<br>[![latest packaged version(s)][r:boehm-gc]][r:boehm-gc/v] | The Boehm-Demers-Weiser conservative garbage collector. Performs automatic memory management.<br>**Supported versions:** 8.2.0+; earlier versions require a patch for MT support | [MIT-style][bdwgc-license] |
+| [Libevent]<br>[![latest packaged version(s)][r:llvm]][r:llvm/v] | An event notification library. Implements the event loop on OpenBSD, NetBSD, DragonflyBSD and Solaris by default and on other Unix-like systems with `-Devloop=libevent` ([availability][RFC0009]). Never used on Windows or WASI. | [Modified BSD][libevent-license] |
 | [compiler-rt builtins] | Provides optimized implementations for low-level routines required by code generation, such as integer multiplication. Several of these routines are ported to Crystal directly. | [MIT / UIUC][compiler-rt builtins] |
 
 [bdwgc-license]: https://github.com/ivmai/bdwgc/blob/master/LICENSE
@@ -67,8 +67,8 @@ PCRE2 support was added in Crystal 1.7 and it's the default since 1.8 (see [Rege
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [PCRE2]<br>[![latest packaged version(s)][repology:pcre2.svg]][repology:pcre2/versions] | Perl Compatible Regular Expressions, version 2.<br>**Supported versions:** all (recommended: 10.36+) | [BSD][pcre-license] |
-| [PCRE][PCRE2]<br>[![latest packaged version(s)][repology:pcre.svg]][repology:pcre/versions] | Perl Compatible Regular Expressions. | [BSD][pcre-license] |
+| [PCRE2]<br>[![latest packaged version(s)][r:pcre2]][r:pcre2/v] | Perl Compatible Regular Expressions, version 2.<br>**Supported versions:** all (recommended: 10.36+) | [BSD][pcre-license] |
+| [PCRE][PCRE2]<br>[![latest packaged version(s)][r:pcre]][r:pcre/v] | Perl Compatible Regular Expressions. | [BSD][pcre-license] |
 
 [pcre-license]: http://www.pcre.org/licence.txt
 
@@ -80,8 +80,8 @@ Implementations for `Big` types such as [`BigInt`][BigInt].
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [GMP]<br>[![latest packaged version(s)][repology:gmp.svg]][repology:gmp/versions] | GNU multiple precision arithmetic library. | [LGPL v3+ / GPL v2+][gmp-license] |
-| [MPIR]<br>[![latest packaged version(s)][repology:mpir.svg]][repology:mpir/versions] | Multiple Precision Integers and Rationals, forked from GMP. Used on Windows MSVC. | [GPL-3.0][mpir-copying] and [LGPL-3.0][mpir-copying.lib] |
+| [GMP]<br>[![latest packaged version(s)][r:gmp]][r:gmp/v] | GNU multiple precision arithmetic library. | [LGPL v3+ / GPL v2+][gmp-license] |
+| [MPIR]<br>[![latest packaged version(s)][r:mpir]][r:mpir/v] | Multiple Precision Integers and Rationals, forked from GMP. Used on Windows MSVC. | [GPL-3.0][mpir-copying] and [LGPL-3.0][mpir-copying.lib] |
 
 [gmp-license]: https://gmplib.org/manual/Copying
 [mpir-copying]: https://github.com/wbhart/mpir/blob/master/COPYING
@@ -94,7 +94,7 @@ Using a standalone library over the system library implementation can be enforce
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [libiconv] (GNU)<br>[![latest packaged version(s)][repology:libiconv.svg]][repology:libiconv/versions] | Internationalization conversion library. | [LGPL 3.0] |
+| [libiconv] (GNU)<br>[![latest packaged version(s)][r:libiconv]][r:libiconv/v] | Internationalization conversion library. | [LGPL 3.0] |
 
 ### TLS
 
@@ -107,8 +107,8 @@ Both `OpenSSL` and `LibreSSL` are supported and the bindings automatically detec
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [OpenSSL][openssl.org]<br>[![latest packaged version(s)][repology:openssl.svg]][repology:openssl/versions] | Implementation of the SSL and TLS protocols <br>**Supported versions:** 1.1.1+–3.4+ | [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)] |
-| [LibreSSL]<br>[![latest packaged version(s)][repology:libressl.svg]][repology:libressl/versions] | Implementation of the SSL and TLS protocols; forked from OpenSSL in 2014 <br>**Supported versions:** 3.0–4.0+ | [ISC / OpenSSL / SSLeay] |
+| [OpenSSL][openssl.org]<br>[![latest packaged version(s)][r:openssl]][r:openssl/v] | Implementation of the SSL and TLS protocols <br>**Supported versions:** 1.1.1+–3.4+ | [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)] |
+| [LibreSSL]<br>[![latest packaged version(s)][r:libressl]][r:libressl/v] | Implementation of the SSL and TLS protocols; forked from OpenSSL in 2014 <br>**Supported versions:** 3.0–4.0+ | [ISC / OpenSSL / SSLeay] |
 
 [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)]: https://www.openssl.org/source/license.html
 [ISC / OpenSSL / SSLeay]: https://github.com/libressl-portable/openbsd/blob/master/src/lib/libssl/LICENSE
@@ -117,10 +117,10 @@ Both `OpenSSL` and `LibreSSL` are supported and the bindings automatically detec
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [LibXML2]<br>[![latest packaged version(s)][repology:libxml2.svg]][repology:libxml2/versions] | XML parser developed for the Gnome project. Implements the [`XML`][XML] module.<br>**Supported versions:** LibXML2 2.9–2.14 | [MIT][gnome-license] |
-| [LibYAML]<br>[![latest packaged version(s)][repology:libyaml.svg]][repology:libyaml/versions] | YAML parser and emitter library. Implements the [`YAML`][YAML] module. | [MIT][yaml-license] |
-| [zlib]<br>[![latest packaged version(s)][repology:zlib.svg]][repology:zlib/versions] | Lossless data compression library. Implements the [`Compress`][Compress] module. May be disabled with the `-Dwithout_zlib` compile-time flag. | [zlib][zlib-license] |
-| [LLVM][libllvm]<br>[![latest packaged version(s)][repology:llvm.svg]][repology:llvm/versions] | Target-independent code generator and optimizer. Implements the [`LLVM`][LLVM] API. <br>**Supported versions:** LLVM 8-22 (aarch64 requires LLVM 13+) | [Apache v2 with LLVM exceptions] |
+| [LibXML2]<br>[![latest packaged version(s)][r:libxml2]][r:libxml2/v] | XML parser developed for the Gnome project. Implements the [`XML`][XML] module.<br>**Supported versions:** LibXML2 2.9–2.14 | [MIT][gnome-license] |
+| [LibYAML]<br>[![latest packaged version(s)][r:libyaml]][r:libyaml/v] | YAML parser and emitter library. Implements the [`YAML`][YAML] module. | [MIT][yaml-license] |
+| [zlib]<br>[![latest packaged version(s)][r:zlib]][r:zlib/v] | Lossless data compression library. Implements the [`Compress`][Compress] module. May be disabled with the `-Dwithout_zlib` compile-time flag. | [zlib][zlib-license] |
+| [LLVM][libllvm]<br>[![latest packaged version(s)][r:llvm]][r:llvm/v] | Target-independent code generator and optimizer. Implements the [`LLVM`][LLVM] API. <br>**Supported versions:** LLVM 8-22 (aarch64 requires LLVM 13+) | [Apache v2 with LLVM exceptions] |
 
 [gnome-license]: https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/Copyright
 [yaml-license]: https://github.com/yaml/libyaml/blob/master/License
@@ -140,7 +140,7 @@ In addition to the [core runtime dependencies](#core-runtime-dependencies), thes
 | ------- | ----------- | ------- |
 | [PCRE2] | See [*Regular expression engine*] | |
 | [LLVM][libllvm] | See [*Other stdlib libraries*] | [Apache v2 with LLVM exceptions] |
-| [libffi]<br>[![latest packaged version(s)][repology:libffi.svg]][repology:libffi/versions] | Foreign function interface. Used for implementing binary interfaces in the interpreter. May be disabled with the `-Dwithout_interpreter` compile-time flag. | [MIT][ffi-license] |
+| [libffi]<br>[![latest packaged version(s)][r:libffi]][r:libffi/v] | Foreign function interface. Used for implementing binary interfaces in the interpreter. May be disabled with the `-Dwithout_interpreter` compile-time flag. | [MIT][ffi-license] |
 | [libxml2] | Optional dependency for docs sanitizer. May be disabled with the `-Dwithout_libxml2` compile-time flag. See [*Other stdlib libraries*] | [MIT][gnome-license] |
 
 [*Other stdlib libraries*]: #other-stdlib-libraries
@@ -175,39 +175,39 @@ In addition to the [core runtime dependencies](#core-runtime-dependencies), thes
 [WASI]: https://wasi.dev/
 [zlib]: http://zlib.net/
 
-[repology:boehm-gc.svg]: https://repology.org/badge/latest-versions/boehm-gc.svg?header=latest
-[repology:boehm-gc/versions]: https://repology.org/project/boehm-gc/versions
-[repology:freebsd.svg]: https://repology.org/badge/latest-versions/freebsd.svg?header=latest
-[repology:freebsd/versions]: https://repology.org/project/freebsd/versions
-[repology:glibc.svg]: https://repology.org/badge/latest-versions/glibc.svg?header=latest
-[repology:glibc/versions]: https://repology.org/project/glibc/versions
-[repology:gmp.svg]: https://repology.org/badge/latest-versions/gmp.svg?header=latest
-[repology:gmp/versions]: https://repology.org/project/gmp/versions
-[repology:libffi.svg]: https://repology.org/badge/latest-versions/libffi.svg?header=latest
-[repology:libffi/versions]: https://repology.org/project/libffi/versions
-[repology:libiconv.svg]: https://repology.org/badge/latest-versions/libiconv.svg?header=latest
-[repology:libiconv/versions]: https://repology.org/project/libiconv/versions
-[repology:libressl.svg]: https://repology.org/badge/latest-versions/libressl.svg?header=latest
-[repology:libressl/versions]: https://repology.org/project/libressl/versions
-[repology:libxml2.svg]: https://repology.org/badge/latest-versions/libxml2.svg?header=latest
-[repology:libxml2/versions]: https://repology.org/project/libxml2/versions
-[repology:libyaml.svg]: https://repology.org/badge/latest-versions/libyaml.svg?header=latest
-[repology:libyaml/versions]: https://repology.org/project/libyaml/versions
-[repology:llvm.svg]: https://repology.org/badge/latest-versions/llvm.svg?header=latest
-[repology:llvm/versions]: https://repology.org/project/llvm/versions
-[repology:mpir.svg]: https://repology.org/badge/latest-versions/mpir.svg?header=latest
-[repology:mpir/versions]: https://repology.org/project/mpir/versions
-[repology:musl.svg]: https://repology.org/badge/latest-versions/musl.svg?header=latest
-[repology:musl/versions]: https://repology.org/project/musl/versions
-[repology:openbsd.svg]: https://repology.org/badge/latest-versions/openbsd.svg?header=latest
-[repology:openbsd/versions]: https://repology.org/project/openbsd/versions
-[repology:openssl.svg]: https://repology.org/badge/latest-versions/openssl.svg?header=latest
-[repology:openssl/versions]: https://repology.org/project/openssl/versions
-[repology:pcre.svg]: https://repology.org/badge/latest-versions/pcre.svg?header=latest
-[repology:pcre/versions]: https://repology.org/project/pcre/versions
-[repology:pcre2.svg]: https://repology.org/badge/latest-versions/pcre2.svg?header=latest
-[repology:pcre2/versions]: https://repology.org/project/pcre2/versions
-[repology:wasi-libc.svg]: https://repology.org/badge/latest-versions/wasi-libc.svg?header=latest
-[repology:wasi-libc/versions]: https://repology.org/project/wasi-libc/versions
-[repology:zlib.svg]: https://repology.org/badge/latest-versions/zlib.svg?header=latest
-[repology:zlib/versions]: https://repology.org/project/zlib/versions
+[r:boehm-gc]: https://repology.org/badge/latest-versions/boehm-gc.svg?header=latest
+[r:boehm-gc/v]: https://repology.org/project/boehm-gc/versions
+[r:freebsd]: https://repology.org/badge/latest-versions/freebsd.svg?header=latest
+[r:freebsd/v]: https://repology.org/project/freebsd/versions
+[r:glibc]: https://repology.org/badge/latest-versions/glibc.svg?header=latest
+[r:glibc/v]: https://repology.org/project/glibc/versions
+[r:gmp]: https://repology.org/badge/latest-versions/gmp.svg?header=latest
+[r:gmp/v]: https://repology.org/project/gmp/versions
+[r:libffi]: https://repology.org/badge/latest-versions/libffi.svg?header=latest
+[r:libffi/v]: https://repology.org/project/libffi/versions
+[r:libiconv]: https://repology.org/badge/latest-versions/libiconv.svg?header=latest
+[r:libiconv/v]: https://repology.org/project/libiconv/versions
+[r:libressl]: https://repology.org/badge/latest-versions/libressl.svg?header=latest
+[r:libressl/v]: https://repology.org/project/libressl/versions
+[r:libxml2]: https://repology.org/badge/latest-versions/libxml2.svg?header=latest
+[r:libxml2/v]: https://repology.org/project/libxml2/versions
+[r:libyaml]: https://repology.org/badge/latest-versions/libyaml.svg?header=latest
+[r:libyaml/v]: https://repology.org/project/libyaml/versions
+[r:llvm]: https://repology.org/badge/latest-versions/llvm.svg?header=latest
+[r:llvm/v]: https://repology.org/project/llvm/versions
+[r:mpir]: https://repology.org/badge/latest-versions/mpir.svg?header=latest
+[r:mpir/v]: https://repology.org/project/mpir/versions
+[r:musl]: https://repology.org/badge/latest-versions/musl.svg?header=latest
+[r:musl/v]: https://repology.org/project/musl/versions
+[r:openbsd]: https://repology.org/badge/latest-versions/openbsd.svg?header=latest
+[r:openbsd/v]: https://repology.org/project/openbsd/versions
+[r:openssl]: https://repology.org/badge/latest-versions/openssl.svg?header=latest
+[r:openssl/v]: https://repology.org/project/openssl/versions
+[r:pcre]: https://repology.org/badge/latest-versions/pcre.svg?header=latest
+[r:pcre/v]: https://repology.org/project/pcre/versions
+[r:pcre2]: https://repology.org/badge/latest-versions/pcre2.svg?header=latest
+[r:pcre2/v]: https://repology.org/project/pcre2/versions
+[r:wasi-libc]: https://repology.org/badge/latest-versions/wasi-libc.svg?header=latest
+[r:wasi-libc/v]: https://repology.org/project/wasi-libc/versions
+[r:zlib]: https://repology.org/badge/latest-versions/zlib.svg?header=latest
+[r:zlib/v]: https://repology.org/project/zlib/versions

--- a/docs/man/required_libraries.md
+++ b/docs/man/required_libraries.md
@@ -28,17 +28,6 @@ which may be part of the C library or standalone libraries. On most platforms al
 | [bionic libc] | C library for Android <br>**Supported versions:** ABI Level 24+ | [BSD-like][android-notice] |
 | [illumos libc] | System library for Illumos | [CDDL] |
 
-[repology:glibc/versions]: https://repology.org/project/glibc/versions
-[repology:glibc.svg]: https://repology.org/badge/latest-versions/glibc.svg?header=latest
-[repology:musl/versions]: https://repology.org/project/musl/versions
-[repology:musl.svg]: https://repology.org/badge/latest-versions/musl.svg?header=latest
-[repology:freebsd/versions]: https://repology.org/project/freebsd/versions
-[repology:freebsd.svg]: https://repology.org/badge/latest-versions/freebsd.svg?header=latest
-[repology:openbsd/versions]: https://repology.org/project/openbsd/versions
-[repology:openbsd.svg]: https://repology.org/badge/latest-versions/openbsd.svg?header=latest
-[repology:wasi-libc/versions]: https://repology.org/project/wasi-libc/versions
-[repology:wasi-libc.svg]: https://repology.org/badge/latest-versions/wasi-libc.svg?header=latest
-
 [LGPL 3.0]: https://www.gnu.org/licenses/lgpl-3.0.en.html
 [musl-copyright]: https://git.musl-libc.org/cgit/musl/tree/COPYRIGHT
 [freebsd-license]: https://www.freebsd.org/copyright/freebsd-license/
@@ -58,11 +47,6 @@ which may be part of the C library or standalone libraries. On most platforms al
 | [Boehm GC]<br>[![latest packaged version(s)][repology:boehm-gc.svg]][repology:boehm-gc/versions] | The Boehm-Demers-Weiser conservative garbage collector. Performs automatic memory management.<br>**Supported versions:** 8.2.0+; earlier versions require a patch for MT support | [MIT-style][bdwgc-license] |
 | [Libevent]<br>[![latest packaged version(s)][repology:llvm.svg]][repology:llvm/versions] | An event notification library. Implements the event loop on OpenBSD, NetBSD, DragonflyBSD and Solaris by default and on other Unix-like systems with `-Devloop=libevent` ([availability][RFC0009]). Never used on Windows or WASI. | [Modified BSD][libevent-license] |
 | [compiler-rt builtins] | Provides optimized implementations for low-level routines required by code generation, such as integer multiplication. Several of these routines are ported to Crystal directly. | [MIT / UIUC][compiler-rt builtins] |
-
-[repology:boehm-gc/versions]: https://repology.org/project/boehm-gc/versions
-[repology:boehm-gc.svg]: https://repology.org/badge/latest-versions/boehm-gc.svg?header=latest
-[repology:llvm/versions]: https://repology.org/project/llvm/versions
-[repology:llvm.svg]: https://repology.org/badge/latest-versions/llvm.svg?header=latest
 
 [bdwgc-license]: https://github.com/ivmai/bdwgc/blob/master/LICENSE
 [libevent-license]: https://github.com/libevent/libevent/blob/master/LICENSE
@@ -86,11 +70,6 @@ PCRE2 support was added in Crystal 1.7 and it's the default since 1.8 (see [Rege
 | [PCRE2]<br>[![latest packaged version(s)][repology:pcre2.svg]][repology:pcre2/versions] | Perl Compatible Regular Expressions, version 2.<br>**Supported versions:** all (recommended: 10.36+) | [BSD][pcre-license] |
 | [PCRE][PCRE2]<br>[![latest packaged version(s)][repology:pcre.svg]][repology:pcre/versions] | Perl Compatible Regular Expressions. | [BSD][pcre-license] |
 
-[repology:pcre2/versions]: https://repology.org/project/pcre2/versions
-[repology:pcre2.svg]: https://repology.org/badge/latest-versions/pcre2.svg?header=latest
-[repology:pcre/versions]: https://repology.org/project/pcre/versions
-[repology:pcre.svg]: https://repology.org/badge/latest-versions/pcre.svg?header=latest
-
 [pcre-license]: http://www.pcre.org/licence.txt
 
 ### Big Numbers
@@ -104,11 +83,6 @@ Implementations for `Big` types such as [`BigInt`][BigInt].
 | [GMP]<br>[![latest packaged version(s)][repology:gmp.svg]][repology:gmp/versions] | GNU multiple precision arithmetic library. | [LGPL v3+ / GPL v2+][gmp-license] |
 | [MPIR]<br>[![latest packaged version(s)][repology:mpir.svg]][repology:mpir/versions] | Multiple Precision Integers and Rationals, forked from GMP. Used on Windows MSVC. | [GPL-3.0][mpir-copying] and [LGPL-3.0][mpir-copying.lib] |
 
-[repology:gmp/versions]: https://repology.org/project/gmp/versions
-[repology:gmp.svg]: https://repology.org/badge/latest-versions/gmp.svg?header=latest
-[repology:mpir/versions]: https://repology.org/project/mpir/versions
-[repology:mpir.svg]: https://repology.org/badge/latest-versions/mpir.svg?header=latest
-
 [gmp-license]: https://gmplib.org/manual/Copying
 [mpir-copying]: https://github.com/wbhart/mpir/blob/master/COPYING
 [mpir-copying.lib]: https://github.com/wbhart/mpir/blob/master/COPYING.LIB
@@ -121,9 +95,6 @@ Using a standalone library over the system library implementation can be enforce
 | Library | Description | License |
 | ------- | ----------- | ------- |
 | [libiconv] (GNU)<br>[![latest packaged version(s)][repology:libiconv.svg]][repology:libiconv/versions] | Internationalization conversion library. | [LGPL 3.0] |
-
-[repology:libiconv/versions]: https://repology.org/project/libiconv/versions
-[repology:libiconv.svg]: https://repology.org/badge/latest-versions/libiconv.svg?header=latest
 
 ### TLS
 
@@ -139,11 +110,6 @@ Both `OpenSSL` and `LibreSSL` are supported and the bindings automatically detec
 | [OpenSSL][openssl.org]<br>[![latest packaged version(s)][repology:openssl.svg]][repology:openssl/versions] | Implementation of the SSL and TLS protocols <br>**Supported versions:** 1.1.1+–3.4+ | [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)] |
 | [LibreSSL]<br>[![latest packaged version(s)][repology:libressl.svg]][repology:libressl/versions] | Implementation of the SSL and TLS protocols; forked from OpenSSL in 2014 <br>**Supported versions:** 3.0–4.0+ | [ISC / OpenSSL / SSLeay] |
 
-[repology:openssl/versions]: https://repology.org/project/openssl/versions
-[repology:openssl.svg]: https://repology.org/badge/latest-versions/openssl.svg?header=latest
-[repology:libressl/versions]: https://repology.org/project/libressl/versions
-[repology:libressl.svg]: https://repology.org/badge/latest-versions/libressl.svg?header=latest
-
 [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)]: https://www.openssl.org/source/license.html
 [ISC / OpenSSL / SSLeay]: https://github.com/libressl-portable/openbsd/blob/master/src/lib/libssl/LICENSE
 
@@ -155,13 +121,6 @@ Both `OpenSSL` and `LibreSSL` are supported and the bindings automatically detec
 | [LibYAML]<br>[![latest packaged version(s)][repology:libyaml.svg]][repology:libyaml/versions] | YAML parser and emitter library. Implements the [`YAML`][YAML] module. | [MIT][yaml-license] |
 | [zlib]<br>[![latest packaged version(s)][repology:zlib.svg]][repology:zlib/versions] | Lossless data compression library. Implements the [`Compress`][Compress] module. May be disabled with the `-Dwithout_zlib` compile-time flag. | [zlib][zlib-license] |
 | [LLVM][libllvm]<br>[![latest packaged version(s)][repology:llvm.svg]][repology:llvm/versions] | Target-independent code generator and optimizer. Implements the [`LLVM`][LLVM] API. <br>**Supported versions:** LLVM 8-22 (aarch64 requires LLVM 13+) | [Apache v2 with LLVM exceptions] |
-
-[repology:libxml2/versions]: https://repology.org/project/libxml2/versions
-[repology:libxml2.svg]: https://repology.org/badge/latest-versions/libxml2.svg?header=latest
-[repology:libyaml/versions]: https://repology.org/project/libyaml/versions
-[repology:libyaml.svg]: https://repology.org/badge/latest-versions/libyaml.svg?header=latest
-[repology:zlib/versions]: https://repology.org/project/zlib/versions
-[repology:zlib.svg]: https://repology.org/badge/latest-versions/zlib.svg?header=latest
 
 [gnome-license]: https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/Copyright
 [yaml-license]: https://github.com/yaml/libyaml/blob/master/License
@@ -186,9 +145,6 @@ In addition to the [core runtime dependencies](#core-runtime-dependencies), thes
 
 [*Other stdlib libraries*]: #other-stdlib-libraries
 [*Regular expression engine*]: #regular-expression-engine
-
-[repology:libffi/versions]: https://repology.org/project/libffi/versions
-[repology:libffi.svg]: https://repology.org/badge/latest-versions/libffi.svg?header=latest
 
 [ffi-license]: https://github.com/libffi/libffi/blob/master/LICENSE
 
@@ -218,3 +174,40 @@ In addition to the [core runtime dependencies](#core-runtime-dependencies), thes
 [UCRT]: https://learn.microsoft.com/en-us/cpp/windows/universal-crt-deployment?view=msvc-170
 [WASI]: https://wasi.dev/
 [zlib]: http://zlib.net/
+
+[repology:boehm-gc.svg]: https://repology.org/badge/latest-versions/boehm-gc.svg?header=latest
+[repology:boehm-gc/versions]: https://repology.org/project/boehm-gc/versions
+[repology:freebsd.svg]: https://repology.org/badge/latest-versions/freebsd.svg?header=latest
+[repology:freebsd/versions]: https://repology.org/project/freebsd/versions
+[repology:glibc.svg]: https://repology.org/badge/latest-versions/glibc.svg?header=latest
+[repology:glibc/versions]: https://repology.org/project/glibc/versions
+[repology:gmp.svg]: https://repology.org/badge/latest-versions/gmp.svg?header=latest
+[repology:gmp/versions]: https://repology.org/project/gmp/versions
+[repology:libffi.svg]: https://repology.org/badge/latest-versions/libffi.svg?header=latest
+[repology:libffi/versions]: https://repology.org/project/libffi/versions
+[repology:libiconv.svg]: https://repology.org/badge/latest-versions/libiconv.svg?header=latest
+[repology:libiconv/versions]: https://repology.org/project/libiconv/versions
+[repology:libressl.svg]: https://repology.org/badge/latest-versions/libressl.svg?header=latest
+[repology:libressl/versions]: https://repology.org/project/libressl/versions
+[repology:libxml2.svg]: https://repology.org/badge/latest-versions/libxml2.svg?header=latest
+[repology:libxml2/versions]: https://repology.org/project/libxml2/versions
+[repology:libyaml.svg]: https://repology.org/badge/latest-versions/libyaml.svg?header=latest
+[repology:libyaml/versions]: https://repology.org/project/libyaml/versions
+[repology:llvm.svg]: https://repology.org/badge/latest-versions/llvm.svg?header=latest
+[repology:llvm/versions]: https://repology.org/project/llvm/versions
+[repology:mpir.svg]: https://repology.org/badge/latest-versions/mpir.svg?header=latest
+[repology:mpir/versions]: https://repology.org/project/mpir/versions
+[repology:musl.svg]: https://repology.org/badge/latest-versions/musl.svg?header=latest
+[repology:musl/versions]: https://repology.org/project/musl/versions
+[repology:openbsd.svg]: https://repology.org/badge/latest-versions/openbsd.svg?header=latest
+[repology:openbsd/versions]: https://repology.org/project/openbsd/versions
+[repology:openssl.svg]: https://repology.org/badge/latest-versions/openssl.svg?header=latest
+[repology:openssl/versions]: https://repology.org/project/openssl/versions
+[repology:pcre.svg]: https://repology.org/badge/latest-versions/pcre.svg?header=latest
+[repology:pcre/versions]: https://repology.org/project/pcre/versions
+[repology:pcre2.svg]: https://repology.org/badge/latest-versions/pcre2.svg?header=latest
+[repology:pcre2/versions]: https://repology.org/project/pcre2/versions
+[repology:wasi-libc.svg]: https://repology.org/badge/latest-versions/wasi-libc.svg?header=latest
+[repology:wasi-libc/versions]: https://repology.org/project/wasi-libc/versions
+[repology:zlib.svg]: https://repology.org/badge/latest-versions/zlib.svg?header=latest
+[repology:zlib/versions]: https://repology.org/project/zlib/versions

--- a/docs/man/required_libraries.md
+++ b/docs/man/required_libraries.md
@@ -42,8 +42,11 @@ These libraries are required by different parts of the standard library, only wh
 
 ### Regular Expression engine
 
-Engine implementation for the [`Regex`](https://crystal-lang.org/api/Regex.html) class.
-PCRE2 support was added in Crystal 1.7 and it's the default since 1.8 (see [Regex documentation](../syntax_and_semantics/literals/regex.md)).
+Engine implementation for the [`Regex`][Regex] class.
+PCRE2 support was added in Crystal 1.7 and it's the default since 1.8 (see [Regex documentation]).
+
+[Regex]: https://crystal-lang.org/api/Regex.html
+[Regex documentation]: ../syntax_and_semantics/literals/regex.md
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
@@ -52,7 +55,9 @@ PCRE2 support was added in Crystal 1.7 and it's the default since 1.8 (see [Rege
 
 ### Big Numbers
 
-Implementations for `Big` types such as [`BigInt`](https://crystal-lang.org/api/BigInt.html).
+Implementations for `Big` types such as [`BigInt`][BigInt].
+
+[BigInt]: https://crystal-lang.org/api/BigInt.html
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
@@ -70,23 +75,31 @@ Using a standalone library over the system library implementation can be enforce
 
 ### TLS
 
-TLS protocol implementation and general-purpose cryptographic routines for the [`OpenSSL`](https://crystal-lang.org/api/OpenSSL.html) API. May be disabled with the `-Dwithout_openssl` [compile-time flag](../syntax_and_semantics/compile_time_flags.md#stdlib-features).
+TLS protocol implementation and general-purpose cryptographic routines for the [`OpenSSL`][OpenSSL] API. May be disabled with the `-Dwithout_openssl` [compile-time flag][stdlib-features].
 
 Both `OpenSSL` and `LibreSSL` are supported and the bindings automatically detect which library and API version is available on the host system.
 
+[OpenSSL]:https://crystal-lang.org/api/OpenSSL.html
+[stdlib-features]: ../syntax_and_semantics/compile_time_flags.md#stdlib-features
+
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [OpenSSL][openssl]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/openssl.svg?header=latest)](https://repology.org/project/openssl/versions) | Implementation of the SSL and TLS protocols <br>**Supported versions:** 1.1.1+–3.4+ | [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)](https://www.openssl.org/source/license.html) |
+| [OpenSSL][openssl.org]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/openssl.svg?header=latest)](https://repology.org/project/openssl/versions) | Implementation of the SSL and TLS protocols <br>**Supported versions:** 1.1.1+–3.4+ | [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)](https://www.openssl.org/source/license.html) |
 | [LibreSSL][libressl]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/libressl.svg?header=latest)](https://repology.org/project/libressl/versions) | Implementation of the SSL and TLS protocols; forked from OpenSSL in 2014 <br>**Supported versions:** 3.0–4.0+ | [ISC / OpenSSL / SSLeay](https://github.com/libressl-portable/openbsd/blob/master/src/lib/libssl/LICENSE) |
 
 ### Other stdlib libraries
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [LibXML2][libxml2]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/libxml2.svg?header=latest)](https://repology.org/project/libxml2/versions) | XML parser developed for the Gnome project. Implements the [`XML`](https://crystal-lang.org/api/XML.html) module.<br>**Supported versions:** LibXML2 2.9–2.14 | [MIT](https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/Copyright) |
-| [LibYAML][libyaml]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/libyaml.svg?header=latest)](https://repology.org/project/libyaml/versions) | YAML parser and emitter library. Implements the [`YAML`](https://crystal-lang.org/api/YAML.html) module. | [MIT](https://github.com/yaml/libyaml/blob/master/License) |
-| [zlib][zlib]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/zlib.svg?header=latest)](https://repology.org/project/zlib/versions) | Lossless data compression library. Implements the [`Compress`](https://crystal-lang.org/api/Compress.html) module. May be disabled with the `-Dwithout_zlib` compile-time flag. | [zlib](http://zlib.net/zlib_license.html) |
-| [LLVM][libllvm]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/llvm.svg?header=latest)](https://repology.org/project/llvm/versions) | Target-independent code generator and optimizer. Implements the [`LLVM`](https://crystal-lang.org/api/LLVM.html) API. <br>**Supported versions:** LLVM 8-22 (aarch64 requires LLVM 13+) | [Apache v2 with LLVM exceptions](https://llvm.org/docs/DeveloperPolicy.html#new-llvm-project-license-framework) |
+| [LibXML2][libxml2]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/libxml2.svg?header=latest)](https://repology.org/project/libxml2/versions) | XML parser developed for the Gnome project. Implements the [`XML`][XML] module.<br>**Supported versions:** LibXML2 2.9–2.14 | [MIT](https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/Copyright) |
+| [LibYAML][libyaml]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/libyaml.svg?header=latest)](https://repology.org/project/libyaml/versions) | YAML parser and emitter library. Implements the [`YAML`][YAML] module. | [MIT](https://github.com/yaml/libyaml/blob/master/License) |
+| [zlib][zlib]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/zlib.svg?header=latest)](https://repology.org/project/zlib/versions) | Lossless data compression library. Implements the [`Compress`][Compress] module. May be disabled with the `-Dwithout_zlib` compile-time flag. | [zlib](http://zlib.net/zlib_license.html) |
+| [LLVM][libllvm]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/llvm.svg?header=latest)](https://repology.org/project/llvm/versions) | Target-independent code generator and optimizer. Implements the [`LLVM`][LLVM] API. <br>**Supported versions:** LLVM 8-22 (aarch64 requires LLVM 13+) | [Apache v2 with LLVM exceptions](https://llvm.org/docs/DeveloperPolicy.html#new-llvm-project-license-framework) |
+
+[XML]: https://crystal-lang.org/api/XML.html
+[YAML]: https://crystal-lang.org/api/YAML.html
+[Compress]: https://crystal-lang.org/api/Compress.html
+[LLVM]: https://crystal-lang.org/api/LLVM.html
 
 ## Compiler dependencies
 
@@ -94,10 +107,13 @@ In addition to the [core runtime dependencies](#core-runtime-dependencies), thes
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [PCRE2][libpcre] | See [*Regular expression engine*](#regular-expression-engine) | |
-| [LLVM][libllvm] | See [*Other stdlib libraries*](#other-stdlib-libraries) | [Apache v2 with LLVM exceptions](https://llvm.org/docs/DeveloperPolicy.html#new-llvm-project-license-framework) |
+| [PCRE2][libpcre] | See [*Regular expression engine*] | |
+| [LLVM][libllvm] | See [*Other stdlib libraries*] | [Apache v2 with LLVM exceptions](https://llvm.org/docs/DeveloperPolicy.html#new-llvm-project-license-framework) |
 | [libffi][libffi]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/libffi.svg?header=latest)](https://repology.org/project/libffi/versions) | Foreign function interface. Used for implementing binary interfaces in the interpreter. May be disabled with the `-Dwithout_interpreter` compile-time flag. | [MIT](https://github.com/libffi/libffi/blob/master/LICENSE) |
-| [libxml2][libxml2] | Optional dependency for docs sanitizer. May be disabled with the `-Dwithout_libxml2` compile-time flag. See [*Other stdlib libraries*](#other-stdlib-libraries) | [MIT](https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/Copyright) |
+| [libxml2][libxml2] | Optional dependency for docs sanitizer. May be disabled with the `-Dwithout_libxml2` compile-time flag. See [*Other stdlib libraries*] | [MIT](https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/Copyright) |
+
+[*Other stdlib libraries*]: #other-stdlib-libraries
+[*Regular expression engine*]: #regular-expression-engine
 
 [bionic-libc]: https://android.googlesource.com/platform/bionic/+/refs/heads/master/libc/
 [compiler-rt]: https://compiler-rt.llvm.org/
@@ -121,7 +137,7 @@ In addition to the [core runtime dependencies](#core-runtime-dependencies), thes
 [musl-libc]: https://musl.libc.org/
 [netbsd-libc]: http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/?only_with_tag=MAIN
 [openbsd-libc]: http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/lib/libc/
-[openssl]: https://www.openssl.org/
+[openssl.org]: https://www.openssl.org/
 [ucrt]: https://learn.microsoft.com/en-us/cpp/windows/universal-crt-deployment?view=msvc-170
 [wasi]: https://wasi.dev/
 [zlib]: http://zlib.net/

--- a/docs/man/required_libraries.md
+++ b/docs/man/required_libraries.md
@@ -15,26 +15,59 @@ which may be part of the C library or standalone libraries. On most platforms al
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [glibc][glibc]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/glibc.svg?header=latest)](https://repology.org/project/glibc/versions) | standard C library for Linux <br>**Supported versions:** GNU libc 2.26+ | [LGPL](https://www.gnu.org/licenses/lgpl-3.0.en.html) |
-| [musl libc][musl-libc]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/musl.svg?header=latest)](https://repology.org/project/musl/versions) | standard C library for Linux <br>**Supported versions:** MUSL libc 1.2+ | [MIT](https://git.musl-libc.org/cgit/musl/tree/COPYRIGHT) |
-| [FreeBSD libc][freebsd-libc]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/freebsd.svg?header=latest)](https://repology.org/project/freebsd/versions) | standard C library for FreeBSD <br>**Supported versions:** 12+ | [BSD](https://www.freebsd.org/copyright/freebsd-license/) |
-| [NetBSD libc][netbsd-libc] | standard C library for NetBSD | [BSD](http://www.netbsd.org/about/redistribution.html) |
-| [OpenBSD libc][openbsd-libc]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/openbsd.svg?header=latest)](https://repology.org/project/openbsd/versions) | standard C library for OpenBSD <br>**Supported versions:** 6+ | [BSD](https://www.openbsd.org/policy.html) |
-| [Dragonfly libc][dragonfly-libc] | standard C library for DragonflyBSD | [BSD](https://www.dragonflybsd.org/docs/developer/DragonFly_BSD_License/) |
-| [macOS libsystem][macos-libsystem] | standard C library for macOS <br>**Supported versions:** 11+ | [Apple](https://github.com/apple-oss-distributions/Libsystem/blob/main/APPLE_LICENSE) |
+| [glibc][glibc]<br>[![latest packaged version(s)][repology:glibc.svg]][repology:glibc/versions] | standard C library for Linux <br>**Supported versions:** GNU libc 2.26+ | [LGPL 3.0] |
+| [musl libc][musl-libc]<br>[![latest packaged version(s)][repology:musl.svg]][repology:musl/versions] | standard C library for Linux <br>**Supported versions:** MUSL libc 1.2+ | [MIT][musl-copyright] |
+| [FreeBSD libc][freebsd-libc]<br>[![latest packaged version(s)][repology:freebsd.svg]][repology:freebsd/versions] | standard C library for FreeBSD <br>**Supported versions:** 12+ | [BSD][freebsd-license] |
+| [NetBSD libc][netbsd-libc] | standard C library for NetBSD | [BSD][netbsd-license] |
+| [OpenBSD libc][openbsd-libc]<br>[![latest packaged version(s)][repology:openbsd.svg]][repology:openbsd/versions] | standard C library for OpenBSD <br>**Supported versions:** 6+ | [BSD][openbsd-policy] |
+| [Dragonfly libc][dragonfly-libc] | standard C library for DragonflyBSD | [BSD][dragonfly-license] |
+| [macOS libsystem][macos-libsystem] | standard C library for macOS <br>**Supported versions:** 11+ | [Apple][APPLE_LICENSE] |
 | [MSVCRT][msvcrt] | standard C library for Visual Studio 2013 or below | |
-| [UCRT][ucrt] | Universal CRT for Windows / Visual Studio 2015+ | [MIT subset available](https://www.nuget.org/packages/Microsoft.Windows.SDK.CRTSource/10.0.22621.3/License) |
-| [WASI][wasi]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/wasi-libc.svg?header=latest)](https://repology.org/project/wasi-libc/versions) | WebAssembly System Interface | [Apache v2 and others](https://github.com/WebAssembly/wasi-libc/blob/main/LICENSE) |
-| [bionic libc][bionic-libc] | C library for Android <br>**Supported versions:** ABI Level 24+ | [BSD-like](https://android.googlesource.com/platform/bionic/+/refs/heads/master/libc/NOTICE) |
-| [illumos libc][illumos-libc] | System library for Illumos | [CDDL](https://illumos.org/license/CDDL) |
+| [UCRT][ucrt] | Universal CRT for Windows / Visual Studio 2015+ | [MIT subset available][MIT-windows] |
+| [WASI][wasi]<br>[![latest packaged version(s)][repology:wasi-libc.svg]][repology:wasi-libc/versions] | WebAssembly System Interface | [Apache v2 and others][wasi-license] |
+| [bionic libc][bionic-libc] | C library for Android <br>**Supported versions:** ABI Level 24+ | [BSD-like][android-notice] |
+| [illumos libc][illumos-libc] | System library for Illumos | [CDDL] |
+
+[repology:glibc/versions]: https://repology.org/project/glibc/versions
+[repology:glibc.svg]: https://repology.org/badge/latest-versions/glibc.svg?header=latest
+[repology:musl/versions]: https://repology.org/project/musl/versions
+[repology:musl.svg]: https://repology.org/badge/latest-versions/musl.svg?header=latest
+[repology:freebsd/versions]: https://repology.org/project/freebsd/versions
+[repology:freebsd.svg]: https://repology.org/badge/latest-versions/freebsd.svg?header=latest
+[repology:openbsd/versions]: https://repology.org/project/openbsd/versions
+[repology:openbsd.svg]: https://repology.org/badge/latest-versions/openbsd.svg?header=latest
+[repology:wasi-libc/versions]: https://repology.org/project/wasi-libc/versions
+[repology:wasi-libc.svg]: https://repology.org/badge/latest-versions/wasi-libc.svg?header=latest
+
+[LGPL 3.0]: https://www.gnu.org/licenses/lgpl-3.0.en.html
+[musl-copyright]: https://git.musl-libc.org/cgit/musl/tree/COPYRIGHT
+[freebsd-license]: https://www.freebsd.org/copyright/freebsd-license/
+[netbsd-license]: http://www.netbsd.org/about/redistribution.html
+[openbsd-policy]: https://www.openbsd.org/policy.html
+[dragonfly-license]: https://www.dragonflybsd.org/docs/developer/DragonFly_BSD_License/
+[APPLE_LICENSE]: https://github.com/apple-oss-distributions/Libsystem/blob/main/APPLE_LICENSE
+[MIT-windows]: https://www.nuget.org/packages/Microsoft.Windows.SDK.CRTSource/10.0.22621.3/License
+[wasi-license]: https://github.com/WebAssembly/wasi-libc/blob/main/LICENSE
+[android-notice]: https://android.googlesource.com/platform/bionic/+/refs/heads/master/libc/NOTICE
+[CDDL]: https://illumos.org/license/CDDL
 
 ### Other runtime libraries
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [Boehm GC][libgc]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/boehm-gc.svg?header=latest)](https://repology.org/project/boehm-gc/versions) | The Boehm-Demers-Weiser conservative garbage collector. Performs automatic memory management.<br>**Supported versions:** 8.2.0+; earlier versions require a patch for MT support | [MIT-style](https://github.com/ivmai/bdwgc/blob/master/LICENSE) |
-| [Libevent][libevent]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/llvm.svg?header=latest)](https://repology.org/project/llvm/versions) | An event notification library. Implements the event loop on OpenBSD, NetBSD, DragonflyBSD and Solaris by default and on other Unix-like systems with `-Devloop=libevent` ([availability](https://github.com/crystal-lang/rfcs/blob/main/text/0009-lifetime-event_loop.md#availability)). Never used on Windows or WASI. | [Modified BSD](https://github.com/libevent/libevent/blob/master/LICENSE) |
+| [Boehm GC][libgc]<br>[![latest packaged version(s)][repology:boehm-gc.svg]][repology:boehm-gc/versions] | The Boehm-Demers-Weiser conservative garbage collector. Performs automatic memory management.<br>**Supported versions:** 8.2.0+; earlier versions require a patch for MT support | [MIT-style][bdwgc-license] |
+| [Libevent][libevent]<br>[![latest packaged version(s)][repology:llvm.svg]][repology:llvm/versions] | An event notification library. Implements the event loop on OpenBSD, NetBSD, DragonflyBSD and Solaris by default and on other Unix-like systems with `-Devloop=libevent` ([availability][RFC0009]). Never used on Windows or WASI. | [Modified BSD][libevent-license] |
 | [compiler-rt builtins][compiler-rt] | Provides optimized implementations for low-level routines required by code generation, such as integer multiplication. Several of these routines are ported to Crystal directly. | [MIT / UIUC][compiler-rt] |
+
+[repology:boehm-gc/versions]: https://repology.org/project/boehm-gc/versions
+[repology:boehm-gc.svg]: https://repology.org/badge/latest-versions/boehm-gc.svg?header=latest
+[repology:llvm/versions]: https://repology.org/project/llvm/versions
+[repology:llvm.svg]: https://repology.org/badge/latest-versions/llvm.svg?header=latest
+
+[bdwgc-license]: https://github.com/ivmai/bdwgc/blob/master/LICENSE
+[libevent-license]: https://github.com/libevent/libevent/blob/master/LICENSE
+
+[RFC0009]: https://github.com/crystal-lang/rfcs/blob/main/text/0009-lifetime-event_loop.md#availability
 
 ## Optional standard library dependencies
 
@@ -50,8 +83,15 @@ PCRE2 support was added in Crystal 1.7 and it's the default since 1.8 (see [Rege
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [PCRE2][libpcre]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/pcre2.svg?header=latest)](https://repology.org/project/pcre2/versions) | Perl Compatible Regular Expressions, version 2.<br>**Supported versions:** all (recommended: 10.36+) | [BSD](http://www.pcre.org/licence.txt) |
-| [PCRE][libpcre]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/pcre.svg?header=latest)](https://repology.org/project/pcre/versions) | Perl Compatible Regular Expressions. | [BSD](http://www.pcre.org/licence.txt) |
+| [PCRE2][libpcre]<br>[![latest packaged version(s)][repology:pcre2.svg]][repology:pcre2/versions] | Perl Compatible Regular Expressions, version 2.<br>**Supported versions:** all (recommended: 10.36+) | [BSD][pcre-license] |
+| [PCRE][libpcre]<br>[![latest packaged version(s)][repology:pcre.svg]][repology:pcre/versions] | Perl Compatible Regular Expressions. | [BSD][pcre-license] |
+
+[repology:pcre2/versions]: https://repology.org/project/pcre2/versions
+[repology:pcre2.svg]: https://repology.org/badge/latest-versions/pcre2.svg?header=latest
+[repology:pcre/versions]: https://repology.org/project/pcre/versions
+[repology:pcre.svg]: https://repology.org/badge/latest-versions/pcre.svg?header=latest
+
+[pcre-license]: http://www.pcre.org/licence.txt
 
 ### Big Numbers
 
@@ -61,8 +101,17 @@ Implementations for `Big` types such as [`BigInt`][BigInt].
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [GMP][libgmp]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/gmp.svg?header=latest)](https://repology.org/project/gmp/versions) | GNU multiple precision arithmetic library. | [LGPL v3+ / GPL v2+](https://gmplib.org/manual/Copying) |
-| [MPIR][libmpir]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/mpir.svg?header=latest)](https://repology.org/project/mpir/versions) | Multiple Precision Integers and Rationals, forked from GMP. Used on Windows MSVC. | [GPL-3.0](https://github.com/wbhart/mpir/blob/master/COPYING) and [LGPL-3.0](https://github.com/wbhart/mpir/blob/master/COPYING.LIB) |
+| [GMP][libgmp]<br>[![latest packaged version(s)][repology:gmp.svg]][repology:gmp/versions] | GNU multiple precision arithmetic library. | [LGPL v3+ / GPL v2+][gmp-license] |
+| [MPIR][libmpir]<br>[![latest packaged version(s)][repology:mpir.svg]][repology:mpir/versions] | Multiple Precision Integers and Rationals, forked from GMP. Used on Windows MSVC. | [GPL-3.0][mpir-copying] and [LGPL-3.0][mpir-copying.lib] |
+
+[repology:gmp/versions]: https://repology.org/project/gmp/versions
+[repology:gmp.svg]: https://repology.org/badge/latest-versions/gmp.svg?header=latest
+[repology:mpir/versions]: https://repology.org/project/mpir/versions
+[repology:mpir.svg]: https://repology.org/badge/latest-versions/mpir.svg?header=latest
+
+[gmp-license]: https://gmplib.org/manual/Copying
+[mpir-copying]: https://github.com/wbhart/mpir/blob/master/COPYING
+[mpir-copying.lib]: https://github.com/wbhart/mpir/blob/master/COPYING.LIB
 
 ### Internationalization conversion
 
@@ -71,7 +120,10 @@ Using a standalone library over the system library implementation can be enforce
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [libiconv][libiconv-gnu] (GNU)<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/libiconv.svg?header=latest)](https://repology.org/project/libiconv/versions) | Internationalization conversion library. | [LGPL-3.0](https://www.gnu.org/licenses/lgpl.html) |
+| [libiconv][libiconv-gnu] (GNU)<br>[![latest packaged version(s)][repology:libiconv.svg]][repology:libiconv/versions] | Internationalization conversion library. | [LGPL 3.0] |
+
+[repology:libiconv/versions]: https://repology.org/project/libiconv/versions
+[repology:libiconv.svg]: https://repology.org/badge/latest-versions/libiconv.svg?header=latest
 
 ### TLS
 
@@ -84,17 +136,37 @@ Both `OpenSSL` and `LibreSSL` are supported and the bindings automatically detec
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [OpenSSL][openssl.org]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/openssl.svg?header=latest)](https://repology.org/project/openssl/versions) | Implementation of the SSL and TLS protocols <br>**Supported versions:** 1.1.1+–3.4+ | [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)](https://www.openssl.org/source/license.html) |
-| [LibreSSL][libressl]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/libressl.svg?header=latest)](https://repology.org/project/libressl/versions) | Implementation of the SSL and TLS protocols; forked from OpenSSL in 2014 <br>**Supported versions:** 3.0–4.0+ | [ISC / OpenSSL / SSLeay](https://github.com/libressl-portable/openbsd/blob/master/src/lib/libssl/LICENSE) |
+| [OpenSSL][openssl.org]<br>[![latest packaged version(s)][repology:openssl.svg]][repology:openssl/versions] | Implementation of the SSL and TLS protocols <br>**Supported versions:** 1.1.1+–3.4+ | [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)] |
+| [LibreSSL][libressl]<br>[![latest packaged version(s)][repology:libressl.svg]][repology:libressl/versions] | Implementation of the SSL and TLS protocols; forked from OpenSSL in 2014 <br>**Supported versions:** 3.0–4.0+ | [ISC / OpenSSL / SSLeay] |
+
+[repology:openssl/versions]: https://repology.org/project/openssl/versions
+[repology:openssl.svg]: https://repology.org/badge/latest-versions/openssl.svg?header=latest
+[repology:libressl/versions]: https://repology.org/project/libressl/versions
+[repology:libressl.svg]: https://repology.org/badge/latest-versions/libressl.svg?header=latest
+
+[Apache v2 (3.0+), OpenSSL / SSLeay (1.x)]: https://www.openssl.org/source/license.html
+[ISC / OpenSSL / SSLeay]: https://github.com/libressl-portable/openbsd/blob/master/src/lib/libssl/LICENSE
 
 ### Other stdlib libraries
 
 | Library | Description | License |
 | ------- | ----------- | ------- |
-| [LibXML2][libxml2]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/libxml2.svg?header=latest)](https://repology.org/project/libxml2/versions) | XML parser developed for the Gnome project. Implements the [`XML`][XML] module.<br>**Supported versions:** LibXML2 2.9–2.14 | [MIT](https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/Copyright) |
-| [LibYAML][libyaml]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/libyaml.svg?header=latest)](https://repology.org/project/libyaml/versions) | YAML parser and emitter library. Implements the [`YAML`][YAML] module. | [MIT](https://github.com/yaml/libyaml/blob/master/License) |
-| [zlib][zlib]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/zlib.svg?header=latest)](https://repology.org/project/zlib/versions) | Lossless data compression library. Implements the [`Compress`][Compress] module. May be disabled with the `-Dwithout_zlib` compile-time flag. | [zlib](http://zlib.net/zlib_license.html) |
-| [LLVM][libllvm]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/llvm.svg?header=latest)](https://repology.org/project/llvm/versions) | Target-independent code generator and optimizer. Implements the [`LLVM`][LLVM] API. <br>**Supported versions:** LLVM 8-22 (aarch64 requires LLVM 13+) | [Apache v2 with LLVM exceptions](https://llvm.org/docs/DeveloperPolicy.html#new-llvm-project-license-framework) |
+| [LibXML2][libxml2]<br>[![latest packaged version(s)][repology:libxml2.svg]][repology:libxml2/versions] | XML parser developed for the Gnome project. Implements the [`XML`][XML] module.<br>**Supported versions:** LibXML2 2.9–2.14 | [MIT][gnome-license] |
+| [LibYAML][libyaml]<br>[![latest packaged version(s)][repology:libyaml.svg]][repology:libyaml/versions] | YAML parser and emitter library. Implements the [`YAML`][YAML] module. | [MIT][yaml-license] |
+| [zlib][zlib]<br>[![latest packaged version(s)][repology:zlib.svg]][repology:zlib/versions] | Lossless data compression library. Implements the [`Compress`][Compress] module. May be disabled with the `-Dwithout_zlib` compile-time flag. | [zlib][zlib-license] |
+| [LLVM][libllvm]<br>[![latest packaged version(s)][repology:llvm.svg]][repology:llvm/versions] | Target-independent code generator and optimizer. Implements the [`LLVM`][LLVM] API. <br>**Supported versions:** LLVM 8-22 (aarch64 requires LLVM 13+) | [Apache v2 with LLVM exceptions] |
+
+[repology:libxml2/versions]: https://repology.org/project/libxml2/versions
+[repology:libxml2.svg]: https://repology.org/badge/latest-versions/libxml2.svg?header=latest
+[repology:libyaml/versions]: https://repology.org/project/libyaml/versions
+[repology:libyaml.svg]: https://repology.org/badge/latest-versions/libyaml.svg?header=latest
+[repology:zlib/versions]: https://repology.org/project/zlib/versions
+[repology:zlib.svg]: https://repology.org/badge/latest-versions/zlib.svg?header=latest
+
+[gnome-license]: https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/Copyright
+[yaml-license]: https://github.com/yaml/libyaml/blob/master/License
+[zlib-license]: http://zlib.net/zlib_license.html
+[Apache v2 with LLVM exceptions]: https://llvm.org/docs/DeveloperPolicy.html#new-llvm-project-license-framework
 
 [XML]: https://crystal-lang.org/api/XML.html
 [YAML]: https://crystal-lang.org/api/YAML.html
@@ -108,12 +180,17 @@ In addition to the [core runtime dependencies](#core-runtime-dependencies), thes
 | Library | Description | License |
 | ------- | ----------- | ------- |
 | [PCRE2][libpcre] | See [*Regular expression engine*] | |
-| [LLVM][libllvm] | See [*Other stdlib libraries*] | [Apache v2 with LLVM exceptions](https://llvm.org/docs/DeveloperPolicy.html#new-llvm-project-license-framework) |
-| [libffi][libffi]<br>[![latest packaged version(s)](https://repology.org/badge/latest-versions/libffi.svg?header=latest)](https://repology.org/project/libffi/versions) | Foreign function interface. Used for implementing binary interfaces in the interpreter. May be disabled with the `-Dwithout_interpreter` compile-time flag. | [MIT](https://github.com/libffi/libffi/blob/master/LICENSE) |
-| [libxml2][libxml2] | Optional dependency for docs sanitizer. May be disabled with the `-Dwithout_libxml2` compile-time flag. See [*Other stdlib libraries*] | [MIT](https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/Copyright) |
+| [LLVM][libllvm] | See [*Other stdlib libraries*] | [Apache v2 with LLVM exceptions] |
+| [libffi][libffi]<br>[![latest packaged version(s)][repology:libffi.svg]][repology:libffi/versions] | Foreign function interface. Used for implementing binary interfaces in the interpreter. May be disabled with the `-Dwithout_interpreter` compile-time flag. | [MIT][ffi-license] |
+| [libxml2][libxml2] | Optional dependency for docs sanitizer. May be disabled with the `-Dwithout_libxml2` compile-time flag. See [*Other stdlib libraries*] | [MIT][gnome-license] |
 
 [*Other stdlib libraries*]: #other-stdlib-libraries
 [*Regular expression engine*]: #regular-expression-engine
+
+[repology:libffi/versions]: https://repology.org/project/libffi/versions
+[repology:libffi.svg]: https://repology.org/badge/latest-versions/libffi.svg?header=latest
+
+[ffi-license]: https://github.com/libffi/libffi/blob/master/LICENSE
 
 [bionic-libc]: https://android.googlesource.com/platform/bionic/+/refs/heads/master/libc/
 [compiler-rt]: https://compiler-rt.llvm.org/

--- a/docs/syntax_and_semantics/compile_time_flags.md
+++ b/docs/syntax_and_semantics/compile_time_flags.md
@@ -9,7 +9,7 @@ User-provided flags are passed to the compiler, which allow them to be used as f
 ## Querying flags
 
 A flag is a named identifier which is either set or not.
-The status can be queried from code via the macro method [`flag?`](https://crystal-lang.org/api/Crystal/Macros.html#flag%3F%28name%29%3ABoolLiteral-instance-method). It receives the name of a flag as a string or symbol
+The status can be queried from code via the macro method [`flag?`][flag?]. It receives the name of a flag as a string or symbol
 literal and returns a bool literal indicating the flag's state. A flag can have an optional value, in which case the macro method `flag?` returns a string literal instead of a bool literal.
 
 The following program shows the use of compile-time flags by printing the target OS family.
@@ -26,9 +26,12 @@ The following program shows the use of compile-time flags by printing the target
 {% end %}
 ```
 
-There's also the macro method [`host_flag?`](https://crystal-lang.org/api/Crystal/Macros.html#host_flag%3F%28name%29%3ABoolLiteral-instance-method)
+There's also the macro method [`host_flag?`][host_flag?]
 which returns whether a flag is set for the *host* platform, which can differ
 from the target platform (queried by `flag?`) during cross-compilation.
+
+[flag?]: https://crystal-lang.org/api/Crystal/Macros.html#flag%3F%28name%29%3ABoolLiteral-instance-method
+[host_flag?]: https://crystal-lang.org/api/Crystal/Macros.html#host_flag%3F%28name%29%3ABoolLiteral-instance-method
 
 ## Compiler-provided flags
 
@@ -36,12 +39,15 @@ The compiler defines a couple of implicit flags. They describe either the target
 
 ### Target platform flags
 
-Platform-specific flags derive from the [target triple](http://llvm.org/docs/LangRef.html#target-triple).
-See [Platform Support](platform_support.md) for a list of supported target platforms.
+Platform-specific flags derive from the [target triple].
+See [Platform Support] for a list of supported target platforms.
 
 `crystal --version` shows the default target triple of the compiler. It can be changed with the `--target` option.
 
 The flags in each of the following tables are mutually exclusive, except for those marked as *(derived)*.
+
+[target triple]: http://llvm.org/docs/LangRef.html#target-triple
+[Platform Support]: platform_support.md
 
 #### Architecture
 
@@ -143,14 +149,14 @@ Crystal program.
 
 | Flag name | Description |
 | --------- | ----------- |
-| `gc_none` | Disables garbage collection ([#5314](https://github.com/crystal-lang/crystal/pull/5314)) |
+| `gc_none` | Disables garbage collection ([#5314]) |
 | `debug_raise` | Debugging flag for `raise` logic. Prints the backtrace before raising. |
-| `evloop=epoll`, `evloop=kqueue`, `evloop=libevent` | Select event loop driver ([RFC 0009](https://github.com/crystal-lang/rfcs/blob/main/text/0009-lifetime-event_loop.md#availability)). Introduced in 1.15 |
-| `execution_context` | Enable execution contexts preview ([RFC 0002](https://github.com/crystal-lang/rfcs/blob/main/text/0002-execution-contexts.md)). [Introduced in 1.16](https://github.com/crystal-lang/crystal/issues/15350) |
+| `evloop=epoll`, `evloop=kqueue`, `evloop=libevent` | Select event loop driver ([RFC 0009]). Introduced in 1.15 |
+| `execution_context` | Enable execution contexts preview ([RFC 0002]). [Introduced in 1.16][#15350] |
 | `execvpe_impl` | Experimental flag for choosing the custom `execvpe` implementation instead of the system function. Introduced in 1.19 |
-| `preview_mt` | Enables multithreading preview. Introduced in 0.28.0 ([#7546](https://github.com/crystal-lang/crystal/pull/7546)) |
+| `preview_mt` | Enables multithreading preview. Introduced in 0.28.0 ([#7546]) |
 | `skip_crystal_compiler_rt` | Exclude Crystal's native `compiler-rt` implementation. |
-| `tracing` | Build with support for [runtime tracing](../guides/runtime_tracing.md). |
+| `tracing` | Build with support for [runtime tracing]. |
 | `use_libiconv` | Use `libiconv` instead of the `iconv` system library |
 | `use_pcre2` | Use PCRE2 as regex engine (instead of legacy PCRE). Introduced in 1.7.0. |
 | `use_pcre` | Use PCRE as regex engine (instead of PCRE2). Introduced in 1.8.0. |
@@ -159,16 +165,30 @@ Crystal program.
 | `without_openssl` | Build without OpenSSL support |
 | `without_zlib` | Build without Zlib support |
 
+[#5314]: https://github.com/crystal-lang/crystal/pull/5314
+[RFC 0009]: https://github.com/crystal-lang/rfcs/blob/main/text/0009-lifetime-event_loop.md#availability
+[RFC 0002]: https://github.com/crystal-lang/rfcs/blob/main/text/0002-execution-contexts.md
+[#15350]: https://github.com/crystal-lang/crystal/issues/15350
+[#7546]: https://github.com/crystal-lang/crystal/pull/7546
+[runtime tracing]: ../guides/runtime_tracing.md
+
 ### Language features
 
 These flags enable or disable language features when building a Crystal program.
 
 | Flag name | Description |
 | --------- | ----------- |
-| `no_number_autocast` | Will not [autocast](autocasting.md#number-autocasting) numeric expressions, only literals |
-| `no_restrictions_augmenter` | Disable enhanced restrictions augmenter. Introduced in 1.5 ([#12103](https://github.com/crystal-lang/crystal/pull/12103)). |
-| `preview_overload_order` | Enable more robust ordering between def overloads. Introduced in 1.6 ([#10711](https://github.com/crystal-lang/crystal/issues/10711)). |
-| `strict_multi_assign` | Enable strict semantics for [one-to-many assignment](assignment.md#one-to-many-assignment). Introduced in 1.3.0 ([#11145](https://github.com/crystal-lang/crystal/pull/11145), [#11545](https://github.com/crystal-lang/crystal/pull/11545)) |
+| `no_number_autocast` | Will not [autocast] numeric expressions, only literals |
+| `no_restrictions_augmenter` | Disable enhanced restrictions augmenter. Introduced in 1.5 ([#12103]). |
+| `preview_overload_order` | Enable more robust ordering between def overloads. Introduced in 1.6 ([#10711]). |
+| `strict_multi_assign` | Enable strict semantics for [one-to-many assignment]. Introduced in 1.3.0 ([#11145], [#11545]) |
+
+[autocast]: autocasting.md#number-autocasting
+[#12103]: https://github.com/crystal-lang/crystal/pull/12103
+[#10711]: https://github.com/crystal-lang/crystal/issues/10711
+[one-to-many assignment]: assignment.md#one-to-many-assignment
+[#11145]: https://github.com/crystal-lang/crystal/pull/11145
+[#11545]: https://github.com/crystal-lang/crystal/pull/11545
 
 ### Codegen features
 
@@ -176,8 +196,10 @@ These flags enable or disable codegen features when building a Crystal program.
 
 | Flag name | Description |
 | --------- | ----------- |
-| `cf-protection=branch`, `cf-protection=return`, `cf-protection=full` | Indirect branch tracking for x86 and x86_64. Implicitly set on OpenBSD. Introduced in 1.15.0 ([#15122](https://github.com/crystal-lang/crystal/pull/15122)) |
-| `branch-protection=bti` | Indirect branch tracking for aarch64. Implicitly set on OpenBSD. Introduced in 1.15.0 ([#15122](https://github.com/crystal-lang/crystal/pull/15122)) |
+| `cf-protection=branch`, `cf-protection=return`, `cf-protection=full` | Indirect branch tracking for x86 and x86_64. Implicitly set on OpenBSD. Introduced in 1.15.0 ([#15122]) |
+| `branch-protection=bti` | Indirect branch tracking for aarch64. Implicitly set on OpenBSD. Introduced in 1.15.0 ([#15122]) |
+
+[#15122]: https://github.com/crystal-lang/crystal/pull/15122
 
 ### Compiler build features
 
@@ -187,9 +209,11 @@ These flags enable or disable features when building the Crystal compiler.
 | --------- | ----------- |
 | `without_ffi` | Build the compiler without `libffi` |
 | `without_interpreter` | Build the compiler without interpreter support |
-| `without_libxml2` | Build the compiler without sanitization for the doc generator. [Introduced in 1.19](https://github.com/crystal-lang/crystal/pull/14646).<br> Note: The default `Makefile` passes this flag unless `docs_sanitizer=1` |
+| `without_libxml2` | Build the compiler without sanitization for the doc generator. [Introduced in 1.19][#14646].<br> Note: The default `Makefile` passes this flag unless `docs_sanitizer=1` |
 | `without_playground` | Build the compiler without playground (`crystal play`) |
 | `i_know_what_im_doing` | Safety guard against involuntarily building the compiler |
+
+[#14646]: https://github.com/crystal-lang/crystal/pull/14646
 
 ### User code features
 

--- a/docs/syntax_and_semantics/literals/README.md
+++ b/docs/syntax_and_semantics/literals/README.md
@@ -2,22 +2,40 @@
 
 Crystal provides several literals for creating values of some basic types.
 
-| Literal                                        | Sample values                                           |
-| ---------------------------------------------- | ------------------------------------------------------- |
-| [Nil](nil.md)                                  | `nil`                                                   |
-| [Bool](bool.md)                                | `true`, `false`                                         |
-| [Integers](integers.md)                        | `18`, `-12`, `19_i64`, `14_u32`,`64_u8`                 |
-| [Floats](floats.md)                            | `1.0`, `1.0_f32`, `1e10`, `-0.5`                        |
-| [Char](char.md)                                | `'a'`, `'\n'`, `'あ'`                                   |
-| [String](string.md)                            | `"foo\tbar"`, `%("あ")`, `%q(foo #{foo})`               |
-| [Symbol](symbol.md)                            | `:symbol`, `:"foo bar"`                                 |
-| [Array](array.md)                              | `[1, 2, 3]`, `[1, 2, 3] of Int32`, `%w(one two three)`  |
-| [Array-like](array.md#array-like-type-literal) | `Set{1, 2, 3}`                                          |
-| [Hash](hash.md)                                | `{"foo" => 2}`, `{} of String => Int32`                 |
-| [Hash-like](hash.md#hash-like-type-literal)    | `MyType{"foo" => "bar"}`                                |
-| [Range](range.md)                              | `1..9`, `1...10`, `0..var`                              |
-| [Regex](regex.md)                              | `/(foo)?bar/`, `/foo #{foo}/imx`, `%r(foo/)`            |
-| [Tuple](tuple.md)                              | `{1, "hello", 'x'}`                                     |
-| [NamedTuple](named_tuple.md)                   | `{name: "Crystal", year: 2011}`, `{"this is a key": 1}` |
-| [Proc](proc.md)                                | `->(x : Int32, y : Int32) { x + y }`                    |
-| [Command](command.md)                          | `` `echo foo` ``, `%x(echo foo)`                        |
+| Literal      | Sample values                                           |
+| ------------ | ------------------------------------------------------- |
+| [Nil]        | `nil`                                                   |
+| [Bool]       | `true`, `false`                                         |
+| [Integers]   | `18`, `-12`, `19_i64`, `14_u32`,`64_u8`                 |
+| [Floats]     | `1.0`, `1.0_f32`, `1e10`, `-0.5`                        |
+| [Char]       | `'a'`, `'\n'`, `'あ'`                                   |
+| [String]     | `"foo\tbar"`, `%("あ")`, `%q(foo #{foo})`               |
+| [Symbol]     | `:symbol`, `:"foo bar"`                                 |
+| [Array]      | `[1, 2, 3]`, `[1, 2, 3] of Int32`, `%w(one two three)`  |
+| [Array-like] | `Set{1, 2, 3}`                                          |
+| [Hash]       | `{"foo" => 2}`, `{} of String => Int32`                 |
+| [Hash-like]  | `MyType{"foo" => "bar"}`                                |
+| [Range]      | `1..9`, `1...10`, `0..var`                              |
+| [Regex]      | `/(foo)?bar/`, `/foo #{foo}/imx`, `%r(foo/)`            |
+| [Tuple]      | `{1, "hello", 'x'}`                                     |
+| [NamedTuple] | `{name: "Crystal", year: 2011}`, `{"this is a key": 1}` |
+| [Proc]       | `->(x : Int32, y : Int32) { x + y }`                    |
+| [Command]    | `` `echo foo` ``, `%x(echo foo)`                        |
+
+[Nil]: nil.md
+[Bool]: bool.md
+[Integers]: integers.md
+[Floats]: floats.md
+[Char]: char.md
+[String]: string.md
+[Symbol]: symbol.md
+[Array]: array.md
+[Array-like]: array.md#array-like-type-literal
+[Hash]: hash.md
+[Hash-like]: hash.md#hash-like-type-literal
+[Range]: range.md
+[Regex]: regex.md
+[Tuple]: tuple.md
+[NamedTuple]: named_tuple.md
+[Proc]: proc.md
+[Command]: command.md

--- a/docs/syntax_and_semantics/literals/integers.md
+++ b/docs/syntax_and_semantics/literals/integers.md
@@ -4,16 +4,27 @@ There are five signed integer types, and five unsigned integer types:
 
 | Type | Length | Minimum Value | Maximum Value |
 | ---- | -----: | ------------: | ------------: |
-| [Int8](http://crystal-lang.org/api/Int8.html) | 8 | -128 | 127 |
-| [Int16](http://crystal-lang.org/api/Int16.html) | 16 | −32,768 | 32,767 |
-| [Int32](http://crystal-lang.org/api/Int32.html) | 32 | −2,147,483,648 | 2,147,483,647 |
-| [Int64](http://crystal-lang.org/api/Int64.html) | 64 | −2<sup>63</sup> | 2<sup>63</sup> - 1 |
-| [Int128](https://crystal-lang.org/api/Int128.html) | 128 | −2<sup>127</sup> | 2<sup>127</sup> - 1 |
-| [UInt8](http://crystal-lang.org/api/UInt8.html) | 8 | 0 | 255 |
-| [UInt16](http://crystal-lang.org/api/UInt16.html) | 16 | 0 | 65,535 |
-| [UInt32](http://crystal-lang.org/api/UInt32.html) | 32 | 0 | 4,294,967,295 |
-| [UInt64](http://crystal-lang.org/api/UInt64.html) | 64 | 0 | 2<sup>64</sup> - 1 |
-| [UInt128](https://crystal-lang.org/api/UInt128.html) | 128 | 0 | 2<sup>128</sup> - 1 |
+| [Int8] | 8 | -128 | 127 |
+| [Int16] | 16 | −32,768 | 32,767 |
+| [Int32] | 32 | −2,147,483,648 | 2,147,483,647 |
+| [Int64] | 64 | −2<sup>63</sup> | 2<sup>63</sup> - 1 |
+| [Int128] | 128 | −2<sup>127</sup> | 2<sup>127</sup> - 1 |
+| [UInt8] | 8 | 0 | 255 |
+| [UInt16] | 16 | 0 | 65,535 |
+| [UInt32] | 32 | 0 | 4,294,967,295 |
+| [UInt64] | 64 | 0 | 2<sup>64</sup> - 1 |
+| [UInt128] | 128 | 0 | 2<sup>128</sup> - 1 |
+
+[Int8]: https://crystal-lang.org/api/Int8.html
+[Int16]: https://crystal-lang.org/api/Int16.html
+[Int32]: https://crystal-lang.org/api/Int32.html
+[Int64]: https://crystal-lang.org/api/Int64.html
+[Int128]: https://crystal-lang.org/api/Int128.html
+[UInt8]: https://crystal-lang.org/api/UInt8.html
+[UInt16]: https://crystal-lang.org/api/UInt16.html
+[UInt32]: https://crystal-lang.org/api/UInt32.html
+[UInt64]: https://crystal-lang.org/api/UInt64.html
+[UInt128]: https://crystal-lang.org/api/UInt128.html
 
 An integer literal is an optional `+` or `-` sign, followed by
 a sequence of digits and underscores, optionally followed by a suffix.


### PR DESCRIPTION
Link refs allow separating the target URL from the location of the link text. This separation can improve code readability, especially for offloading information in dense sections such as tables.

In particular the tables in `required_libraries.md` benefit a lot and are much better to handle this way.
The longest line drops from 559 characters to 331. That's still a lot, but what can we do with GFM table syntax 🤷 It's definitely much better to handle than before.

There is still a lot of boilerplate for the repology version badges. Maybe we could consider implementing this with macro templates or a post-processing plugin. But that also adds more complexity to the setup. For now it's already a good improvement.

As a potential enhancement we could reformat the table with more whitespace and aligned delimiters. That'll be a follow-up.