### PR TITLE
Fix previous step's output expression after splitting workflow job [fixup #891]

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -85,5 +85,5 @@ jobs:
       - name: Deploy book
         run: aws s3 sync ./site s3://crystal-book/reference/${STEPS_BRANCH_OUTPUTS_BRANCH} --delete
         env:
-          STEPS_BRANCH_OUTPUTS_BRANCH: ${{ steps.branch.outputs.branch }}
+          STEPS_BRANCH_OUTPUTS_BRANCH: ${{ needs.build.outputs.branch }}
 


### PR DESCRIPTION
After splitting the workflow in #891 I failed to update this expression, which ended up running a delete on the entire reference folder 🙈 

```shell
aws s3 sync ./site s3://crystal-book/reference/ --delete
```

https://github.com/crystal-lang/crystal-book/actions/runs/22978870993/job/66714027109