### PR TITLE
Markdownlint: Format with `table-column-style: aligned`

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -23,4 +23,4 @@ fenced-code-language: false
 commands-show-output: false
 
 table-column-style:
-  aligned_delimiter: true
+  style: aligned

--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -450,12 +450,12 @@ Crystal provides a few pseudo-constants which provide reflective data about the 
 
 > [Read more about Pseudo Constants in the Crystal documentation.](../syntax_and_semantics/constants.md#pseudo-constants)
 
-| Crystal | Ruby | Description |
-| ------- | ---- | ----------- |
-| `__FILE__` | `__FILE__` | The full path to the currently executing Crystal file. |
-| `__DIR__` | `__dir__` | The full path to the directory where the currently executing Crystal file is located. |
-| `__LINE__` | `__LINE__` | The current line number in the currently executing Crystal file. |
-| `__END_LINE__` | - | The line number of the end of the calling block. Can only be used as a default value to a method parameter. |
+| Crystal        | Ruby       | Description                                                                                                 |
+| -------------- | ---------- | ----------------------------------------------------------------------------------------------------------- |
+| `__FILE__`     | `__FILE__` | The full path to the currently executing Crystal file.                                                      |
+| `__DIR__`      | `__dir__`  | The full path to the directory where the currently executing Crystal file is located.                       |
+| `__LINE__`     | `__LINE__` | The current line number in the currently executing Crystal file.                                            |
+| `__END_LINE__` | -          | The line number of the end of the calling block. Can only be used as a default value to a method parameter. |
 
 > TIP: Further reading about `__DIR__` vs. `__dir__`:
 >

--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -74,12 +74,12 @@ Global variables ``$` `` and `$'` are not supported (yet `$~` and `$1`, `$2`, ..
 In Ruby where there are several methods for doing the same thing, in Crystal there may be only one.
 Specifically:
 
-| Ruby Method               | Crystal Method        |
-| ------------------------- | --------------------- |
-| `Enumerable#detect`       | `Enumerable#find`     |
-| `Enumerable#collect`      | `Enumerable#map`      |
-| `Object#respond_to?`      | `Object#responds_to?` |
-| `length`, `size`, `count` | `size`                |
+| Ruby Method               | Crystal Method
+| ------------------------- | --------------
+| `Enumerable#detect`       | `Enumerable#find`
+| `Enumerable#collect`      | `Enumerable#map`
+| `Object#respond_to?`      | `Object#responds_to?`
+| `length`, `size`, `count` | `size`
 
 ## Omitted Language Constructs
 
@@ -323,11 +323,11 @@ In Crystal, the compiler will treat `process_data(b: 2, a: "one")` as calling `p
 
 The Ruby `attr_accessor`, `attr_reader` and `attr_writer` methods are replaced by macros with different names:
 
-| Ruby Keyword    | Crystal    |
-| --------------- | ---------- |
-| `attr_accessor` | `property` |
-| `attr_reader`   | `getter`   |
-| `attr_writer`   | `setter`   |
+| Ruby Keyword    | Crystal
+| --------------- | -------
+| `attr_accessor` | `property`
+| `attr_reader`   | `getter`
+| `attr_writer`   | `setter`
 
 Example:
 
@@ -337,10 +337,10 @@ getter :name, :bday
 
 In addition, Crystal added accessor macros for nilable or boolean instance variables. They have a question mark (`?`) in the name:
 
-| Crystal     |
-| ----------- |
-| `property?` |
-| `getter?`   |
+| Crystal
+| -----------
+| `property?`
+| `getter?`
 
 Example:
 
@@ -450,12 +450,12 @@ Crystal provides a few pseudo-constants which provide reflective data about the 
 
 > [Read more about Pseudo Constants in the Crystal documentation.](../syntax_and_semantics/constants.md#pseudo-constants)
 
-| Crystal        | Ruby       | Description                                                                                                 |
-| -------------- | ---------- | ----------------------------------------------------------------------------------------------------------- |
-| `__FILE__`     | `__FILE__` | The full path to the currently executing Crystal file.                                                      |
-| `__DIR__`      | `__dir__`  | The full path to the directory where the currently executing Crystal file is located.                       |
-| `__LINE__`     | `__LINE__` | The current line number in the currently executing Crystal file.                                            |
-| `__END_LINE__` | -          | The line number of the end of the calling block. Can only be used as a default value to a method parameter. |
+| Crystal        | Ruby       | Description
+| -------------- | ---------- | -----------
+| `__FILE__`     | `__FILE__` | The full path to the currently executing Crystal file.
+| `__DIR__`      | `__dir__`  | The full path to the directory where the currently executing Crystal file is located.
+| `__LINE__`     | `__LINE__` | The current line number in the currently executing Crystal file.
+| `__END_LINE__` | -          | The line number of the end of the calling block. Can only be used as a default value to a method parameter.
 
 > TIP: Further reading about `__DIR__` vs. `__dir__`:
 >

--- a/docs/database/connection_pool.md
+++ b/docs/database/connection_pool.md
@@ -33,14 +33,14 @@ If a connection can't be created, or if a connection loss occurs while the state
 
 The behavior of the pool can be configured from a set of parameters that can appear as query string in the connection URI.
 
-| Name                  | Default value   |
-| :-------------------- | :-------------- |
-| initial\_pool\_size   | 1               |
-| max\_pool\_size       | 0 \(unlimited\) |
-| max\_idle\_pool\_size | 1               |
-| checkout\_timeout     | 5.0 \(seconds\) |
-| retry\_attempts       | 1               |
-| retry\_delay          | 1.0 \(seconds\) |
+| Name                  | Default value
+| :-------------------- | :------------
+| initial\_pool\_size   | 1
+| max\_pool\_size       | 0 \(unlimited\)
+| max\_idle\_pool\_size | 1
+| checkout\_timeout     | 5.0 \(seconds\)
+| retry\_attempts       | 1
+| retry\_delay          | 1.0 \(seconds\)
 
 When `DB::Database` is opened an initial number of `initial_pool_size` connections will be created. The pool will never hold more than `max_pool_size` connections. When returning/releasing a connection to the pool it will be closed if there are already `max_idle_pool_size` idle connections.
 

--- a/docs/database/connection_pool.md
+++ b/docs/database/connection_pool.md
@@ -33,14 +33,14 @@ If a connection can't be created, or if a connection loss occurs while the state
 
 The behavior of the pool can be configured from a set of parameters that can appear as query string in the connection URI.
 
-| Name | Default value |
-| :--- | :------------ |
-| initial\_pool\_size | 1 |
-| max\_pool\_size | 0 \(unlimited\) |
-| max\_idle\_pool\_size | 1 |
-| checkout\_timeout | 5.0 \(seconds\) |
-| retry\_attempts | 1 |
-| retry\_delay | 1.0 \(seconds\) |
+| Name                  | Default value   |
+| :-------------------- | :-------------- |
+| initial\_pool\_size   | 1               |
+| max\_pool\_size       | 0 \(unlimited\) |
+| max\_idle\_pool\_size | 1               |
+| checkout\_timeout     | 5.0 \(seconds\) |
+| retry\_attempts       | 1               |
+| retry\_delay          | 1.0 \(seconds\) |
 
 When `DB::Database` is opened an initial number of `initial_pool_size` connections will be created. The pool will never hold more than `max_pool_size` connections. When returning/releasing a connection to the pool it will be closed if there are already `max_idle_pool_size` idle connections.
 

--- a/docs/man/required_libraries.md
+++ b/docs/man/required_libraries.md
@@ -13,20 +13,20 @@ A major component is the system library. Selection depends on the target platfor
 This usually includes the C standard library as well as additional system libraries such as `libdl`, `libm`, `libpthread`, `libcmt`, or `libiconv`
 which may be part of the C library or standalone libraries. On most platforms all these libraries are provided by the operating system.
 
-| Library | Description | License |
-| ------- | ----------- | ------- |
-| [glibc]<br>[![repology][r:glibc]][r:glibc/v] | standard C library for Linux <br>**Supported versions:** GNU libc 2.26+ | [LGPL 3.0] |
-| [musl libc]<br>[![repology][r:musl]][r:musl/v] | standard C library for Linux <br>**Supported versions:** MUSL libc 1.2+ | [MIT][musl-copyright] |
-| [FreeBSD libc]<br>[![repology][r:freebsd]][r:freebsd/v] | standard C library for FreeBSD <br>**Supported versions:** 12+ | [BSD][freebsd-license] |
-| [NetBSD libc] | standard C library for NetBSD | [BSD][netbsd-license] |
-| [OpenBSD libc]<br>[![repology][r:openbsd]][r:openbsd/v] | standard C library for OpenBSD <br>**Supported versions:** 6+ | [BSD][openbsd-policy] |
-| [Dragonfly libc] | standard C library for DragonflyBSD | [BSD][dragonfly-license] |
-| [macOS libsystem] | standard C library for macOS <br>**Supported versions:** 11+ | [Apple][APPLE_LICENSE] |
-| [MSVCRT] | standard C library for Visual Studio 2013 or below | |
-| [UCRT] | Universal CRT for Windows / Visual Studio 2015+ | [MIT subset available][MIT-windows] |
-| [WASI]<br>[![repology][r:wasi-libc]][r:wasi-libc/v] | WebAssembly System Interface | [Apache v2 and others][wasi-license] |
-| [bionic libc] | C library for Android <br>**Supported versions:** ABI Level 24+ | [BSD-like][android-notice] |
-| [illumos libc] | System library for Illumos | [CDDL] |
+| Library                                                 | Description                                                             | License                              |
+| ------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------ |
+| [glibc]<br>[![repology][r:glibc]][r:glibc/v]            | standard C library for Linux <br>**Supported versions:** GNU libc 2.26+ | [LGPL 3.0]                           |
+| [musl libc]<br>[![repology][r:musl]][r:musl/v]          | standard C library for Linux <br>**Supported versions:** MUSL libc 1.2+ | [MIT][musl-copyright]                |
+| [FreeBSD libc]<br>[![repology][r:freebsd]][r:freebsd/v] | standard C library for FreeBSD <br>**Supported versions:** 12+          | [BSD][freebsd-license]               |
+| [NetBSD libc]                                           | standard C library for NetBSD                                           | [BSD][netbsd-license]                |
+| [OpenBSD libc]<br>[![repology][r:openbsd]][r:openbsd/v] | standard C library for OpenBSD <br>**Supported versions:** 6+           | [BSD][openbsd-policy]                |
+| [Dragonfly libc]                                        | standard C library for DragonflyBSD                                     | [BSD][dragonfly-license]             |
+| [macOS libsystem]                                       | standard C library for macOS <br>**Supported versions:** 11+            | [Apple][APPLE_LICENSE]               |
+| [MSVCRT]                                                | standard C library for Visual Studio 2013 or below                      |                                      |
+| [UCRT]                                                  | Universal CRT for Windows / Visual Studio 2015+                         | [MIT subset available][MIT-windows]  |
+| [WASI]<br>[![repology][r:wasi-libc]][r:wasi-libc/v]     | WebAssembly System Interface                                            | [Apache v2 and others][wasi-license] |
+| [bionic libc]                                           | C library for Android <br>**Supported versions:** ABI Level 24+         | [BSD-like][android-notice]           |
+| [illumos libc]                                          | System library for Illumos                                              | [CDDL]                               |
 
 [LGPL 3.0]: https://www.gnu.org/licenses/lgpl-3.0.en.html
 [musl-copyright]: https://git.musl-libc.org/cgit/musl/tree/COPYRIGHT
@@ -42,11 +42,11 @@ which may be part of the C library or standalone libraries. On most platforms al
 
 ### Other runtime libraries
 
-| Library | Description | License |
-| ------- | ----------- | ------- |
-| [Boehm GC]<br>[![repology][r:boehm-gc]][r:boehm-gc/v] | The Boehm-Demers-Weiser conservative garbage collector. Performs automatic memory management.<br>**Supported versions:** 8.2.0+; earlier versions require a patch for MT support | [MIT-style][bdwgc-license] |
-| [Libevent]<br>[![repology][r:llvm]][r:llvm/v] | An event notification library. Implements the event loop on OpenBSD, NetBSD, DragonflyBSD and Solaris by default and on other Unix-like systems with `-Devloop=libevent` ([availability][RFC0009]). Never used on Windows or WASI. | [Modified BSD][libevent-license] |
-| [compiler-rt builtins] | Provides optimized implementations for low-level routines required by code generation, such as integer multiplication. Several of these routines are ported to Crystal directly. | [MIT / UIUC][compiler-rt builtins] |
+| Library                                               | Description                                                                                                                                                                                                                        | License                            |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| [Boehm GC]<br>[![repology][r:boehm-gc]][r:boehm-gc/v] | The Boehm-Demers-Weiser conservative garbage collector. Performs automatic memory management.<br>**Supported versions:** 8.2.0+; earlier versions require a patch for MT support                                                   | [MIT-style][bdwgc-license]         |
+| [Libevent]<br>[![repology][r:llvm]][r:llvm/v]         | An event notification library. Implements the event loop on OpenBSD, NetBSD, DragonflyBSD and Solaris by default and on other Unix-like systems with `-Devloop=libevent` ([availability][RFC0009]). Never used on Windows or WASI. | [Modified BSD][libevent-license]   |
+| [compiler-rt builtins]                                | Provides optimized implementations for low-level routines required by code generation, such as integer multiplication. Several of these routines are ported to Crystal directly.                                                   | [MIT / UIUC][compiler-rt builtins] |
 
 [bdwgc-license]: https://github.com/ivmai/bdwgc/blob/master/LICENSE
 [libevent-license]: https://github.com/libevent/libevent/blob/master/LICENSE
@@ -65,10 +65,10 @@ PCRE2 support was added in Crystal 1.7 and it's the default since 1.8 (see [Rege
 [Regex]: https://crystal-lang.org/api/Regex.html
 [Regex documentation]: ../syntax_and_semantics/literals/regex.md
 
-| Library | Description | License |
-| ------- | ----------- | ------- |
-| [PCRE2]<br>[![repology][r:pcre2]][r:pcre2/v] | Perl Compatible Regular Expressions, version 2.<br>**Supported versions:** all (recommended: 10.36+) | [BSD][pcre-license] |
-| [PCRE][PCRE2]<br>[![repology][r:pcre]][r:pcre/v] | Perl Compatible Regular Expressions. | [BSD][pcre-license] |
+| Library                                          | Description                                                                                          | License             |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | ------------------- |
+| [PCRE2]<br>[![repology][r:pcre2]][r:pcre2/v]     | Perl Compatible Regular Expressions, version 2.<br>**Supported versions:** all (recommended: 10.36+) | [BSD][pcre-license] |
+| [PCRE][PCRE2]<br>[![repology][r:pcre]][r:pcre/v] | Perl Compatible Regular Expressions.                                                                 | [BSD][pcre-license] |
 
 [pcre-license]: http://www.pcre.org/licence.txt
 
@@ -78,9 +78,9 @@ Implementations for `Big` types such as [`BigInt`][BigInt].
 
 [BigInt]: https://crystal-lang.org/api/BigInt.html
 
-| Library | Description | License |
-| ------- | ----------- | ------- |
-| [GMP]<br>[![repology][r:gmp]][r:gmp/v] | GNU multiple precision arithmetic library. | [LGPL v3+ / GPL v2+][gmp-license] |
+| Library                                   | Description                                                                       | License                                                  |
+| ----------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| [GMP]<br>[![repology][r:gmp]][r:gmp/v]    | GNU multiple precision arithmetic library.                                        | [LGPL v3+ / GPL v2+][gmp-license]                        |
 | [MPIR]<br>[![repology][r:mpir]][r:mpir/v] | Multiple Precision Integers and Rationals, forked from GMP. Used on Windows MSVC. | [GPL-3.0][mpir-copying] and [LGPL-3.0][mpir-copying.lib] |
 
 [gmp-license]: https://gmplib.org/manual/Copying
@@ -92,8 +92,8 @@ Implementations for `Big` types such as [`BigInt`][BigInt].
 This is either a standalone library or may be provided as part of the system library on some platforms. May be disabled with the `-Dwithout_iconv` compile-time flag.
 Using a standalone library over the system library implementation can be enforced with the `-Duse_libiconv` compile-time flag.
 
-| Library | Description | License |
-| ------- | ----------- | ------- |
+| Library                                                     | Description                              | License    |
+| ----------------------------------------------------------- | ---------------------------------------- | ---------- |
 | [libiconv] (GNU)<br>[![repology][r:libiconv]][r:libiconv/v] | Internationalization conversion library. | [LGPL 3.0] |
 
 ### TLS
@@ -105,21 +105,21 @@ Both `OpenSSL` and `LibreSSL` are supported and the bindings automatically detec
 [OpenSSL]:https://crystal-lang.org/api/OpenSSL.html
 [stdlib-features]: ../syntax_and_semantics/compile_time_flags.md#stdlib-features
 
-| Library | Description | License |
-| ------- | ----------- | ------- |
-| [OpenSSL][openssl.org]<br>[![repology][r:openssl]][r:openssl/v] | Implementation of the SSL and TLS protocols <br>**Supported versions:** 1.1.1+–3.4+ | [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)] |
-| [LibreSSL]<br>[![repology][r:libressl]][r:libressl/v] | Implementation of the SSL and TLS protocols; forked from OpenSSL in 2014 <br>**Supported versions:** 3.0–4.0+ | [ISC / OpenSSL / SSLeay] |
+| Library                                                         | Description                                                                                                   | License                                    |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| [OpenSSL][openssl.org]<br>[![repology][r:openssl]][r:openssl/v] | Implementation of the SSL and TLS protocols <br>**Supported versions:** 1.1.1+–3.4+                           | [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)] |
+| [LibreSSL]<br>[![repology][r:libressl]][r:libressl/v]           | Implementation of the SSL and TLS protocols; forked from OpenSSL in 2014 <br>**Supported versions:** 3.0–4.0+ | [ISC / OpenSSL / SSLeay]                   |
 
 [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)]: https://www.openssl.org/source/license.html
 [ISC / OpenSSL / SSLeay]: https://github.com/libressl-portable/openbsd/blob/master/src/lib/libssl/LICENSE
 
 ### Other stdlib libraries
 
-| Library | Description | License |
-| ------- | ----------- | ------- |
-| [LibXML2]<br>[![repology][r:libxml2]][r:libxml2/v] | XML parser developed for the Gnome project. Implements the [`XML`][XML] module.<br>**Supported versions:** LibXML2 2.9–2.14 | [MIT][gnome-license] |
-| [LibYAML]<br>[![repology][r:libyaml]][r:libyaml/v] | YAML parser and emitter library. Implements the [`YAML`][YAML] module. | [MIT][yaml-license] |
-| [zlib]<br>[![repology][r:zlib]][r:zlib/v] | Lossless data compression library. Implements the [`Compress`][Compress] module. May be disabled with the `-Dwithout_zlib` compile-time flag. | [zlib][zlib-license] |
+| Library                                            | Description                                                                                                                                           | License                          |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| [LibXML2]<br>[![repology][r:libxml2]][r:libxml2/v] | XML parser developed for the Gnome project. Implements the [`XML`][XML] module.<br>**Supported versions:** LibXML2 2.9–2.14                           | [MIT][gnome-license]             |
+| [LibYAML]<br>[![repology][r:libyaml]][r:libyaml/v] | YAML parser and emitter library. Implements the [`YAML`][YAML] module.                                                                                | [MIT][yaml-license]              |
+| [zlib]<br>[![repology][r:zlib]][r:zlib/v]          | Lossless data compression library. Implements the [`Compress`][Compress] module. May be disabled with the `-Dwithout_zlib` compile-time flag.         | [zlib][zlib-license]             |
 | [LLVM][libllvm]<br>[![repology][r:llvm]][r:llvm/v] | Target-independent code generator and optimizer. Implements the [`LLVM`][LLVM] API. <br>**Supported versions:** LLVM 8-22 (aarch64 requires LLVM 13+) | [Apache v2 with LLVM exceptions] |
 
 [gnome-license]: https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/Copyright
@@ -136,12 +136,12 @@ Both `OpenSSL` and `LibreSSL` are supported and the bindings automatically detec
 
 In addition to the [core runtime dependencies](#core-runtime-dependencies), these libraries are needed to build the Crystal compiler.
 
-| Library | Description | License |
-| ------- | ----------- | ------- |
-| [PCRE2] | See [*Regular expression engine*] | |
-| [LLVM][libllvm] | See [*Other stdlib libraries*] | [Apache v2 with LLVM exceptions] |
-| [libffi]<br>[![repology][r:libffi]][r:libffi/v] | Foreign function interface. Used for implementing binary interfaces in the interpreter. May be disabled with the `-Dwithout_interpreter` compile-time flag. | [MIT][ffi-license] |
-| [libxml2] | Optional dependency for docs sanitizer. May be disabled with the `-Dwithout_libxml2` compile-time flag. See [*Other stdlib libraries*] | [MIT][gnome-license] |
+| Library                                         | Description                                                                                                                                                 | License                          |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| [PCRE2]                                         | See [*Regular expression engine*]                                                                                                                           |                                  |
+| [LLVM][libllvm]                                 | See [*Other stdlib libraries*]                                                                                                                              | [Apache v2 with LLVM exceptions] |
+| [libffi]<br>[![repology][r:libffi]][r:libffi/v] | Foreign function interface. Used for implementing binary interfaces in the interpreter. May be disabled with the `-Dwithout_interpreter` compile-time flag. | [MIT][ffi-license]               |
+| [libxml2]                                       | Optional dependency for docs sanitizer. May be disabled with the `-Dwithout_libxml2` compile-time flag. See [*Other stdlib libraries*]                      | [MIT][gnome-license]             |
 
 [*Other stdlib libraries*]: #other-stdlib-libraries
 [*Regular expression engine*]: #regular-expression-engine

--- a/docs/man/required_libraries.md
+++ b/docs/man/required_libraries.md
@@ -13,20 +13,20 @@ A major component is the system library. Selection depends on the target platfor
 This usually includes the C standard library as well as additional system libraries such as `libdl`, `libm`, `libpthread`, `libcmt`, or `libiconv`
 which may be part of the C library or standalone libraries. On most platforms all these libraries are provided by the operating system.
 
-| Library                                                 | Description                                                             | License                              |
-| ------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------ |
-| [glibc]<br>[![repology][r:glibc]][r:glibc/v]            | standard C library for Linux <br>**Supported versions:** GNU libc 2.26+ | [LGPL 3.0]                           |
-| [musl libc]<br>[![repology][r:musl]][r:musl/v]          | standard C library for Linux <br>**Supported versions:** MUSL libc 1.2+ | [MIT][musl-copyright]                |
-| [FreeBSD libc]<br>[![repology][r:freebsd]][r:freebsd/v] | standard C library for FreeBSD <br>**Supported versions:** 12+          | [BSD][freebsd-license]               |
-| [NetBSD libc]                                           | standard C library for NetBSD                                           | [BSD][netbsd-license]                |
-| [OpenBSD libc]<br>[![repology][r:openbsd]][r:openbsd/v] | standard C library for OpenBSD <br>**Supported versions:** 6+           | [BSD][openbsd-policy]                |
-| [Dragonfly libc]                                        | standard C library for DragonflyBSD                                     | [BSD][dragonfly-license]             |
-| [macOS libsystem]                                       | standard C library for macOS <br>**Supported versions:** 11+            | [Apple][APPLE_LICENSE]               |
-| [MSVCRT]                                                | standard C library for Visual Studio 2013 or below                      |                                      |
-| [UCRT]                                                  | Universal CRT for Windows / Visual Studio 2015+                         | [MIT subset available][MIT-windows]  |
-| [WASI]<br>[![repology][r:wasi-libc]][r:wasi-libc/v]     | WebAssembly System Interface                                            | [Apache v2 and others][wasi-license] |
-| [bionic libc]                                           | C library for Android <br>**Supported versions:** ABI Level 24+         | [BSD-like][android-notice]           |
-| [illumos libc]                                          | System library for Illumos                                              | [CDDL]                               |
+| Library                                                 | Description                                                             | License
+| ------------------------------------------------------- | ----------------------------------------------------------------------- | -------
+| [glibc]<br>[![repology][r:glibc]][r:glibc/v]            | standard C library for Linux <br>**Supported versions:** GNU libc 2.26+ | [LGPL 3.0]
+| [musl libc]<br>[![repology][r:musl]][r:musl/v]          | standard C library for Linux <br>**Supported versions:** MUSL libc 1.2+ | [MIT][musl-copyright]
+| [FreeBSD libc]<br>[![repology][r:freebsd]][r:freebsd/v] | standard C library for FreeBSD <br>**Supported versions:** 12+          | [BSD][freebsd-license]
+| [NetBSD libc]                                           | standard C library for NetBSD                                           | [BSD][netbsd-license]
+| [OpenBSD libc]<br>[![repology][r:openbsd]][r:openbsd/v] | standard C library for OpenBSD <br>**Supported versions:** 6+           | [BSD][openbsd-policy]
+| [Dragonfly libc]                                        | standard C library for DragonflyBSD                                     | [BSD][dragonfly-license]
+| [macOS libsystem]                                       | standard C library for macOS <br>**Supported versions:** 11+            | [Apple][APPLE_LICENSE]
+| [MSVCRT]                                                | standard C library for Visual Studio 2013 or below                      | &nbsp;
+| [UCRT]                                                  | Universal CRT for Windows / Visual Studio 2015+                         | [MIT subset available][MIT-windows]
+| [WASI]<br>[![repology][r:wasi-libc]][r:wasi-libc/v]     | WebAssembly System Interface                                            | [Apache v2 and others][wasi-license]
+| [bionic libc]                                           | C library for Android <br>**Supported versions:** ABI Level 24+         | [BSD-like][android-notice]
+| [illumos libc]                                          | System library for Illumos                                              | [CDDL]
 
 [LGPL 3.0]: https://www.gnu.org/licenses/lgpl-3.0.en.html
 [musl-copyright]: https://git.musl-libc.org/cgit/musl/tree/COPYRIGHT
@@ -42,11 +42,11 @@ which may be part of the C library or standalone libraries. On most platforms al
 
 ### Other runtime libraries
 
-| Library                                               | Description                                                                                                                                                                                                                        | License                            |
-| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| [Boehm GC]<br>[![repology][r:boehm-gc]][r:boehm-gc/v] | The Boehm-Demers-Weiser conservative garbage collector. Performs automatic memory management.<br>**Supported versions:** 8.2.0+; earlier versions require a patch for MT support                                                   | [MIT-style][bdwgc-license]         |
-| [Libevent]<br>[![repology][r:llvm]][r:llvm/v]         | An event notification library. Implements the event loop on OpenBSD, NetBSD, DragonflyBSD and Solaris by default and on other Unix-like systems with `-Devloop=libevent` ([availability][RFC0009]). Never used on Windows or WASI. | [Modified BSD][libevent-license]   |
-| [compiler-rt builtins]                                | Provides optimized implementations for low-level routines required by code generation, such as integer multiplication. Several of these routines are ported to Crystal directly.                                                   | [MIT / UIUC][compiler-rt builtins] |
+| Library                                               | Description                                                                                                                                                                                                                        | License
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------
+| [Boehm GC]<br>[![repology][r:boehm-gc]][r:boehm-gc/v] | The Boehm-Demers-Weiser conservative garbage collector. Performs automatic memory management.<br>**Supported versions:** 8.2.0+; earlier versions require a patch for MT support                                                   | [MIT-style][bdwgc-license]
+| [Libevent]<br>[![repology][r:llvm]][r:llvm/v]         | An event notification library. Implements the event loop on OpenBSD, NetBSD, DragonflyBSD and Solaris by default and on other Unix-like systems with `-Devloop=libevent` ([availability][RFC0009]). Never used on Windows or WASI. | [Modified BSD][libevent-license]
+| [compiler-rt builtins]                                | Provides optimized implementations for low-level routines required by code generation, such as integer multiplication. Several of these routines are ported to Crystal directly.                                                   | [MIT / UIUC][compiler-rt builtins]
 
 [bdwgc-license]: https://github.com/ivmai/bdwgc/blob/master/LICENSE
 [libevent-license]: https://github.com/libevent/libevent/blob/master/LICENSE
@@ -65,10 +65,10 @@ PCRE2 support was added in Crystal 1.7 and it's the default since 1.8 (see [Rege
 [Regex]: https://crystal-lang.org/api/Regex.html
 [Regex documentation]: ../syntax_and_semantics/literals/regex.md
 
-| Library                                          | Description                                                                                          | License             |
-| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | ------------------- |
-| [PCRE2]<br>[![repology][r:pcre2]][r:pcre2/v]     | Perl Compatible Regular Expressions, version 2.<br>**Supported versions:** all (recommended: 10.36+) | [BSD][pcre-license] |
-| [PCRE][PCRE2]<br>[![repology][r:pcre]][r:pcre/v] | Perl Compatible Regular Expressions.                                                                 | [BSD][pcre-license] |
+| Library                                          | Description                                                                                          | License
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | -------
+| [PCRE2]<br>[![repology][r:pcre2]][r:pcre2/v]     | Perl Compatible Regular Expressions, version 2.<br>**Supported versions:** all (recommended: 10.36+) | [BSD][pcre-license]
+| [PCRE][PCRE2]<br>[![repology][r:pcre]][r:pcre/v] | Perl Compatible Regular Expressions.                                                                 | [BSD][pcre-license]
 
 [pcre-license]: http://www.pcre.org/licence.txt
 
@@ -78,10 +78,10 @@ Implementations for `Big` types such as [`BigInt`][BigInt].
 
 [BigInt]: https://crystal-lang.org/api/BigInt.html
 
-| Library                                   | Description                                                                       | License                                                  |
-| ----------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| [GMP]<br>[![repology][r:gmp]][r:gmp/v]    | GNU multiple precision arithmetic library.                                        | [LGPL v3+ / GPL v2+][gmp-license]                        |
-| [MPIR]<br>[![repology][r:mpir]][r:mpir/v] | Multiple Precision Integers and Rationals, forked from GMP. Used on Windows MSVC. | [GPL-3.0][mpir-copying] and [LGPL-3.0][mpir-copying.lib] |
+| Library                                   | Description                                                                       | License
+| ----------------------------------------- | --------------------------------------------------------------------------------- | -------
+| [GMP]<br>[![repology][r:gmp]][r:gmp/v]    | GNU multiple precision arithmetic library.                                        | [LGPL v3+ / GPL v2+][gmp-license]
+| [MPIR]<br>[![repology][r:mpir]][r:mpir/v] | Multiple Precision Integers and Rationals, forked from GMP. Used on Windows MSVC. | [GPL-3.0][mpir-copying] and [LGPL-3.0][mpir-copying.lib]
 
 [gmp-license]: https://gmplib.org/manual/Copying
 [mpir-copying]: https://github.com/wbhart/mpir/blob/master/COPYING
@@ -92,9 +92,9 @@ Implementations for `Big` types such as [`BigInt`][BigInt].
 This is either a standalone library or may be provided as part of the system library on some platforms. May be disabled with the `-Dwithout_iconv` compile-time flag.
 Using a standalone library over the system library implementation can be enforced with the `-Duse_libiconv` compile-time flag.
 
-| Library                                                     | Description                              | License    |
-| ----------------------------------------------------------- | ---------------------------------------- | ---------- |
-| [libiconv] (GNU)<br>[![repology][r:libiconv]][r:libiconv/v] | Internationalization conversion library. | [LGPL 3.0] |
+| Library                                                     | Description                              | License
+| ----------------------------------------------------------- | ---------------------------------------- | ----------
+| [libiconv] (GNU)<br>[![repology][r:libiconv]][r:libiconv/v] | Internationalization conversion library. | [LGPL 3.0]
 
 ### TLS
 
@@ -105,22 +105,22 @@ Both `OpenSSL` and `LibreSSL` are supported and the bindings automatically detec
 [OpenSSL]:https://crystal-lang.org/api/OpenSSL.html
 [stdlib-features]: ../syntax_and_semantics/compile_time_flags.md#stdlib-features
 
-| Library                                                         | Description                                                                                                   | License                                    |
-| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| [OpenSSL][openssl.org]<br>[![repology][r:openssl]][r:openssl/v] | Implementation of the SSL and TLS protocols <br>**Supported versions:** 1.1.1+–3.4+                           | [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)] |
-| [LibreSSL]<br>[![repology][r:libressl]][r:libressl/v]           | Implementation of the SSL and TLS protocols; forked from OpenSSL in 2014 <br>**Supported versions:** 3.0–4.0+ | [ISC / OpenSSL / SSLeay]                   |
+| Library                                                         | Description                                                                                                   | License
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | -------
+| [OpenSSL][openssl.org]<br>[![repology][r:openssl]][r:openssl/v] | Implementation of the SSL and TLS protocols <br>**Supported versions:** 1.1.1+–3.4+                           | [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)]
+| [LibreSSL]<br>[![repology][r:libressl]][r:libressl/v]           | Implementation of the SSL and TLS protocols; forked from OpenSSL in 2014 <br>**Supported versions:** 3.0–4.0+ | [ISC / OpenSSL / SSLeay]
 
 [Apache v2 (3.0+), OpenSSL / SSLeay (1.x)]: https://www.openssl.org/source/license.html
 [ISC / OpenSSL / SSLeay]: https://github.com/libressl-portable/openbsd/blob/master/src/lib/libssl/LICENSE
 
 ### Other stdlib libraries
 
-| Library                                            | Description                                                                                                                                           | License                          |
-| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
-| [LibXML2]<br>[![repology][r:libxml2]][r:libxml2/v] | XML parser developed for the Gnome project. Implements the [`XML`][XML] module.<br>**Supported versions:** LibXML2 2.9–2.14                           | [MIT][gnome-license]             |
-| [LibYAML]<br>[![repology][r:libyaml]][r:libyaml/v] | YAML parser and emitter library. Implements the [`YAML`][YAML] module.                                                                                | [MIT][yaml-license]              |
-| [zlib]<br>[![repology][r:zlib]][r:zlib/v]          | Lossless data compression library. Implements the [`Compress`][Compress] module. May be disabled with the `-Dwithout_zlib` compile-time flag.         | [zlib][zlib-license]             |
-| [LLVM][libllvm]<br>[![repology][r:llvm]][r:llvm/v] | Target-independent code generator and optimizer. Implements the [`LLVM`][LLVM] API. <br>**Supported versions:** LLVM 8-22 (aarch64 requires LLVM 13+) | [Apache v2 with LLVM exceptions] |
+| Library                                            | Description                                                                                                                                           | License
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------
+| [LibXML2]<br>[![repology][r:libxml2]][r:libxml2/v] | XML parser developed for the Gnome project. Implements the [`XML`][XML] module.<br>**Supported versions:** LibXML2 2.9–2.14                           | [MIT][gnome-license]
+| [LibYAML]<br>[![repology][r:libyaml]][r:libyaml/v] | YAML parser and emitter library. Implements the [`YAML`][YAML] module.                                                                                | [MIT][yaml-license]
+| [zlib]<br>[![repology][r:zlib]][r:zlib/v]          | Lossless data compression library. Implements the [`Compress`][Compress] module. May be disabled with the `-Dwithout_zlib` compile-time flag.         | [zlib][zlib-license]
+| [LLVM][libllvm]<br>[![repology][r:llvm]][r:llvm/v] | Target-independent code generator and optimizer. Implements the [`LLVM`][LLVM] API. <br>**Supported versions:** LLVM 8-22 (aarch64 requires LLVM 13+) | [Apache v2 with LLVM exceptions]
 
 [gnome-license]: https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/Copyright
 [yaml-license]: https://github.com/yaml/libyaml/blob/master/License
@@ -136,12 +136,12 @@ Both `OpenSSL` and `LibreSSL` are supported and the bindings automatically detec
 
 In addition to the [core runtime dependencies](#core-runtime-dependencies), these libraries are needed to build the Crystal compiler.
 
-| Library                                         | Description                                                                                                                                                 | License                          |
-| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
-| [PCRE2]                                         | See [*Regular expression engine*]                                                                                                                           |                                  |
-| [LLVM][libllvm]                                 | See [*Other stdlib libraries*]                                                                                                                              | [Apache v2 with LLVM exceptions] |
-| [libffi]<br>[![repology][r:libffi]][r:libffi/v] | Foreign function interface. Used for implementing binary interfaces in the interpreter. May be disabled with the `-Dwithout_interpreter` compile-time flag. | [MIT][ffi-license]               |
-| [libxml2]                                       | Optional dependency for docs sanitizer. May be disabled with the `-Dwithout_libxml2` compile-time flag. See [*Other stdlib libraries*]                      | [MIT][gnome-license]             |
+| Library                                         | Description                                                                                                                                                 | License
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------
+| [PCRE2]                                         | See [*Regular expression engine*]                                                                                                                           | &nbsp;
+| [LLVM][libllvm]                                 | See [*Other stdlib libraries*]                                                                                                                              | [Apache v2 with LLVM exceptions]
+| [libffi]<br>[![repology][r:libffi]][r:libffi/v] | Foreign function interface. Used for implementing binary interfaces in the interpreter. May be disabled with the `-Dwithout_interpreter` compile-time flag. | [MIT][ffi-license]
+| [libxml2]                                       | Optional dependency for docs sanitizer. May be disabled with the `-Dwithout_libxml2` compile-time flag. See [*Other stdlib libraries*]                      | [MIT][gnome-license]
 
 [*Other stdlib libraries*]: #other-stdlib-libraries
 [*Regular expression engine*]: #regular-expression-engine

--- a/docs/syntax_and_semantics/compile_time_flags.md
+++ b/docs/syntax_and_semantics/compile_time_flags.md
@@ -53,51 +53,51 @@ The flags in each of the following tables are mutually exclusive, except for tho
 
 The target architecture is the first component of the target triple.
 
-| Flag name | Description |
-| --------- | ----------- |
-| `aarch64` | AArch64 architecture |
-| `avr` | AVR architecture |
-| `arm` | ARM architecture |
-| `i386` | x86 architecture (32-bit) |
-| `wasm32` | WebAssembly |
-| `x86_64` | x86-64 architecture |
-| `bits32` *(derived)* | 32-bit architecture |
-| `bits64` *(derived)* | 64-bit architecture |
+| Flag name            | Description               |
+| -------------------- | ------------------------- |
+| `aarch64`            | AArch64 architecture      |
+| `avr`                | AVR architecture          |
+| `arm`                | ARM architecture          |
+| `i386`               | x86 architecture (32-bit) |
+| `wasm32`             | WebAssembly               |
+| `x86_64`             | x86-64 architecture       |
+| `bits32` *(derived)* | 32-bit architecture       |
+| `bits64` *(derived)* | 64-bit architecture       |
 
 #### Vendor
 
 The vendor is the second component of the target triple. This is typically unused,
 so the most common vendor is `unknown`.
 
-| Flag name | Description |
-| --------- | ----------- |
-| `macosx` | Apple |
+| Flag name | Description     |
+| --------- | --------------- |
+| `macosx`  | Apple           |
 | `portbld` | FreeBSD variant |
-| `unknown` | Unknown vendor |
+| `unknown` | Unknown vendor  |
 
 #### Operating System
 
 The operating system is derived from the third component of the target triple.
 
-| Flag name | Description |
-| --------- | ----------- |
-| `bsd` *(derived)* | BSD family (DragonFlyBSD, FreeBSD, NetBSD, OpenBSD) |
-| `darwin` | Darwin (MacOS) |
-| `dragonfly` | DragonFlyBSD |
-| `freebsd` | FreeBSD |
-| `linux` | Linux |
-| `netbsd` | NetBSD |
-| `openbsd` | OpenBSD |
-| `solaris` | Solaris/illumos |
-| `unix` *(derived)* | UNIX-like (BSD, Darwin, Linux, Solaris) |
-| `windows` | Windows |
+| Flag name          | Description                                         |
+| ------------------ | --------------------------------------------------- |
+| `bsd` *(derived)*  | BSD family (DragonFlyBSD, FreeBSD, NetBSD, OpenBSD) |
+| `darwin`           | Darwin (MacOS)                                      |
+| `dragonfly`        | DragonFlyBSD                                        |
+| `freebsd`          | FreeBSD                                             |
+| `linux`            | Linux                                               |
+| `netbsd`           | NetBSD                                              |
+| `openbsd`          | OpenBSD                                             |
+| `solaris`          | Solaris/illumos                                     |
+| `unix` *(derived)* | UNIX-like (BSD, Darwin, Linux, Solaris)             |
+| `windows`          | Windows                                             |
 
 #### Operating System versions
 
 The version of the operating is derived from the third component of the target triple if available.
 
-| Flag name | Description |
-| --------- | ----------- |
+| Flag name   | Description        |
+| ----------- | ------------------ |
 | `freebsd12` | FreeBSD version 12 |
 | `freebsd13` | FreeBSD version 13 |
 
@@ -105,28 +105,28 @@ The version of the operating is derived from the third component of the target t
 
 The ABI is derived from the last component of the target triple.
 
-| Flag name | Description |
-| --------- | ----------- |
-| `android` | Android (Bionic C runtime) |
-| `armhf` *(derived)* | ARM EABI with hard float |
-| `gnu` | GNU |
-| `gnueabihf` | GNU EABI with hard float |
-| `msvc` | Microsoft Visual C++ |
-| `musl` | musl |
-| `wasi` | Web Assembly System Interface |
-| `win32` *(derived)* | Windows API |
+| Flag name           | Description                   |
+| ------------------- | ----------------------------- |
+| `android`           | Android (Bionic C runtime)    |
+| `armhf` *(derived)* | ARM EABI with hard float      |
+| `gnu`               | GNU                           |
+| `gnueabihf`         | GNU EABI with hard float      |
+| `msvc`              | Microsoft Visual C++          |
+| `musl`              | musl                          |
+| `wasi`              | Web Assembly System Interface |
+| `win32` *(derived)* | Windows API                   |
 
 ### Compiler options
 
 The compiler sets these flags based on compiler configuration.
 
-| Flag name | Description |
-| --------- | ----------- |
-| `release` | Compiler operates in release mode (`--release` or `-O3 --single-module` CLI option) |
-| `debug` | Compiler generates debug symbols (without `--no-debug` CLI option) |
-| `static` | Compiler creates a statically linked executable (`--static` CLI option) |
-| `docs` | Code is processed to generate API docs (`crystal docs` command) |
-| `interpreted` | Running in the interpreter (`crystal i`) |
+| Flag name     | Description                                                                         |
+| ------------- | ----------------------------------------------------------------------------------- |
+| `release`     | Compiler operates in release mode (`--release` or `-O3 --single-module` CLI option) |
+| `debug`       | Compiler generates debug symbols (without `--no-debug` CLI option)                  |
+| `static`      | Compiler creates a statically linked executable (`--static` CLI option)             |
+| `docs`        | Code is processed to generate API docs (`crystal docs` command)                     |
+| `interpreted` | Running in the interpreter (`crystal i`)                                            |
 
 ## User-provided flags
 
@@ -147,23 +147,23 @@ $ crystal eval -Dfoo=bar 'p {{ flag?(:foo) }}'
 These flags enable or disable features in the standard library when building a
 Crystal program.
 
-| Flag name | Description |
-| --------- | ----------- |
-| `gc_none` | Disables garbage collection ([#5314]) |
-| `debug_raise` | Debugging flag for `raise` logic. Prints the backtrace before raising. |
-| `evloop=epoll`, `evloop=kqueue`, `evloop=libevent` | Select event loop driver ([RFC 0009]). Introduced in 1.15 |
-| `execution_context` | Enable execution contexts preview ([RFC 0002]). [Introduced in 1.16][#15350] |
-| `execvpe_impl` | Experimental flag for choosing the custom `execvpe` implementation instead of the system function. Introduced in 1.19 |
-| `preview_mt` | Enables multithreading preview. Introduced in 0.28.0 ([#7546]) |
-| `skip_crystal_compiler_rt` | Exclude Crystal's native `compiler-rt` implementation. |
-| `tracing` | Build with support for [runtime tracing]. |
-| `use_libiconv` | Use `libiconv` instead of the `iconv` system library |
-| `use_pcre2` | Use PCRE2 as regex engine (instead of legacy PCRE). Introduced in 1.7.0. |
-| `use_pcre` | Use PCRE as regex engine (instead of PCRE2). Introduced in 1.8.0. |
-| `win7` | Use Win32 WinNT API for Windows 7 |
-| `without_iconv` | Do not link `iconv`/`libiconv` |
-| `without_openssl` | Build without OpenSSL support |
-| `without_zlib` | Build without Zlib support |
+| Flag name                                          | Description                                                                                                           |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `gc_none`                                          | Disables garbage collection ([#5314])                                                                                 |
+| `debug_raise`                                      | Debugging flag for `raise` logic. Prints the backtrace before raising.                                                |
+| `evloop=epoll`, `evloop=kqueue`, `evloop=libevent` | Select event loop driver ([RFC 0009]). Introduced in 1.15                                                             |
+| `execution_context`                                | Enable execution contexts preview ([RFC 0002]). [Introduced in 1.16][#15350]                                          |
+| `execvpe_impl`                                     | Experimental flag for choosing the custom `execvpe` implementation instead of the system function. Introduced in 1.19 |
+| `preview_mt`                                       | Enables multithreading preview. Introduced in 0.28.0 ([#7546])                                                        |
+| `skip_crystal_compiler_rt`                         | Exclude Crystal's native `compiler-rt` implementation.                                                                |
+| `tracing`                                          | Build with support for [runtime tracing].                                                                             |
+| `use_libiconv`                                     | Use `libiconv` instead of the `iconv` system library                                                                  |
+| `use_pcre2`                                        | Use PCRE2 as regex engine (instead of legacy PCRE). Introduced in 1.7.0.                                              |
+| `use_pcre`                                         | Use PCRE as regex engine (instead of PCRE2). Introduced in 1.8.0.                                                     |
+| `win7`                                             | Use Win32 WinNT API for Windows 7                                                                                     |
+| `without_iconv`                                    | Do not link `iconv`/`libiconv`                                                                                        |
+| `without_openssl`                                  | Build without OpenSSL support                                                                                         |
+| `without_zlib`                                     | Build without Zlib support                                                                                            |
 
 [#5314]: https://github.com/crystal-lang/crystal/pull/5314
 [RFC 0009]: https://github.com/crystal-lang/rfcs/blob/main/text/0009-lifetime-event_loop.md#availability
@@ -176,12 +176,12 @@ Crystal program.
 
 These flags enable or disable language features when building a Crystal program.
 
-| Flag name | Description |
-| --------- | ----------- |
-| `no_number_autocast` | Will not [autocast] numeric expressions, only literals |
-| `no_restrictions_augmenter` | Disable enhanced restrictions augmenter. Introduced in 1.5 ([#12103]). |
-| `preview_overload_order` | Enable more robust ordering between def overloads. Introduced in 1.6 ([#10711]). |
-| `strict_multi_assign` | Enable strict semantics for [one-to-many assignment]. Introduced in 1.3.0 ([#11145], [#11545]) |
+| Flag name                   | Description                                                                                    |
+| --------------------------- | ---------------------------------------------------------------------------------------------- |
+| `no_number_autocast`        | Will not [autocast] numeric expressions, only literals                                         |
+| `no_restrictions_augmenter` | Disable enhanced restrictions augmenter. Introduced in 1.5 ([#12103]).                         |
+| `preview_overload_order`    | Enable more robust ordering between def overloads. Introduced in 1.6 ([#10711]).               |
+| `strict_multi_assign`       | Enable strict semantics for [one-to-many assignment]. Introduced in 1.3.0 ([#11145], [#11545]) |
 
 [autocast]: autocasting.md#number-autocasting
 [#12103]: https://github.com/crystal-lang/crystal/pull/12103
@@ -194,10 +194,10 @@ These flags enable or disable language features when building a Crystal program.
 
 These flags enable or disable codegen features when building a Crystal program.
 
-| Flag name | Description |
-| --------- | ----------- |
+| Flag name                                                            | Description                                                                                             |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `cf-protection=branch`, `cf-protection=return`, `cf-protection=full` | Indirect branch tracking for x86 and x86_64. Implicitly set on OpenBSD. Introduced in 1.15.0 ([#15122]) |
-| `branch-protection=bti` | Indirect branch tracking for aarch64. Implicitly set on OpenBSD. Introduced in 1.15.0 ([#15122]) |
+| `branch-protection=bti`                                              | Indirect branch tracking for aarch64. Implicitly set on OpenBSD. Introduced in 1.15.0 ([#15122])        |
 
 [#15122]: https://github.com/crystal-lang/crystal/pull/15122
 
@@ -205,13 +205,13 @@ These flags enable or disable codegen features when building a Crystal program.
 
 These flags enable or disable features when building the Crystal compiler.
 
-| Flag name | Description |
-| --------- | ----------- |
-| `without_ffi` | Build the compiler without `libffi` |
-| `without_interpreter` | Build the compiler without interpreter support |
-| `without_libxml2` | Build the compiler without sanitization for the doc generator. [Introduced in 1.19][#14646].<br> Note: The default `Makefile` passes this flag unless `docs_sanitizer=1` |
-| `without_playground` | Build the compiler without playground (`crystal play`) |
-| `i_know_what_im_doing` | Safety guard against involuntarily building the compiler |
+| Flag name              | Description                                                                                                                                                              |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `without_ffi`          | Build the compiler without `libffi`                                                                                                                                      |
+| `without_interpreter`  | Build the compiler without interpreter support                                                                                                                           |
+| `without_libxml2`      | Build the compiler without sanitization for the doc generator. [Introduced in 1.19][#14646].<br> Note: The default `Makefile` passes this flag unless `docs_sanitizer=1` |
+| `without_playground`   | Build the compiler without playground (`crystal play`)                                                                                                                   |
+| `i_know_what_im_doing` | Safety guard against involuntarily building the compiler                                                                                                                 |
 
 [#14646]: https://github.com/crystal-lang/crystal/pull/14646
 

--- a/docs/syntax_and_semantics/compile_time_flags.md
+++ b/docs/syntax_and_semantics/compile_time_flags.md
@@ -53,80 +53,80 @@ The flags in each of the following tables are mutually exclusive, except for tho
 
 The target architecture is the first component of the target triple.
 
-| Flag name            | Description               |
-| -------------------- | ------------------------- |
-| `aarch64`            | AArch64 architecture      |
-| `avr`                | AVR architecture          |
-| `arm`                | ARM architecture          |
-| `i386`               | x86 architecture (32-bit) |
-| `wasm32`             | WebAssembly               |
-| `x86_64`             | x86-64 architecture       |
-| `bits32` *(derived)* | 32-bit architecture       |
-| `bits64` *(derived)* | 64-bit architecture       |
+| Flag name            | Description
+| -------------------- | -----------
+| `aarch64`            | AArch64 architecture
+| `avr`                | AVR architecture
+| `arm`                | ARM architecture
+| `i386`               | x86 architecture (32-bit)
+| `wasm32`             | WebAssembly
+| `x86_64`             | x86-64 architecture
+| `bits32` *(derived)* | 32-bit architecture
+| `bits64` *(derived)* | 64-bit architecture
 
 #### Vendor
 
 The vendor is the second component of the target triple. This is typically unused,
 so the most common vendor is `unknown`.
 
-| Flag name | Description     |
-| --------- | --------------- |
-| `macosx`  | Apple           |
-| `portbld` | FreeBSD variant |
-| `unknown` | Unknown vendor  |
+| Flag name | Description
+| --------- | -----------
+| `macosx`  | Apple
+| `portbld` | FreeBSD variant
+| `unknown` | Unknown vendor
 
 #### Operating System
 
 The operating system is derived from the third component of the target triple.
 
-| Flag name          | Description                                         |
-| ------------------ | --------------------------------------------------- |
-| `bsd` *(derived)*  | BSD family (DragonFlyBSD, FreeBSD, NetBSD, OpenBSD) |
-| `darwin`           | Darwin (MacOS)                                      |
-| `dragonfly`        | DragonFlyBSD                                        |
-| `freebsd`          | FreeBSD                                             |
-| `linux`            | Linux                                               |
-| `netbsd`           | NetBSD                                              |
-| `openbsd`          | OpenBSD                                             |
-| `solaris`          | Solaris/illumos                                     |
-| `unix` *(derived)* | UNIX-like (BSD, Darwin, Linux, Solaris)             |
-| `windows`          | Windows                                             |
+| Flag name          | Description
+| ------------------ | ---------------------------------------------------
+| `bsd` *(derived)*  | BSD family (DragonFlyBSD, FreeBSD, NetBSD, OpenBSD)
+| `darwin`           | Darwin (MacOS)
+| `dragonfly`        | DragonFlyBSD
+| `freebsd`          | FreeBSD
+| `linux`            | Linux
+| `netbsd`           | NetBSD
+| `openbsd`          | OpenBSD
+| `solaris`          | Solaris/illumos
+| `unix` *(derived)* | UNIX-like (BSD, Darwin, Linux, Solaris)
+| `windows`          | Windows
 
 #### Operating System versions
 
 The version of the operating is derived from the third component of the target triple if available.
 
-| Flag name   | Description        |
-| ----------- | ------------------ |
-| `freebsd12` | FreeBSD version 12 |
-| `freebsd13` | FreeBSD version 13 |
+| Flag name   | Description
+| ----------- | -----------
+| `freebsd12` | FreeBSD version 12
+| `freebsd13` | FreeBSD version 13
 
 #### ABI
 
 The ABI is derived from the last component of the target triple.
 
-| Flag name           | Description                   |
-| ------------------- | ----------------------------- |
-| `android`           | Android (Bionic C runtime)    |
-| `armhf` *(derived)* | ARM EABI with hard float      |
-| `gnu`               | GNU                           |
-| `gnueabihf`         | GNU EABI with hard float      |
-| `msvc`              | Microsoft Visual C++          |
-| `musl`              | musl                          |
-| `wasi`              | Web Assembly System Interface |
-| `win32` *(derived)* | Windows API                   |
+| Flag name           | Description
+| ------------------- | -----------
+| `android`           | Android (Bionic C runtime)
+| `armhf` *(derived)* | ARM EABI with hard float
+| `gnu`               | GNU
+| `gnueabihf`         | GNU EABI with hard float
+| `msvc`              | Microsoft Visual C++
+| `musl`              | musl
+| `wasi`              | Web Assembly System Interface
+| `win32` *(derived)* | Windows API
 
 ### Compiler options
 
 The compiler sets these flags based on compiler configuration.
 
-| Flag name     | Description                                                                         |
-| ------------- | ----------------------------------------------------------------------------------- |
-| `release`     | Compiler operates in release mode (`--release` or `-O3 --single-module` CLI option) |
-| `debug`       | Compiler generates debug symbols (without `--no-debug` CLI option)                  |
-| `static`      | Compiler creates a statically linked executable (`--static` CLI option)             |
-| `docs`        | Code is processed to generate API docs (`crystal docs` command)                     |
-| `interpreted` | Running in the interpreter (`crystal i`)                                            |
+| Flag name     | Description
+| ------------- | -----------
+| `release`     | Compiler operates in release mode (`--release` or `-O3 --single-module` CLI option)
+| `debug`       | Compiler generates debug symbols (without `--no-debug` CLI option)
+| `static`      | Compiler creates a statically linked executable (`--static` CLI option)
+| `docs`        | Code is processed to generate API docs (`crystal docs` command)
+| `interpreted` | Running in the interpreter (`crystal i`)
 
 ## User-provided flags
 
@@ -147,23 +147,23 @@ $ crystal eval -Dfoo=bar 'p {{ flag?(:foo) }}'
 These flags enable or disable features in the standard library when building a
 Crystal program.
 
-| Flag name                                          | Description                                                                                                           |
-| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `gc_none`                                          | Disables garbage collection ([#5314])                                                                                 |
-| `debug_raise`                                      | Debugging flag for `raise` logic. Prints the backtrace before raising.                                                |
-| `evloop=epoll`, `evloop=kqueue`, `evloop=libevent` | Select event loop driver ([RFC 0009]). Introduced in 1.15                                                             |
-| `execution_context`                                | Enable execution contexts preview ([RFC 0002]). [Introduced in 1.16][#15350]                                          |
-| `execvpe_impl`                                     | Experimental flag for choosing the custom `execvpe` implementation instead of the system function. Introduced in 1.19 |
-| `preview_mt`                                       | Enables multithreading preview. Introduced in 0.28.0 ([#7546])                                                        |
-| `skip_crystal_compiler_rt`                         | Exclude Crystal's native `compiler-rt` implementation.                                                                |
-| `tracing`                                          | Build with support for [runtime tracing].                                                                             |
-| `use_libiconv`                                     | Use `libiconv` instead of the `iconv` system library                                                                  |
-| `use_pcre2`                                        | Use PCRE2 as regex engine (instead of legacy PCRE). Introduced in 1.7.0.                                              |
-| `use_pcre`                                         | Use PCRE as regex engine (instead of PCRE2). Introduced in 1.8.0.                                                     |
-| `win7`                                             | Use Win32 WinNT API for Windows 7                                                                                     |
-| `without_iconv`                                    | Do not link `iconv`/`libiconv`                                                                                        |
-| `without_openssl`                                  | Build without OpenSSL support                                                                                         |
-| `without_zlib`                                     | Build without Zlib support                                                                                            |
+| Flag name                                          | Description
+| -------------------------------------------------- | -----------
+| `gc_none`                                          | Disables garbage collection ([#5314])
+| `debug_raise`                                      | Debugging flag for `raise` logic. Prints the backtrace before raising.
+| `evloop=epoll`, `evloop=kqueue`, `evloop=libevent` | Select event loop driver ([RFC 0009]). Introduced in 1.15
+| `execution_context`                                | Enable execution contexts preview ([RFC 0002]). [Introduced in 1.16][#15350]
+| `execvpe_impl`                                     | Experimental flag for choosing the custom `execvpe` implementation instead of the system function. Introduced in 1.19
+| `preview_mt`                                       | Enables multithreading preview. Introduced in 0.28.0 ([#7546])
+| `skip_crystal_compiler_rt`                         | Exclude Crystal's native `compiler-rt` implementation.
+| `tracing`                                          | Build with support for [runtime tracing].
+| `use_libiconv`                                     | Use `libiconv` instead of the `iconv` system library
+| `use_pcre2`                                        | Use PCRE2 as regex engine (instead of legacy PCRE). Introduced in 1.7.0.
+| `use_pcre`                                         | Use PCRE as regex engine (instead of PCRE2). Introduced in 1.8.0.
+| `win7`                                             | Use Win32 WinNT API for Windows 7
+| `without_iconv`                                    | Do not link `iconv`/`libiconv`
+| `without_openssl`                                  | Build without OpenSSL support
+| `without_zlib`                                     | Build without Zlib support
 
 [#5314]: https://github.com/crystal-lang/crystal/pull/5314
 [RFC 0009]: https://github.com/crystal-lang/rfcs/blob/main/text/0009-lifetime-event_loop.md#availability
@@ -176,12 +176,12 @@ Crystal program.
 
 These flags enable or disable language features when building a Crystal program.
 
-| Flag name                   | Description                                                                                    |
-| --------------------------- | ---------------------------------------------------------------------------------------------- |
-| `no_number_autocast`        | Will not [autocast] numeric expressions, only literals                                         |
-| `no_restrictions_augmenter` | Disable enhanced restrictions augmenter. Introduced in 1.5 ([#12103]).                         |
-| `preview_overload_order`    | Enable more robust ordering between def overloads. Introduced in 1.6 ([#10711]).               |
-| `strict_multi_assign`       | Enable strict semantics for [one-to-many assignment]. Introduced in 1.3.0 ([#11145], [#11545]) |
+| Flag name                   | Description
+| --------------------------- | -----------
+| `no_number_autocast`        | Will not [autocast] numeric expressions, only literals
+| `no_restrictions_augmenter` | Disable enhanced restrictions augmenter. Introduced in 1.5 ([#12103]).
+| `preview_overload_order`    | Enable more robust ordering between def overloads. Introduced in 1.6 ([#10711]).
+| `strict_multi_assign`       | Enable strict semantics for [one-to-many assignment]. Introduced in 1.3.0 ([#11145], [#11545])
 
 [autocast]: autocasting.md#number-autocasting
 [#12103]: https://github.com/crystal-lang/crystal/pull/12103
@@ -194,10 +194,10 @@ These flags enable or disable language features when building a Crystal program.
 
 These flags enable or disable codegen features when building a Crystal program.
 
-| Flag name                                                            | Description                                                                                             |
-| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `cf-protection=branch`, `cf-protection=return`, `cf-protection=full` | Indirect branch tracking for x86 and x86_64. Implicitly set on OpenBSD. Introduced in 1.15.0 ([#15122]) |
-| `branch-protection=bti`                                              | Indirect branch tracking for aarch64. Implicitly set on OpenBSD. Introduced in 1.15.0 ([#15122])        |
+| Flag name                                                            | Description
+| -------------------------------------------------------------------- | -----------
+| `cf-protection=branch`, `cf-protection=return`, `cf-protection=full` | Indirect branch tracking for x86 and x86_64. Implicitly set on OpenBSD. Introduced in 1.15.0 ([#15122])
+| `branch-protection=bti`                                              | Indirect branch tracking for aarch64. Implicitly set on OpenBSD. Introduced in 1.15.0 ([#15122])
 
 [#15122]: https://github.com/crystal-lang/crystal/pull/15122
 
@@ -205,13 +205,13 @@ These flags enable or disable codegen features when building a Crystal program.
 
 These flags enable or disable features when building the Crystal compiler.
 
-| Flag name              | Description                                                                                                                                                              |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `without_ffi`          | Build the compiler without `libffi`                                                                                                                                      |
-| `without_interpreter`  | Build the compiler without interpreter support                                                                                                                           |
-| `without_libxml2`      | Build the compiler without sanitization for the doc generator. [Introduced in 1.19][#14646].<br> Note: The default `Makefile` passes this flag unless `docs_sanitizer=1` |
-| `without_playground`   | Build the compiler without playground (`crystal play`)                                                                                                                   |
-| `i_know_what_im_doing` | Safety guard against involuntarily building the compiler                                                                                                                 |
+| Flag name              | Description
+| ---------------------- | -----------
+| `without_ffi`          | Build the compiler without `libffi`
+| `without_interpreter`  | Build the compiler without interpreter support
+| `without_libxml2`      | Build the compiler without sanitization for the doc generator. [Introduced in 1.19][#14646].<br> Note: The default `Makefile` passes this flag unless `docs_sanitizer=1`
+| `without_playground`   | Build the compiler without playground (`crystal play`)
+| `i_know_what_im_doing` | Safety guard against involuntarily building the compiler
 
 [#14646]: https://github.com/crystal-lang/crystal/pull/14646
 

--- a/docs/syntax_and_semantics/literals/README.md
+++ b/docs/syntax_and_semantics/literals/README.md
@@ -2,25 +2,25 @@
 
 Crystal provides several literals for creating values of some basic types.
 
-| Literal      | Sample values                                           |
-| ------------ | ------------------------------------------------------- |
-| [Nil]        | `nil`                                                   |
-| [Bool]       | `true`, `false`                                         |
-| [Integers]   | `18`, `-12`, `19_i64`, `14_u32`,`64_u8`                 |
-| [Floats]     | `1.0`, `1.0_f32`, `1e10`, `-0.5`                        |
-| [Char]       | `'a'`, `'\n'`, `'あ'`                                   |
-| [String]     | `"foo\tbar"`, `%("あ")`, `%q(foo #{foo})`               |
-| [Symbol]     | `:symbol`, `:"foo bar"`                                 |
-| [Array]      | `[1, 2, 3]`, `[1, 2, 3] of Int32`, `%w(one two three)`  |
-| [Array-like] | `Set{1, 2, 3}`                                          |
-| [Hash]       | `{"foo" => 2}`, `{} of String => Int32`                 |
-| [Hash-like]  | `MyType{"foo" => "bar"}`                                |
-| [Range]      | `1..9`, `1...10`, `0..var`                              |
-| [Regex]      | `/(foo)?bar/`, `/foo #{foo}/imx`, `%r(foo/)`            |
-| [Tuple]      | `{1, "hello", 'x'}`                                     |
-| [NamedTuple] | `{name: "Crystal", year: 2011}`, `{"this is a key": 1}` |
-| [Proc]       | `->(x : Int32, y : Int32) { x + y }`                    |
-| [Command]    | `` `echo foo` ``, `%x(echo foo)`                        |
+| Literal      | Sample values
+| ------------ | -------------
+| [Nil]        | `nil`
+| [Bool]       | `true`, `false`
+| [Integers]   | `18`, `-12`, `19_i64`, `14_u32`,`64_u8`
+| [Floats]     | `1.0`, `1.0_f32`, `1e10`, `-0.5`
+| [Char]       | `'a'`, `'\n'`, `'あ'`
+| [String]     | `"foo\tbar"`, `%("あ")`, `%q(foo #{foo})`
+| [Symbol]     | `:symbol`, `:"foo bar"`
+| [Array]      | `[1, 2, 3]`, `[1, 2, 3] of Int32`, `%w(one two three)`
+| [Array-like] | `Set{1, 2, 3}`
+| [Hash]       | `{"foo" => 2}`, `{} of String => Int32`
+| [Hash-like]  | `MyType{"foo" => "bar"}`
+| [Range]      | `1..9`, `1...10`, `0..var`
+| [Regex]      | `/(foo)?bar/`, `/foo #{foo}/imx`, `%r(foo/)`
+| [Tuple]      | `{1, "hello", 'x'}`
+| [NamedTuple] | `{name: "Crystal", year: 2011}`, `{"this is a key": 1}`
+| [Proc]       | `->(x : Int32, y : Int32) { x + y }`
+| [Command]    | `` `echo foo` ``, `%x(echo foo)`
 
 [Nil]: nil.md
 [Bool]: bool.md

--- a/docs/syntax_and_semantics/literals/integers.md
+++ b/docs/syntax_and_semantics/literals/integers.md
@@ -2,18 +2,18 @@
 
 There are five signed integer types, and five unsigned integer types:
 
-| Type | Length | Minimum Value | Maximum Value |
-| ---- | -----: | ------------: | ------------: |
-| [Int8] | 8 | -128 | 127 |
-| [Int16] | 16 | −32,768 | 32,767 |
-| [Int32] | 32 | −2,147,483,648 | 2,147,483,647 |
-| [Int64] | 64 | −2<sup>63</sup> | 2<sup>63</sup> - 1 |
-| [Int128] | 128 | −2<sup>127</sup> | 2<sup>127</sup> - 1 |
-| [UInt8] | 8 | 0 | 255 |
-| [UInt16] | 16 | 0 | 65,535 |
-| [UInt32] | 32 | 0 | 4,294,967,295 |
-| [UInt64] | 64 | 0 | 2<sup>64</sup> - 1 |
-| [UInt128] | 128 | 0 | 2<sup>128</sup> - 1 |
+| Type      | Length |    Minimum Value |       Maximum Value |
+| --------- | -----: | ---------------: | ------------------: |
+| [Int8]    |      8 |             -128 |                 127 |
+| [Int16]   |     16 |          −32,768 |              32,767 |
+| [Int32]   |     32 |   −2,147,483,648 |       2,147,483,647 |
+| [Int64]   |     64 |  −2<sup>63</sup> |  2<sup>63</sup> - 1 |
+| [Int128]  |    128 | −2<sup>127</sup> | 2<sup>127</sup> - 1 |
+| [UInt8]   |      8 |                0 |                 255 |
+| [UInt16]  |     16 |                0 |              65,535 |
+| [UInt32]  |     32 |                0 |       4,294,967,295 |
+| [UInt64]  |     64 |                0 |  2<sup>64</sup> - 1 |
+| [UInt128] |    128 |                0 | 2<sup>128</sup> - 1 |
 
 [Int8]: https://crystal-lang.org/api/Int8.html
 [Int16]: https://crystal-lang.org/api/Int16.html

--- a/docs/syntax_and_semantics/operators.md
+++ b/docs/syntax_and_semantics/operators.md
@@ -111,24 +111,24 @@ ones.
 
 <!-- markdownlint-disable no-space-in-code -->
 
-| Category                 | Operators                                                                                                                                      |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| Index accessors          | `[]`, `[]?`                                                                                                                                    |
-| Unary                    | `+`, `&+`, `-`, `&-`, `!`, `~`                                                                                                                 |
-| Exponential              | `**`, `&**`                                                                                                                                    |
-| Multiplicative           | `*`, `&*`, `/`, `//`, `%`                                                                                                                      |
-| Additive                 | `+`, `&+`, `-`, `&-`                                                                                                                           |
-| Shift                    | `<<`, `>>`                                                                                                                                     |
-| Binary AND               | `&`                                                                                                                                            |
-| Binary OR/XOR            | <code>\|</code>,`^`                                                                                                                            |
-| Equality and Subsumption | `==`, `!=`, `=~`, `!~`, `===`                                                                                                                  |
-| Comparison               | `<`, `<=`, `>`, `>=`, `<=>`                                                                                                                    |
-| Logical AND              | `&&`                                                                                                                                           |
-| Logical OR               | <code>\|\|</code>                                                                                                                              |
-| Range                    | `..`, `...`                                                                                                                                    |
-| Conditional              | `?:`                                                                                                                                           |
-| Assignment               | `=`, `[]=`, `+=`, `&+=`, `-=`, `&-=`, `*=`, `&*=`, `/=`, `//=`, `%=`, <code>\|=</code>, `&=`,`^=`,`**=`,`<<=`,`>>=`, <code>\|\|=</code>, `&&=` |
-| Splat                    | `*`, `**`                                                                                                                                      |
+| Category                 | Operators
+| ------------------------ | ---------
+| Index accessors          | `[]`, `[]?`
+| Unary                    | `+`, `&+`, `-`, `&-`, `!`, `~`
+| Exponential              | `**`, `&**`
+| Multiplicative           | `*`, `&*`, `/`, `//`, `%`
+| Additive                 | `+`, `&+`, `-`, `&-`
+| Shift                    | `<<`, `>>`
+| Binary AND               | `&`
+| Binary OR/XOR            | <code>\|</code>,`^`
+| Equality and Subsumption | `==`, `!=`, `=~`, `!~`, `===`
+| Comparison               | `<`, `<=`, `>`, `>=`, `<=>`
+| Logical AND              | `&&`
+| Logical OR               | <code>\|\|</code>
+| Range                    | `..`, `...`
+| Conditional              | `?:`
+| Assignment               | `=`, `[]=`, `+=`, `&+=`, `-=`, `&-=`, `*=`, `&*=`, `/=`, `//=`, `%=`, <code>\|=</code>, `&=`,`^=`,`**=`,`<<=`,`>>=`, <code>\|\|=</code>, `&&=`
+| Splat                    | `*`, `**`
 
 <!-- markdownlint-enable no-space-in-code -->
 
@@ -138,55 +138,55 @@ ones.
 
 #### Unary
 
-| Operator | Description       | Example | Overloadable | Associativity |
-| -------- | ----------------- | ------- | ------------ | ------------- |
-| `+`      | positive          | `+1`    | yes          | right         |
-| `&+`     | wrapping positive | `&+1`   | yes          | right         |
-| `-`      | negative          | `-1`    | yes          | right         |
-| `&-`     | wrapping negative | `&-1`   | yes          | right         |
+| Operator | Description       | Example | Overloadable | Associativity
+| -------- | ----------------- | ------- | ------------ | -------------
+| `+`      | positive          | `+1`    | yes          | right
+| `&+`     | wrapping positive | `&+1`   | yes          | right
+| `-`      | negative          | `-1`    | yes          | right
+| `&-`     | wrapping negative | `&-1`   | yes          | right
 
 #### Multiplicative
 
-| Operator | Description             | Example   | Overloadable | Associativity |
-| -------- | ----------------------- | --------- | ------------ | ------------- |
-| `**`     | exponentiation          | `1 ** 2`  | yes          | right         |
-| `&**`    | wrapping exponentiation | `1 &** 2` | yes          | right         |
-| `*`      | multiplication          | `1 * 2`   | yes          | left          |
-| `&*`     | wrapping multiplication | `1 &* 2`  | yes          | left          |
-| `/`      | division                | `1 / 2`   | yes          | left          |
-| `//`     | floor division          | `1 // 2`  | yes          | left          |
-| `%`      | modulus                 | `1 % 2`   | yes          | left          |
+| Operator | Description             | Example   | Overloadable | Associativity
+| -------- | ----------------------- | --------- | ------------ | -------------
+| `**`     | exponentiation          | `1 ** 2`  | yes          | right
+| `&**`    | wrapping exponentiation | `1 &** 2` | yes          | right
+| `*`      | multiplication          | `1 * 2`   | yes          | left
+| `&*`     | wrapping multiplication | `1 &* 2`  | yes          | left
+| `/`      | division                | `1 / 2`   | yes          | left
+| `//`     | floor division          | `1 // 2`  | yes          | left
+| `%`      | modulus                 | `1 % 2`   | yes          | left
 
 #### Additive
 
-| Operator | Description          | Example  | Overloadable | Associativity |
-| -------- | -------------------- | -------- | ------------ | ------------- |
-| `+`      | addition             | `1 + 2`  | yes          | left          |
-| `&+`     | wrapping addition    | `1 &+ 2` | yes          | left          |
-| `-`      | subtraction          | `1 - 2`  | yes          | left          |
-| `&-`     | wrapping subtraction | `1 &- 2` | yes          | left          |
+| Operator | Description          | Example  | Overloadable | Associativity
+| -------- | -------------------- | -------- | ------------ | -------------
+| `+`      | addition             | `1 + 2`  | yes          | left
+| `&+`     | wrapping addition    | `1 &+ 2` | yes          | left
+| `-`      | subtraction          | `1 - 2`  | yes          | left
+| `&-`     | wrapping subtraction | `1 &- 2` | yes          | left
 
 ### Other unary operators
 
-| Operator | Description       | Example | Overloadable | Associativity |
-| -------- | ----------------- | ------- | ------------ | ------------- |
-| `!`      | inversion         | `!true` | no           | right         |
-| `~`      | binary complement | `~1`    | yes          | right         |
+| Operator | Description       | Example | Overloadable | Associativity
+| -------- | ----------------- | ------- | ------------ | -------------
+| `!`      | inversion         | `!true` | no           | right
+| `~`      | binary complement | `~1`    | yes          | right
 
 ### Shifts
 
-| Operator | Description        | Example                     | Overloadable | Associativity |
-| -------- | ------------------ | --------------------------- | ------------ | ------------- |
-| `<<`     | shift left, append | `1 << 2`, `STDOUT << "foo"` | yes          | left          |
-| `>>`     | shift right        | `1 >> 2`                    | yes          | left          |
+| Operator | Description        | Example                     | Overloadable | Associativity
+| -------- | ------------------ | --------------------------- | ------------ | -------------
+| `<<`     | shift left, append | `1 << 2`, `STDOUT << "foo"` | yes          | left
+| `>>`     | shift right        | `1 >> 2`                    | yes          | left
 
 ### Binary
 
-| Operator        | Description | Example             | Overloadable | Associativity |
-| --------------- | ----------- | ------------------- | ------------ | ------------- |
-| `&`             | binary AND  | `1 & 2`             | yes          | left          |
-| <code>\|</code> | binary OR   | <code>1 \| 2</code> | yes          | left          |
-| `^`             | binary XOR  | `1 ^ 2`             | yes          | left          |
+| Operator        | Description | Example             | Overloadable | Associativity
+| --------------- | ----------- | ------------------- | ------------ | -------------
+| `&`             | binary AND  | `1 & 2`             | yes          | left
+| <code>\|</code> | binary OR   | <code>1 \| 2</code> | yes          | left
+| `^`             | binary XOR  | `1 ^ 2`             | yes          | left
 
 ### Relational operators
 
@@ -211,10 +211,10 @@ Both operators are expected to be commutative, i.e. `a == b` if and only if
 `b == a`. This is not enforced by the compiler and implementing types must
 take care themselves.
 
-| Operator | Description | Example  | Overloadable | Associativity |
-| -------- | ----------- | -------- | ------------ | ------------- |
-| `==`     | equal       | `1 == 2` | yes          | left          |
-| `!=`     | not equal   | `1 != 2` | yes          | left          |
+| Operator | Description | Example  | Overloadable | Associativity
+| -------- | ----------- | -------- | ------------ | -------------
+| `==`     | equal       | `1 == 2` | yes          | left
+| `!=`     | not equal   | `1 != 2` | yes          | left
 
 > INFO: The standard library defines [`Reference#same?`](https://crystal-lang.org/api/Reference.html#same?(other:Reference):Bool-instance-method) as another equality
 > test that is not an operator.
@@ -231,13 +231,13 @@ The **three-way comparison operator** `<=>` (also known as *spaceship operator*)
 expresses the order between two elements expressed by the sign of its
 return value.
 
-| Operator | Description          | Example   | Overloadable | Associativity |
-| -------- | -------------------- | --------- | ------------ | ------------- |
-| `<`      | less                 | `1 < 2`   | yes          | left          |
-| `<=`     | less or equal        | `1 <= 2`  | yes          | left          |
-| `>`      | greater              | `1 > 2`   | yes          | left          |
-| `>=`     | greater or equal     | `1 >= 2`  | yes          | left          |
-| `<=>`    | three-way comparison | `1 <=> 2` | yes          | left          |
+| Operator | Description          | Example   | Overloadable | Associativity
+| -------- | -------------------- | --------- | ------------ | -------------
+| `<`      | less                 | `1 < 2`   | yes          | left
+| `<=`     | less or equal        | `1 <= 2`  | yes          | left
+| `>`      | greater              | `1 > 2`   | yes          | left
+| `>=`     | greater or equal     | `1 >= 2`  | yes          | left
+| `<=>`    | three-way comparison | `1 <=> 2` | yes          | left
 
 > INFO: The standard library defines the [`Comparable`](https://crystal-lang.org/api/Comparable.html) module which derives all other inequality operators as well as
 > the equal operator from the three-way comparison operator.
@@ -258,11 +258,11 @@ The compiler inserts this operator in [`case ... when` conditions](case.md).
 
 There is no inverse operator.
 
-| Operator | Description      | Example           | Overloadable | Associativity |
-| -------- | ---------------- | ----------------- | ------------ | ------------- |
-| `=~`     | pattern match    | `"foo" =~ /fo/`   | yes          | left          |
-| `!~`     | no pattern match | `"foo" !~ /fo/`   | yes          | left          |
-| `===`    | case subsumption | `/foo/ === "foo"` | yes          | left          |
+| Operator | Description      | Example           | Overloadable | Associativity
+| -------- | ---------------- | ----------------- | ------------ | -------------
+| `=~`     | pattern match    | `"foo" =~ /fo/`   | yes          | left
+| `!~`     | no pattern match | `"foo" !~ /fo/`   | yes          | left
+| `===`    | case subsumption | `/foo/ === "foo"` | yes          | left
 
 #### Chaining relational operators
 
@@ -280,39 +280,39 @@ For instance, `a == b <= c` is equivalent to `a == b && b <= c`, while `a <= b =
 
 ### Logical
 
-| Operator          | Description           | Example                      | Overloadable | Associativity |
-| ----------------- | --------------------- | ---------------------------- | ------------ | ------------- |
-| `&&`              | [logical AND](and.md) | `true && false`              | no           | left          |
-| <code>\|\|</code> | [logical OR](or.md)   | <code>true \|\| false</code> | no           | left          |
+| Operator          | Description           | Example                      | Overloadable | Associativity
+| ----------------- | --------------------- | ---------------------------- | ------------ | -------------
+| `&&`              | [logical AND](and.md) | `true && false`              | no           | left
+| <code>\|\|</code> | [logical OR](or.md)   | <code>true \|\| false</code> | no           | left
 
 ### Range
 
 The range operators are used in [Range](literals/range.md)
 literals.
 
-| Operator | Description     | Example  | Overloadable |
-| -------- | --------------- | -------- | ------------ |
-| `..`     | inclusive range | `1..10`  | no           |
-| `...`    | exclusive range | `1...10` | no           |
+| Operator | Description     | Example  | Overloadable
+| -------- | --------------- | -------- | ------------
+| `..`     | inclusive range | `1..10`  | no
+| `...`    | exclusive range | `1...10` | no
 
 ### Splats
 
 Splat operators can only be used for destructing tuples in method arguments.
 See [Splats and Tuples](splats_and_tuples.md) for details.
 
-| Operator | Description  | Example | Overloadable |
-| -------- | ------------ | ------- | ------------ |
-| `*`      | splat        | `*foo`  | no           |
-| `**`     | double splat | `**foo` | no           |
+| Operator | Description  | Example | Overloadable
+| -------- | ------------ | ------- | ------------
+| `*`      | splat        | `*foo`  | no
+| `**`     | double splat | `**foo` | no
 
 ### Conditional
 
 The [conditional operator (`? :`)](./ternary_if.md) is internally rewritten to
 an `if` expression by the compiler.
 
-| Operator | Description | Example          | Overloadable | Associativity |
-| -------- | ----------- | ---------------- | ------------ | ------------- |
-| `? :`    | conditional | `a == b ? c : d` | no           | right         |
+| Operator | Description | Example          | Overloadable | Associativity
+| -------- | ----------- | ---------------- | ------------ | -------------
+| `? :`    | conditional | `a == b ? c : d` | no           | right
 
 ### Assignments
 
@@ -321,11 +321,11 @@ operand. The first operand is either a variable (in this case the operator can't
 be redefined) or a call (in this case the operator can be redefined).
 See [assignment](assignment.md) for details.
 
-| Operator | Description         | Example    | Overloadable | Associativity |
-| -------- | ------------------- | ---------- | ------------ | ------------- |
-| `=`      | variable assignment | `a = 1`    | no           | right         |
-| `=`      | call assignment     | `a.b = 1`  | yes          | right         |
-| `[]=`    | index assignment    | `a[0] = 1` | yes          | right         |
+| Operator | Description         | Example    | Overloadable | Associativity
+| -------- | ------------------- | ---------- | ------------ | -------------
+| `=`      | variable assignment | `a = 1`    | no           | right
+| `=`      | call assignment     | `a.b = 1`  | yes          | right
+| `[]=`    | index assignment    | `a[0] = 1` | yes          | right
 
 ### Combined assignments
 
@@ -351,25 +351,25 @@ be callable.
 
 The receiver can't be anything else than a variable or call.
 
-| Operator           | Description                              | Example                   | Overloadable | Associativity |
-| ------------------ | ---------------------------------------- | ------------------------- | ------------ | ------------- |
-| `+=`               | addition *and* assignment                | `i += 1`                  | no           | right         |
-| `&+=`              | wrapping addition *and* assignment       | `i &+= 1`                 | no           | right         |
-| `-=`               | subtraction *and* assignment             | `i -= 1`                  | no           | right         |
-| `&-=`              | wrapping subtraction *and* assignment    | `i &-= 1`                 | no           | right         |
-| `*=`               | multiplication *and* assignment          | `i *= 1`                  | no           | right         |
-| `&*=`              | wrapping multiplication *and* assignment | `i &*= 1`                 | no           | right         |
-| `/=`               | division *and* assignment                | `i /= 1`                  | no           | right         |
-| `//=`              | floor division *and* assignment          | `i //= 1`                 | no           | right         |
-| `%=`               | modulo *and* assignment                  | `i %= 1`                  | yes          | right         |
-| <code>\|=</code>   | binary or *and* assignment               | <code>i \|= 1</code>      | no           | right         |
-| `&=`               | binary and *and* assignment              | `i &= 1`                  | no           | right         |
-| `^=`               | binary xor *and* assignment              | `i ^= 1`                  | no           | right         |
-| `**=`              | exponential *and* assignment             | `i **= 1`                 | no           | right         |
-| `<<=`              | left shift *and* assignment              | `i <<= 1`                 | no           | right         |
-| `>>=`              | right shift *and* assignment             | `i >>= 1`                 | no           | right         |
-| <code>\|\|=</code> | logical or *and* assignment              | <code>i \|\|= true</code> | no           | right         |
-| `&&=`              | logical and *and* assignment             | `i &&= true`              | no           | right         |
+| Operator           | Description                              | Example                   | Overloadable | Associativity
+| ------------------ | ---------------------------------------- | ------------------------- | ------------ | -------------
+| `+=`               | addition *and* assignment                | `i += 1`                  | no           | right
+| `&+=`              | wrapping addition *and* assignment       | `i &+= 1`                 | no           | right
+| `-=`               | subtraction *and* assignment             | `i -= 1`                  | no           | right
+| `&-=`              | wrapping subtraction *and* assignment    | `i &-= 1`                 | no           | right
+| `*=`               | multiplication *and* assignment          | `i *= 1`                  | no           | right
+| `&*=`              | wrapping multiplication *and* assignment | `i &*= 1`                 | no           | right
+| `/=`               | division *and* assignment                | `i /= 1`                  | no           | right
+| `//=`              | floor division *and* assignment          | `i //= 1`                 | no           | right
+| `%=`               | modulo *and* assignment                  | `i %= 1`                  | yes          | right
+| <code>\|=</code>   | binary or *and* assignment               | <code>i \|= 1</code>      | no           | right
+| `&=`               | binary and *and* assignment              | `i &= 1`                  | no           | right
+| `^=`               | binary xor *and* assignment              | `i ^= 1`                  | no           | right
+| `**=`              | exponential *and* assignment             | `i **= 1`                 | no           | right
+| `<<=`              | left shift *and* assignment              | `i <<= 1`                 | no           | right
+| `>>=`              | right shift *and* assignment             | `i >>= 1`                 | no           | right
+| <code>\|\|=</code> | logical or *and* assignment              | <code>i \|\|= true</code> | no           | right
+| `&&=`              | logical and *and* assignment             | `i &&= true`              | no           | right
 
 ### Index Accessors
 
@@ -379,7 +379,7 @@ the index is not found, while the non-nilable variant raises in that case.
 Implementations in the standard-library usually raise [`KeyError`](https://crystal-lang.org/api/KeyError.html)
 or [`IndexError`](https://crystal-lang.org/api/IndexError.html).
 
-| Operator | Description            | Example   | Overloadable |
-| -------- | ---------------------- | --------- | ------------ |
-| `[]`     | index accessor         | `ary[i]`  | yes          |
-| `[]?`    | nilable index accessor | `ary[i]?` | yes          |
+| Operator | Description            | Example   | Overloadable
+| -------- | ---------------------- | --------- | ------------
+| `[]`     | index accessor         | `ary[i]`  | yes
+| `[]?`    | nilable index accessor | `ary[i]?` | yes

--- a/docs/syntax_and_semantics/operators.md
+++ b/docs/syntax_and_semantics/operators.md
@@ -111,24 +111,24 @@ ones.
 
 <!-- markdownlint-disable no-space-in-code -->
 
-| Category | Operators |
-| -------- | --------- |
-| Index accessors | `[]`, `[]?` |
-| Unary | `+`, `&+`, `-`, `&-`, `!`, `~` |
-| Exponential | `**`, `&**` |
-| Multiplicative | `*`, `&*`, `/`, `//`, `%` |
-| Additive | `+`, `&+`, `-`, `&-` |
-| Shift | `<<`, `>>` |
-| Binary AND | `&` |
-| Binary OR/XOR | <code>\|</code>,`^` |
-| Equality and Subsumption | `==`, `!=`, `=~`, `!~`, `===` |
-| Comparison | `<`, `<=`, `>`, `>=`, `<=>` |
-| Logical AND | `&&` |
-| Logical OR | <code>\|\|</code> |
-| Range | `..`, `...` |
-| Conditional | `?:` |
-| Assignment | `=`, `[]=`, `+=`, `&+=`, `-=`, `&-=`, `*=`, `&*=`, `/=`, `//=`, `%=`, <code>\|=</code>, `&=`,`^=`,`**=`,`<<=`,`>>=`, <code>\|\|=</code>, `&&=` |
-| Splat | `*`, `**` |
+| Category                 | Operators                                                                                                                                      |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Index accessors          | `[]`, `[]?`                                                                                                                                    |
+| Unary                    | `+`, `&+`, `-`, `&-`, `!`, `~`                                                                                                                 |
+| Exponential              | `**`, `&**`                                                                                                                                    |
+| Multiplicative           | `*`, `&*`, `/`, `//`, `%`                                                                                                                      |
+| Additive                 | `+`, `&+`, `-`, `&-`                                                                                                                           |
+| Shift                    | `<<`, `>>`                                                                                                                                     |
+| Binary AND               | `&`                                                                                                                                            |
+| Binary OR/XOR            | <code>\|</code>,`^`                                                                                                                            |
+| Equality and Subsumption | `==`, `!=`, `=~`, `!~`, `===`                                                                                                                  |
+| Comparison               | `<`, `<=`, `>`, `>=`, `<=>`                                                                                                                    |
+| Logical AND              | `&&`                                                                                                                                           |
+| Logical OR               | <code>\|\|</code>                                                                                                                              |
+| Range                    | `..`, `...`                                                                                                                                    |
+| Conditional              | `?:`                                                                                                                                           |
+| Assignment               | `=`, `[]=`, `+=`, `&+=`, `-=`, `&-=`, `*=`, `&*=`, `/=`, `//=`, `%=`, <code>\|=</code>, `&=`,`^=`,`**=`,`<<=`,`>>=`, <code>\|\|=</code>, `&&=` |
+| Splat                    | `*`, `**`                                                                                                                                      |
 
 <!-- markdownlint-enable no-space-in-code -->
 
@@ -138,55 +138,55 @@ ones.
 
 #### Unary
 
-| Operator | Description | Example | Overloadable | Associativity |
-| -------- | ----------- | ------- | ------------ | ------------- |
-| `+` | positive | `+1` | yes | right |
-| `&+` | wrapping positive | `&+1` | yes | right |
-| `-` | negative | `-1` | yes | right |
-| `&-` | wrapping negative | `&-1` | yes | right |
+| Operator | Description       | Example | Overloadable | Associativity |
+| -------- | ----------------- | ------- | ------------ | ------------- |
+| `+`      | positive          | `+1`    | yes          | right         |
+| `&+`     | wrapping positive | `&+1`   | yes          | right         |
+| `-`      | negative          | `-1`    | yes          | right         |
+| `&-`     | wrapping negative | `&-1`   | yes          | right         |
 
 #### Multiplicative
 
-| Operator | Description | Example | Overloadable | Associativity |
-| -------- | ----------- | ------- | ------------ | ------------- |
-| `**` | exponentiation | `1 ** 2` | yes | right |
-| `&**` | wrapping exponentiation | `1 &** 2` | yes | right |
-| `*` | multiplication | `1 * 2` | yes | left |
-| `&*` | wrapping multiplication | `1 &* 2` | yes | left |
-| `/` | division | `1 / 2` | yes | left |
-| `//` | floor division | `1 // 2` | yes | left |
-| `%` | modulus | `1 % 2` | yes | left |
+| Operator | Description             | Example   | Overloadable | Associativity |
+| -------- | ----------------------- | --------- | ------------ | ------------- |
+| `**`     | exponentiation          | `1 ** 2`  | yes          | right         |
+| `&**`    | wrapping exponentiation | `1 &** 2` | yes          | right         |
+| `*`      | multiplication          | `1 * 2`   | yes          | left          |
+| `&*`     | wrapping multiplication | `1 &* 2`  | yes          | left          |
+| `/`      | division                | `1 / 2`   | yes          | left          |
+| `//`     | floor division          | `1 // 2`  | yes          | left          |
+| `%`      | modulus                 | `1 % 2`   | yes          | left          |
 
 #### Additive
 
-| Operator | Description | Example | Overloadable | Associativity |
-| -------- | ----------- | ------- | ------------ | ------------- |
-| `+` | addition | `1 + 2` | yes | left |
-| `&+` | wrapping addition | `1 &+ 2` | yes | left |
-| `-` | subtraction | `1 - 2` | yes | left |
-| `&-` | wrapping subtraction | `1 &- 2` | yes | left |
+| Operator | Description          | Example  | Overloadable | Associativity |
+| -------- | -------------------- | -------- | ------------ | ------------- |
+| `+`      | addition             | `1 + 2`  | yes          | left          |
+| `&+`     | wrapping addition    | `1 &+ 2` | yes          | left          |
+| `-`      | subtraction          | `1 - 2`  | yes          | left          |
+| `&-`     | wrapping subtraction | `1 &- 2` | yes          | left          |
 
 ### Other unary operators
 
-| Operator | Description | Example | Overloadable | Associativity |
-| -------- | ----------- | ------- | ------------ | ------------- |
-| `!` | inversion | `!true` | no | right |
-| `~` | binary complement | `~1` | yes | right |
+| Operator | Description       | Example | Overloadable | Associativity |
+| -------- | ----------------- | ------- | ------------ | ------------- |
+| `!`      | inversion         | `!true` | no           | right         |
+| `~`      | binary complement | `~1`    | yes          | right         |
 
 ### Shifts
 
-| Operator | Description | Example | Overloadable | Associativity |
-| -------- | ----------- | ------- | ------------ | ------------- |
-| `<<` | shift left, append | `1 << 2`, `STDOUT << "foo"` | yes | left |
-| `>>` | shift right | `1 >> 2` | yes | left |
+| Operator | Description        | Example                     | Overloadable | Associativity |
+| -------- | ------------------ | --------------------------- | ------------ | ------------- |
+| `<<`     | shift left, append | `1 << 2`, `STDOUT << "foo"` | yes          | left          |
+| `>>`     | shift right        | `1 >> 2`                    | yes          | left          |
 
 ### Binary
 
-| Operator | Description | Example | Overloadable | Associativity |
-| -------- | ----------- | ------- | ------------ | ------------- |
-| `&` | binary AND | `1 & 2` | yes | left |
-| <code>\|</code> | binary OR | <code>1 \| 2</code> | yes | left |
-| `^` | binary XOR | `1 ^ 2` | yes | left |
+| Operator        | Description | Example             | Overloadable | Associativity |
+| --------------- | ----------- | ------------------- | ------------ | ------------- |
+| `&`             | binary AND  | `1 & 2`             | yes          | left          |
+| <code>\|</code> | binary OR   | <code>1 \| 2</code> | yes          | left          |
+| `^`             | binary XOR  | `1 ^ 2`             | yes          | left          |
 
 ### Relational operators
 
@@ -211,10 +211,10 @@ Both operators are expected to be commutative, i.e. `a == b` if and only if
 `b == a`. This is not enforced by the compiler and implementing types must
 take care themselves.
 
-| Operator | Description | Example | Overloadable | Associativity |
-| -------- | ----------- | ------- | ------------ | ------------- |
-| `==` | equal | `1 == 2` | yes | left |
-| `!=` | not equal | `1 != 2` | yes | left |
+| Operator | Description | Example  | Overloadable | Associativity |
+| -------- | ----------- | -------- | ------------ | ------------- |
+| `==`     | equal       | `1 == 2` | yes          | left          |
+| `!=`     | not equal   | `1 != 2` | yes          | left          |
 
 > INFO: The standard library defines [`Reference#same?`](https://crystal-lang.org/api/Reference.html#same?(other:Reference):Bool-instance-method) as another equality
 > test that is not an operator.
@@ -231,13 +231,13 @@ The **three-way comparison operator** `<=>` (also known as *spaceship operator*)
 expresses the order between two elements expressed by the sign of its
 return value.
 
-| Operator | Description | Example | Overloadable | Associativity |
-| -------- | ----------- | ------- | ------------ | ------------- |
-| `<` | less | `1 < 2` | yes | left |
-| `<=` | less or equal | `1 <= 2` | yes | left |
-| `>` | greater | `1 > 2` | yes | left |
-| `>=` | greater or equal | `1 >= 2` | yes | left |
-| `<=>` | three-way comparison | `1 <=> 2` | yes | left |
+| Operator | Description          | Example   | Overloadable | Associativity |
+| -------- | -------------------- | --------- | ------------ | ------------- |
+| `<`      | less                 | `1 < 2`   | yes          | left          |
+| `<=`     | less or equal        | `1 <= 2`  | yes          | left          |
+| `>`      | greater              | `1 > 2`   | yes          | left          |
+| `>=`     | greater or equal     | `1 >= 2`  | yes          | left          |
+| `<=>`    | three-way comparison | `1 <=> 2` | yes          | left          |
 
 > INFO: The standard library defines the [`Comparable`](https://crystal-lang.org/api/Comparable.html) module which derives all other inequality operators as well as
 > the equal operator from the three-way comparison operator.
@@ -258,11 +258,11 @@ The compiler inserts this operator in [`case ... when` conditions](case.md).
 
 There is no inverse operator.
 
-| Operator | Description | Example | Overloadable | Associativity |
-| -------- | ----------- | ------- | ------------ | ------------- |
-| `=~` | pattern match | `"foo" =~ /fo/` | yes | left |
-| `!~` | no pattern match | `"foo" !~ /fo/` | yes | left |
-| `===` | case subsumption | `/foo/ === "foo"` | yes | left |
+| Operator | Description      | Example           | Overloadable | Associativity |
+| -------- | ---------------- | ----------------- | ------------ | ------------- |
+| `=~`     | pattern match    | `"foo" =~ /fo/`   | yes          | left          |
+| `!~`     | no pattern match | `"foo" !~ /fo/`   | yes          | left          |
+| `===`    | case subsumption | `/foo/ === "foo"` | yes          | left          |
 
 #### Chaining relational operators
 
@@ -280,39 +280,39 @@ For instance, `a == b <= c` is equivalent to `a == b && b <= c`, while `a <= b =
 
 ### Logical
 
-| Operator | Description | Example | Overloadable | Associativity |
-| -------- | ----------- | ------- | ------------ | ------------- |
-| `&&` | [logical AND](and.md) | `true && false` | no | left |
-| <code>\|\|</code> | [logical OR](or.md) | <code>true \|\| false</code> | no | left |
+| Operator          | Description           | Example                      | Overloadable | Associativity |
+| ----------------- | --------------------- | ---------------------------- | ------------ | ------------- |
+| `&&`              | [logical AND](and.md) | `true && false`              | no           | left          |
+| <code>\|\|</code> | [logical OR](or.md)   | <code>true \|\| false</code> | no           | left          |
 
 ### Range
 
 The range operators are used in [Range](literals/range.md)
 literals.
 
-| Operator | Description | Example | Overloadable |
-| -------- | ----------- | ------- | ------------ |
-| `..` | inclusive range | `1..10` | no |
-| `...` | exclusive range | `1...10` | no |
+| Operator | Description     | Example  | Overloadable |
+| -------- | --------------- | -------- | ------------ |
+| `..`     | inclusive range | `1..10`  | no           |
+| `...`    | exclusive range | `1...10` | no           |
 
 ### Splats
 
 Splat operators can only be used for destructing tuples in method arguments.
 See [Splats and Tuples](splats_and_tuples.md) for details.
 
-| Operator | Description | Example | Overloadable |
-| -------- | ----------- | ------- | ------------ |
-| `*` | splat | `*foo` | no |
-| `**` | double splat | `**foo` | no |
+| Operator | Description  | Example | Overloadable |
+| -------- | ------------ | ------- | ------------ |
+| `*`      | splat        | `*foo`  | no           |
+| `**`     | double splat | `**foo` | no           |
 
 ### Conditional
 
 The [conditional operator (`? :`)](./ternary_if.md) is internally rewritten to
 an `if` expression by the compiler.
 
-| Operator | Description | Example | Overloadable | Associativity |
-| -------- | ----------- | ------- | ------------ | ------------- |
-| `? :` | conditional | `a == b ? c : d` | no | right |
+| Operator | Description | Example          | Overloadable | Associativity |
+| -------- | ----------- | ---------------- | ------------ | ------------- |
+| `? :`    | conditional | `a == b ? c : d` | no           | right         |
 
 ### Assignments
 
@@ -321,11 +321,11 @@ operand. The first operand is either a variable (in this case the operator can't
 be redefined) or a call (in this case the operator can be redefined).
 See [assignment](assignment.md) for details.
 
-| Operator | Description | Example | Overloadable | Associativity |
-| -------- | ----------- | ------- | ------------ | ------------- |
-| `=` | variable assignment | `a = 1` | no | right |
-| `=` | call assignment | `a.b = 1` | yes | right |
-| `[]=` | index assignment | `a[0] = 1` | yes | right |
+| Operator | Description         | Example    | Overloadable | Associativity |
+| -------- | ------------------- | ---------- | ------------ | ------------- |
+| `=`      | variable assignment | `a = 1`    | no           | right         |
+| `=`      | call assignment     | `a.b = 1`  | yes          | right         |
+| `[]=`    | index assignment    | `a[0] = 1` | yes          | right         |
 
 ### Combined assignments
 
@@ -351,25 +351,25 @@ be callable.
 
 The receiver can't be anything else than a variable or call.
 
-| Operator | Description | Example | Overloadable | Associativity |
-| -------- | ----------- | ------- | ------------ | ------------- |
-| `+=` | addition *and* assignment | `i += 1` | no | right |
-| `&+=` | wrapping addition *and* assignment | `i &+= 1` | no | right |
-| `-=` | subtraction *and* assignment | `i -= 1` | no | right |
-| `&-=` | wrapping subtraction *and* assignment | `i &-= 1` | no | right |
-| `*=` | multiplication *and* assignment | `i *= 1` | no | right |
-| `&*=` | wrapping multiplication *and* assignment | `i &*= 1` | no | right |
-| `/=` | division *and* assignment | `i /= 1` | no | right |
-| `//=` | floor division *and* assignment | `i //= 1` | no | right |
-| `%=` | modulo *and* assignment | `i %= 1` | yes | right |
-| <code>\|=</code> | binary or *and* assignment | <code>i \|= 1</code> | no | right |
-| `&=` | binary and *and* assignment | `i &= 1` | no | right |
-| `^=` | binary xor *and* assignment | `i ^= 1` | no | right |
-| `**=` | exponential *and* assignment | `i **= 1` | no | right |
-| `<<=` | left shift *and* assignment | `i <<= 1` | no | right |
-| `>>=` | right shift *and* assignment | `i >>= 1` | no | right |
-| <code>\|\|=</code> | logical or *and* assignment | <code>i \|\|= true</code> | no | right |
-| `&&=` | logical and *and* assignment | `i &&= true` | no | right |
+| Operator           | Description                              | Example                   | Overloadable | Associativity |
+| ------------------ | ---------------------------------------- | ------------------------- | ------------ | ------------- |
+| `+=`               | addition *and* assignment                | `i += 1`                  | no           | right         |
+| `&+=`              | wrapping addition *and* assignment       | `i &+= 1`                 | no           | right         |
+| `-=`               | subtraction *and* assignment             | `i -= 1`                  | no           | right         |
+| `&-=`              | wrapping subtraction *and* assignment    | `i &-= 1`                 | no           | right         |
+| `*=`               | multiplication *and* assignment          | `i *= 1`                  | no           | right         |
+| `&*=`              | wrapping multiplication *and* assignment | `i &*= 1`                 | no           | right         |
+| `/=`               | division *and* assignment                | `i /= 1`                  | no           | right         |
+| `//=`              | floor division *and* assignment          | `i //= 1`                 | no           | right         |
+| `%=`               | modulo *and* assignment                  | `i %= 1`                  | yes          | right         |
+| <code>\|=</code>   | binary or *and* assignment               | <code>i \|= 1</code>      | no           | right         |
+| `&=`               | binary and *and* assignment              | `i &= 1`                  | no           | right         |
+| `^=`               | binary xor *and* assignment              | `i ^= 1`                  | no           | right         |
+| `**=`              | exponential *and* assignment             | `i **= 1`                 | no           | right         |
+| `<<=`              | left shift *and* assignment              | `i <<= 1`                 | no           | right         |
+| `>>=`              | right shift *and* assignment             | `i >>= 1`                 | no           | right         |
+| <code>\|\|=</code> | logical or *and* assignment              | <code>i \|\|= true</code> | no           | right         |
+| `&&=`              | logical and *and* assignment             | `i &&= true`              | no           | right         |
 
 ### Index Accessors
 
@@ -379,7 +379,7 @@ the index is not found, while the non-nilable variant raises in that case.
 Implementations in the standard-library usually raise [`KeyError`](https://crystal-lang.org/api/KeyError.html)
 or [`IndexError`](https://crystal-lang.org/api/IndexError.html).
 
-| Operator | Description | Example | Overloadable |
-| -------- | ----------- | ------- | ------------ |
-| `[]` | index accessor | `ary[i]` | yes |
-| `[]?` | nilable index accessor | `ary[i]?` | yes |
+| Operator | Description            | Example   | Overloadable |
+| -------- | ---------------------- | --------- | ------------ |
+| `[]`     | index accessor         | `ary[i]`  | yes          |
+| `[]?`    | nilable index accessor | `ary[i]?` | yes          |

--- a/docs/syntax_and_semantics/platform_support.md
+++ b/docs/syntax_and_semantics/platform_support.md
@@ -17,12 +17,12 @@ Tier 1 platforms can be thought of as “guaranteed to work”. Specifically the
 Only maintained operating system versions are fully supported. Obsolete versions are not guaranteed to work
 and drop into *Tier 2*.
 
-| Target              | Description                       | Supported versions                                                      | Comment                                                                              |
-| ------------------- | --------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `aarch64-darwin`    | Aarch64 macOS<br> (Apple Silicon) | 11+ *(testing only on 14)*                                              | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds |
-| `x86_64-darwin`     | x64 macOS<br> (Intel)             | 11+<br> *(testing only on 13; expected to work on 10.7+)*               | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds |
-| `x86_64-linux-gnu`  | x64 Linux                         | kernel 4.14+, GNU libc 2.26+<br> *(expected to work on kernel 2.6.22+)* | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds |
-| `x86_64-linux-musl` | x64 Linux                         | kernel 4.14+, MUSL libc 1.2+<br> *(expected to work on kernel 2.6.22+)* | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds |
+| Target              | Description                       | Supported versions                                                      | Comment
+| ------------------- | --------------------------------- | ----------------------------------------------------------------------- | -------
+| `aarch64-darwin`    | Aarch64 macOS<br> (Apple Silicon) | 11+ *(testing only on 14)*                                              | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds
+| `x86_64-darwin`     | x64 macOS<br> (Intel)             | 11+<br> *(testing only on 13; expected to work on 10.7+)*               | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds
+| `x86_64-linux-gnu`  | x64 Linux                         | kernel 4.14+, GNU libc 2.26+<br> *(expected to work on kernel 2.6.22+)* | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds
+| `x86_64-linux-musl` | x64 Linux                         | kernel 4.14+, MUSL libc 1.2+<br> *(expected to work on kernel 2.6.22+)* | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds
 
 ***
 
@@ -33,15 +33,15 @@ Tier 2 platforms can be thought of as “expected to work”.
 The requirements for *Tier 1* may be partially fulfilled, but are lacking in some way that prevents a solid guarantee.
 Details are described in the *Comment* column.
 
-| Target                | Description                   | Supported versions                                                      | Comment                                                                         |
-| --------------------- | ----------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `aarch64-linux-gnu`   | Aarch64 Linux                 | GNU libc 2.26+                                                          | :material-checkbox-marked-circle: tests<br> :material-selection-ellipse: builds |
-| `aarch64-linux-musl`  | Aarch64 Linux                 | MUSL libc 1.2+                                                          | :material-checkbox-marked-circle: tests<br> :material-selection-ellipse: builds |
-| `arm-linux-gnueabihf` | Aarch32 Linux<br> (hardfloat) | GNU libc 2.26+                                                          | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds      |
-| `i386-linux-gnu`      | x86 Linux                     | kernel 4.14+, GNU libc 2.26+<br> *(expected to work on kernel 2.6.22+)* | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds      |
-| `i386-linux-musl`     | x86 Linux                     | kernel 4.14+, MUSL libc 1.2+<br> *(expected to work on kernel 2.6.22+)* | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds      |
-| `x86_64-openbsd`      | x64 OpenBSD                   | 6+                                                                      | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds      |
-| `x86_64-freebsd`      | x64 FreeBSD                   | 12+                                                                     | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds      |
+| Target                | Description                   | Supported versions                                                      | Comment
+| --------------------- | ----------------------------- | ----------------------------------------------------------------------- | -------
+| `aarch64-linux-gnu`   | Aarch64 Linux                 | GNU libc 2.26+                                                          | :material-checkbox-marked-circle: tests<br> :material-selection-ellipse: builds
+| `aarch64-linux-musl`  | Aarch64 Linux                 | MUSL libc 1.2+                                                          | :material-checkbox-marked-circle: tests<br> :material-selection-ellipse: builds
+| `arm-linux-gnueabihf` | Aarch32 Linux<br> (hardfloat) | GNU libc 2.26+                                                          | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds
+| `i386-linux-gnu`      | x86 Linux                     | kernel 4.14+, GNU libc 2.26+<br> *(expected to work on kernel 2.6.22+)* | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds
+| `i386-linux-musl`     | x86 Linux                     | kernel 4.14+, MUSL libc 1.2+<br> *(expected to work on kernel 2.6.22+)* | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds
+| `x86_64-openbsd`      | x64 OpenBSD                   | 6+                                                                      | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds
+| `x86_64-freebsd`      | x64 FreeBSD                   | 12+                                                                     | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds
 
 ***
 
@@ -52,25 +52,25 @@ Tier 3 platforms can be thought of as “partially works”.
 The Crystal codebase has support for these platforms, but there are some major limitations.
 Most typically, some parts of the standard library are not supported completely.
 
-| Target                     | Description               | Supported versions                                     | Comment                                                                      |
-| -------------------------- | ------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------- |
-| `x86_64-windows-msvc`      | x64 Windows (MSVC)        | 7+                                                     | :material-circle-slice-7: tests<br> :material-checkbox-marked-circle: builds |
-| `x86_64-windows-gnu`       | x64 Windows (MinGW-w64)   | 7+, MSYS2 `UCRT64` / `MINGW64` / `CLANG64` environment | :material-circle-slice-7: tests<br> :material-checkbox-marked-circle: builds |
-| `aarch64-windows-msvc`     | ARM64 Windows (MSVC)      | 11+                                                    | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds   |
-| `aarch64-windows-gnu`      | ARM64 Windows (MinGW-w64) | 11+, MSYS2 `CLANGARM64` environment                    | :material-circle-slice-7: tests<br> :material-checkbox-marked-circle: builds |
-| `aarch64-linux-android`    | aarch64 Android           | Bionic C runtime, API level 24+                        | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds   |
-| `x86_64-unknown-dragonfly` | x64 DragonFlyBSD          |                                                        | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds   |
-| `x86_64-unknown-netbsd`    | x64 NetBSD                |                                                        | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds   |
-| `wasm32-unknown-wasi`      | WebAssembly (WASI libc)   | Wasmtime 2+                                            | :material-circle-slice-5: tests                                              |
-| `x86_64-solaris`           | Solaris/illumos           |                                                        | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds   |
+| Target                     | Description               | Supported versions                                     | Comment
+| -------------------------- | ------------------------- | ------------------------------------------------------ | -------
+| `x86_64-windows-msvc`      | x64 Windows (MSVC)        | 7+                                                     | :material-circle-slice-7: tests<br> :material-checkbox-marked-circle: builds
+| `x86_64-windows-gnu`       | x64 Windows (MinGW-w64)   | 7+, MSYS2 `UCRT64` / `MINGW64` / `CLANG64` environment | :material-circle-slice-7: tests<br> :material-checkbox-marked-circle: builds
+| `aarch64-windows-msvc`     | ARM64 Windows (MSVC)      | 11+                                                    | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds
+| `aarch64-windows-gnu`      | ARM64 Windows (MinGW-w64) | 11+, MSYS2 `CLANGARM64` environment                    | :material-circle-slice-7: tests<br> :material-checkbox-marked-circle: builds
+| `aarch64-linux-android`    | aarch64 Android           | Bionic C runtime, API level 24+                        | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds
+| `x86_64-unknown-dragonfly` | x64 DragonFlyBSD          |                                                        | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds
+| `x86_64-unknown-netbsd`    | x64 NetBSD                |                                                        | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds
+| `wasm32-unknown-wasi`      | WebAssembly (WASI libc)   | Wasmtime 2+                                            | :material-circle-slice-5: tests
+| `x86_64-solaris`           | Solaris/illumos           |                                                        | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds
 
 ## Compiler support
 
 The compiler can target these platforms but there is no support for the standard library (i.e. must compile with `--prelude=empty`).
 
-| Target                | Description                                                                                                         | Supported versions | Comment |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------ | ------- |
-| `avr-unknown-unknown` | AVR (Atmel) CPU architecture (Arduino)<br>This target requires declaration of a CPU model (e.g. `--mcpu=atmega328`) |                    |         |
+| Target                | Description                                                                                                         | Supported versions | Comment
+| --------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------ | -------
+| `avr-unknown-unknown` | AVR (Atmel) CPU architecture (Arduino)<br>This target requires declaration of a CPU model (e.g. `--mcpu=atmega328`) |                    | &nbsp;
 
 !!! info "Legend"
     <ul>

--- a/docs/syntax_and_semantics/platform_support.md
+++ b/docs/syntax_and_semantics/platform_support.md
@@ -17,12 +17,12 @@ Tier 1 platforms can be thought of as “guaranteed to work”. Specifically the
 Only maintained operating system versions are fully supported. Obsolete versions are not guaranteed to work
 and drop into *Tier 2*.
 
-| Target | Description | Supported versions | Comment |
-| ------ | ----------- | ------------------ | ------- |
-| `aarch64-darwin` | Aarch64 macOS<br> (Apple Silicon) | 11+ *(testing only on 14)* | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds |
-| `x86_64-darwin` | x64 macOS<br> (Intel) | 11+<br> *(testing only on 13; expected to work on 10.7+)* | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds |
-| `x86_64-linux-gnu` | x64 Linux | kernel 4.14+, GNU libc 2.26+<br> *(expected to work on kernel 2.6.22+)* | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds |
-| `x86_64-linux-musl` | x64 Linux | kernel 4.14+, MUSL libc 1.2+<br> *(expected to work on kernel 2.6.22+)* | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds |
+| Target              | Description                       | Supported versions                                                      | Comment                                                                              |
+| ------------------- | --------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `aarch64-darwin`    | Aarch64 macOS<br> (Apple Silicon) | 11+ *(testing only on 14)*                                              | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds |
+| `x86_64-darwin`     | x64 macOS<br> (Intel)             | 11+<br> *(testing only on 13; expected to work on 10.7+)*               | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds |
+| `x86_64-linux-gnu`  | x64 Linux                         | kernel 4.14+, GNU libc 2.26+<br> *(expected to work on kernel 2.6.22+)* | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds |
+| `x86_64-linux-musl` | x64 Linux                         | kernel 4.14+, MUSL libc 1.2+<br> *(expected to work on kernel 2.6.22+)* | :material-checkbox-marked-circle: tests<br> :material-checkbox-marked-circle: builds |
 
 ***
 
@@ -33,15 +33,15 @@ Tier 2 platforms can be thought of as “expected to work”.
 The requirements for *Tier 1* may be partially fulfilled, but are lacking in some way that prevents a solid guarantee.
 Details are described in the *Comment* column.
 
-| Target | Description | Supported versions | Comment |
-| ------ | ----------- | ------------------ | ------- |
-| `aarch64-linux-gnu` | Aarch64 Linux | GNU libc 2.26+ | :material-checkbox-marked-circle: tests<br> :material-selection-ellipse: builds |
-| `aarch64-linux-musl` | Aarch64 Linux | MUSL libc 1.2+ | :material-checkbox-marked-circle: tests<br> :material-selection-ellipse: builds |
-| `arm-linux-gnueabihf` | Aarch32 Linux<br> (hardfloat) | GNU libc 2.26+ | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds |
-| `i386-linux-gnu` | x86 Linux | kernel 4.14+, GNU libc 2.26+<br> *(expected to work on kernel 2.6.22+)* | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds |
-| `i386-linux-musl` | x86 Linux | kernel 4.14+, MUSL libc 1.2+<br> *(expected to work on kernel 2.6.22+)* | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds |
-| `x86_64-openbsd` | x64 OpenBSD | 6+ | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds |
-| `x86_64-freebsd` | x64 FreeBSD | 12+ | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds |
+| Target                | Description                   | Supported versions                                                      | Comment                                                                         |
+| --------------------- | ----------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `aarch64-linux-gnu`   | Aarch64 Linux                 | GNU libc 2.26+                                                          | :material-checkbox-marked-circle: tests<br> :material-selection-ellipse: builds |
+| `aarch64-linux-musl`  | Aarch64 Linux                 | MUSL libc 1.2+                                                          | :material-checkbox-marked-circle: tests<br> :material-selection-ellipse: builds |
+| `arm-linux-gnueabihf` | Aarch32 Linux<br> (hardfloat) | GNU libc 2.26+                                                          | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds      |
+| `i386-linux-gnu`      | x86 Linux                     | kernel 4.14+, GNU libc 2.26+<br> *(expected to work on kernel 2.6.22+)* | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds      |
+| `i386-linux-musl`     | x86 Linux                     | kernel 4.14+, MUSL libc 1.2+<br> *(expected to work on kernel 2.6.22+)* | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds      |
+| `x86_64-openbsd`      | x64 OpenBSD                   | 6+                                                                      | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds      |
+| `x86_64-freebsd`      | x64 FreeBSD                   | 12+                                                                     | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds      |
 
 ***
 
@@ -52,25 +52,25 @@ Tier 3 platforms can be thought of as “partially works”.
 The Crystal codebase has support for these platforms, but there are some major limitations.
 Most typically, some parts of the standard library are not supported completely.
 
-| Target | Description | Supported versions | Comment |
-| ------ | ----------- | ------------------ | ------- |
-| `x86_64-windows-msvc` | x64 Windows (MSVC) | 7+ | :material-circle-slice-7: tests<br> :material-checkbox-marked-circle: builds |
-| `x86_64-windows-gnu` | x64 Windows (MinGW-w64) | 7+, MSYS2 `UCRT64` / `MINGW64` / `CLANG64` environment | :material-circle-slice-7: tests<br> :material-checkbox-marked-circle: builds |
-| `aarch64-windows-msvc` | ARM64 Windows (MSVC) | 11+ | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds |
-| `aarch64-windows-gnu` | ARM64 Windows (MinGW-w64) | 11+, MSYS2 `CLANGARM64` environment | :material-circle-slice-7: tests<br> :material-checkbox-marked-circle: builds |
-| `aarch64-linux-android` | aarch64 Android | Bionic C runtime, API level 24+ | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds |
-| `x86_64-unknown-dragonfly` | x64 DragonFlyBSD | | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds |
-| `x86_64-unknown-netbsd` | x64 NetBSD | | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds |
-| `wasm32-unknown-wasi` | WebAssembly (WASI libc) | Wasmtime 2+ | :material-circle-slice-5: tests |
-| `x86_64-solaris` | Solaris/illumos | | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds |
+| Target                     | Description               | Supported versions                                     | Comment                                                                      |
+| -------------------------- | ------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| `x86_64-windows-msvc`      | x64 Windows (MSVC)        | 7+                                                     | :material-circle-slice-7: tests<br> :material-checkbox-marked-circle: builds |
+| `x86_64-windows-gnu`       | x64 Windows (MinGW-w64)   | 7+, MSYS2 `UCRT64` / `MINGW64` / `CLANG64` environment | :material-circle-slice-7: tests<br> :material-checkbox-marked-circle: builds |
+| `aarch64-windows-msvc`     | ARM64 Windows (MSVC)      | 11+                                                    | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds   |
+| `aarch64-windows-gnu`      | ARM64 Windows (MinGW-w64) | 11+, MSYS2 `CLANGARM64` environment                    | :material-circle-slice-7: tests<br> :material-checkbox-marked-circle: builds |
+| `aarch64-linux-android`    | aarch64 Android           | Bionic C runtime, API level 24+                        | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds   |
+| `x86_64-unknown-dragonfly` | x64 DragonFlyBSD          |                                                        | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds   |
+| `x86_64-unknown-netbsd`    | x64 NetBSD                |                                                        | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds   |
+| `wasm32-unknown-wasi`      | WebAssembly (WASI libc)   | Wasmtime 2+                                            | :material-circle-slice-5: tests                                              |
+| `x86_64-solaris`           | Solaris/illumos           |                                                        | :material-selection-ellipse: tests<br> :material-selection-ellipse: builds   |
 
 ## Compiler support
 
 The compiler can target these platforms but there is no support for the standard library (i.e. must compile with `--prelude=empty`).
 
-| Target | Description | Supported versions | Comment |
-| ------ | ----------- | ------------------ | ------- |
-| `avr-unknown-unknown` | AVR (Atmel) CPU architecture (Arduino)<br>This target requires declaration of a CPU model (e.g. `--mcpu=atmega328`) | | |
+| Target                | Description                                                                                                         | Supported versions | Comment |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------ | ------- |
+| `avr-unknown-unknown` | AVR (Atmel) CPU architecture (Arduino)<br>This target requires declaration of a CPU model (e.g. `--mcpu=atmega328`) |                    |         |
 
 !!! info "Legend"
     <ul>


### PR DESCRIPTION
This table format aligns all pipe characters at the same column, which makes for a tabular layout even in the source code.
It's not strictly better than the previous compact format. It certainly causes longer line lengths.
But I think the alignment improves readability. The cost for that is sometimes you need horizontal scroll. But I prefer that clarity over the tightly compressed text.

We don't necessarily need to apply the same format to all tables. We can leave the markdownlint configuration at default (`any`) and format tables differently.
But I actually prefer this format for all current tables.