### PR TITLE
Fix `scripts/validate-flags.sh` to recognize flag values

### DIFF
--- a/scripts/validate-flags.sh
+++ b/scripts/validate-flags.sh
@@ -14,7 +14,7 @@ filter_missing() {
   missing=0
 
   while read -r word; do
-      grep -q "\`$word\`" docs/syntax_and_semantics/compile_time_flags.md || {
+      grep -q "\`${word}[\`=]" docs/syntax_and_semantics/compile_time_flags.md || {
         [ ${missing} -eq 0 ] && echo "# Missing ${1} flags:"
         echo "$word"
         missing=1


### PR DESCRIPTION
Compiler flags (`-Dname=value`) were added in Crystal 1.19 (crystal-lang/crystal#16301).

[#163010]: https://github.com/crystal-lang/crystal/pull/16310