### PR TITLE
Fix `retry_delay` default value in connection_pool.md

### DIFF
--- a/docs/database/connection_pool.md
+++ b/docs/database/connection_pool.md
@@ -40,7 +40,7 @@ The behavior of the pool can be configured from a set of parameters that can app
 | max\_idle\_pool\_size | 1
 | checkout\_timeout     | 5.0 \(seconds\)
 | retry\_attempts       | 1
-| retry\_delay          | 1.0 \(seconds\)
+| retry\_delay          | 0.2 \(seconds\)
 
 When `DB::Database` is opened an initial number of `initial_pool_size` connections will be created. The pool will never hold more than `max_pool_size` connections. When returning/releasing a connection to the pool it will be closed if there are already `max_idle_pool_size` idle connections.
 


### PR DESCRIPTION
Fixed doc to show the correct retry_delay default.

Actual default can be seen: https://github.com/crystal-lang/crystal-db/blob/master/src/db/pool.cr#L19

PR raised on that repo to fix doc string too: https://github.com/crystal-lang/crystal-db/pull/230