### PR TITLE
Drop `-Duse_pcre2` flag for Crystal 1.21

### DIFF
--- a/docs/syntax_and_semantics/compile_time_flags.md
+++ b/docs/syntax_and_semantics/compile_time_flags.md
@@ -160,7 +160,6 @@ Crystal program.
 | `skip_crystal_compiler_rt`                         | Exclude Crystal's native `compiler-rt` implementation.
 | `tracing`                                          | Build with support for [runtime tracing].
 | `use_libiconv`                                     | Use `libiconv` instead of the `iconv` system library
-| `use_pcre2`                                        | Use PCRE2 as regex engine (instead of legacy PCRE). Introduced in 1.7.0.
 | `use_pcre`                                         | Use PCRE as regex engine (instead of PCRE2). Introduced in 1.8.0.
 | `win7`                                             | Use Win32 WinNT API for Windows 7
 | `without_iconv`                                    | Do not link `iconv`/`libiconv`


### PR DESCRIPTION
`-Duse_pcre2` was dropped in https://github.com/crystal-lang/crystal/pull/16924 and is now the default