### PR TITLE
Bind dev server to 0.0.0.0 to allow cross-device connections

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_url: https://crystal-lang.org/reference/latest/
 repo_url: https://github.com/crystal-lang/crystal
 edit_uri: https://github.com/crystal-lang/crystal-book/edit/master/docs/
 use_directory_urls: false
+dev_addr: 0.0.0.0:8000
 
 extra:
   alternate:


### PR DESCRIPTION
By default, the dev server listens only on 127.0.0.1 which makes it impossible to preview the site directly from other devices than the one where the server runs (e.g. phone, VMs).