### PR TITLE
Replace `markdownlint` with `rumdl`

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,29 +1,73 @@
+# Indicators for comment annotations:
+#
+# * `Disabled`: The rule is disabled because it does not seem useful for this repo (or in general).
+# * `BUG`: A bug prevents using this rule either entirely or for specific files.
+# * `FIXME`: The rule seems useful, but requires some effort to resolve. That's deferred for later.
+# * `TODO`: The rule might be useful, but we need to investigate whether we want to use it or not.
+
 default: true
 
-no-inline-html: false
-line-length: false
+## Heading Rules
 
+# MD003 - Heading style should be consistent
+heading-style:
+  style: "atx"
+
+## List Rules
+
+# MD029 - Use consistent numbers for ordered lists
 ol-prefix:
   style: "ordered"
+
+# MD004 - Unordered list style should be consistent
+# TODO: Should be `dash` for consistency
 ul-style:
   style: "asterisk"
+
+# MD007 - Keep list indentation consistent
 ul-indent:
   indent: 4 # Python-Markdown requires 4 indent
 
+## Whitespace Rules
+
+# MD013 - Line length
+# TODO: We might want to consider automatic wrapping (maybe with https://github.com/razziel89/mdslw ?)
+line-length: false
+
+# MD064 - No Multiple Consecutive Spaces
+no-multiple-consecutive-spaces:
+  allow-sentence-double-space: true
+
+## Formatting Rules
+
+# MD033 - No HTML tags
+# TODO: We shouldn't need inline HTML
+no-inline-html: false
+
+# MD038 - No space in code
+# FIXME: Bug in rumdl: https://github.com/rvben/rumdl/issues/665
+no-space-in-code: false
+
+# MD049 - Keep italic text formatting consistent
+# TODO: Should be `underscore` for consistency
 emphasis-style:
   style: "asterisk"
+
+# MD050 - Keep bold text formatting consistent
 strong-style:
   style: "asterisk"
 
-no-duplicate-heading:
-  siblings_only: true
+## Link and Image Rules
+
+# MD034 - Bare URL used
 no-bare-urls: false
 
-fenced-code-language: false
+## Code Block Rules
+
+# MD014 - Show command output in documentation
+# TODO: Fix command output
 commands-show-output: false
 
-table-column-style:
-  style: aligned
-
-no-multiple-consecutive-spaces:
-  allow-sentence-double-space: true
+# MD040 - Code blocks should have a language specified
+# FIXME: We should always specify a language for proper syntax highlighting.
+fenced-code-language: false

--- a/devenv.nix
+++ b/devenv.nix
@@ -25,7 +25,7 @@
     actionlint.enable = true;
     check-toml.enable = true;
     check-vcs-permalinks.enable = true;
-    markdownlint.enable = true;
+    rumdl.enable = true;
     shellcheck = {
       enable = true;
       excludes = [


### PR DESCRIPTION
[rumdl](https://rumdl.dev/) is a Markdown linter similar to [markdownlint](https://github.com/igorshubovych/markdownlint-cli) but with some significant improvements.
It is compatible with markdownlint, supporting the same rules and configuration as before. It's a drop-in replacement with more performance (Rust vs Javascript).
And it brings a bunch of additional rules and features, such as per-file-ignores.
See https://rumdl.dev/markdownlint-comparison/ for a full comparison.

Also standardizes the configuration format, without any relevant changes.
We'll migrate to `rumdl.toml` in a follow-up.

We already applied the same change in https://github.com/crystal-lang/crystal-website/pull/1082 and https://github.com/crystal-lang/crystal/pull/17069