### PR TITLE
Replace `mkdocs` with `properdocs`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 OUTPUT_DIR ?= ./site ## Build directory (default: ./site)
 
-MKDOCS ?= mkdocs
+MKDOCS ?= properdocs
 
 DOCS_FILES := $(shell find docs -type f)
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ devenv shell build
 Building shell ...
 pre-commit-hooks.nix: hooks up to date
 rm -rf ./site
-mkdocs build -d ./site  --strict
+properdocs build -d ./site  --strict
 INFO     -  Cleaning site directory
 INFO     -  Building documentation to directory: ./site
 INFO     -  Documentation built in 2.43 seconds
@@ -96,7 +96,7 @@ Entering shell ...
 
 pre-commit-hooks.nix: hooks up to date
 $(devenv) make build
-mkdocs build -d ./site  --strict
+properdocs build -d ./site  --strict
 INFO     -  Cleaning site directory
 INFO     -  Building documentation to directory: ./site
 INFO     -  Documentation built in 2.43 seconds

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 # https://app.netlify.com is used to build deploy previews for every PR
 # This file documents the settings. Each value overrides anything configured in Netlify's Config UI
 [build]
-  command = "mkdocs build -d site --strict"
+  command = "properdocs build -d site --strict"
   publish = "site/"
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-mkdocs>=1.6.0
+properdocs>=1.6.0
 markdown-callouts>=0.2.0
 mkdocs-material>=8.0.5
 mkdocs-literate-nav>=0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,6 @@ mergedeep==1.3.4
     #   mkdocs-get-deps
 mkdocs==1.6.1
     # via
-    #   -r requirements.in
     #   mkdocs-code-validator
     #   mkdocs-literate-nav
     #   mkdocs-material
@@ -86,6 +85,7 @@ platformdirs==4.9.4
     #   properdocs
 properdocs==1.6.7
     # via
+    #   -r requirements.in
     #   mkdocs-code-validator
     #   mkdocs-literate-nav
     #   mkdocs-redirects


### PR DESCRIPTION
Mkdocs no longer receives any updates and the maintainer has announced a version 2 which will be incompatible and unusable for our purposes. See https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/

https://github.com/ProperDocs/properdocs is a fork that keeps compatibility and receives maintenance. It's a drop-in replacement for mkdocs.

Ref https://github.com/crystal-lang/crystal-book/issues/861#issuecomment-4992495820