### PR TITLE
Fix MD014: Show command output in documentation

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -62,10 +62,6 @@ no-bare-urls: false
 
 ## Code Block Rules
 
-# MD014 - Show command output in documentation
-# TODO: Fix command output
-commands-show-output: false
-
 # MD040 - Code blocks should have a language specified
 # FIXME: We should always specify a language for proper syntax highlighting.
 fenced-code-language: false

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Typically, only branches of maintained releases receive updates, i.e. the branch
 
 ### Building and Serving Locally
 
-```console
-$ git clone https://github.com/crystal-lang/crystal-book
-$ cd crystal-book
-$ pip install -r requirements.txt
+```shell
+git clone https://github.com/crystal-lang/crystal-book
+cd crystal-book
+pip install -r requirements.txt
 ```
 
 Live preview (at http://127.0.0.1:8000):
@@ -51,8 +51,8 @@ INFO    -  Serving on http://127.0.0.1:8000
 
 Build into the `site` directory (some functionality won't work if opening the files locally):
 
-```console
-$ make build
+```shell
+make build
 ```
 
 ### devenv environment
@@ -104,8 +104,8 @@ INFO     -  Documentation built in 2.43 seconds
 
 Run pre-commit checks on the entire repository:
 
-```console
-$ devenv ci
+```shell
+devenv ci
 ```
 
 ### Adding a page

--- a/docs/crystal_for_rubyists/README.md
+++ b/docs/crystal_for_rubyists/README.md
@@ -26,16 +26,16 @@ It looks like `crystal` interprets the file, but what actually happens is that t
 
 If you just want to compile it you can use the `build` command:
 
-```console
-$ crystal build foo.cr
+```shell
+crystal build foo.cr
 ```
 
 This creates a `foo` executable, which you can then run with `./foo`.
 
 Note that this creates an executable that is not optimized. To optimize it, pass the `--release` flag:
 
-```console
-$ crystal build foo.cr --release
+```shell
+crystal build foo.cr --release
 ```
 
 When writing benchmarks or testing performance, always remember to compile in release mode.

--- a/docs/guides/hosting/github.md
+++ b/docs/guides/hosting/github.md
@@ -4,22 +4,22 @@
 
 - Add and commit everything:
 
-    ```console
-    $ git add -A && git commit -am "shard complete"
+    ```shell
+    git add -A && git commit -am "shard complete"
     ```
 
 - Add the remote: (Be sure to replace `<YOUR-GITHUB-USERNAME>` and `<YOUR-REPOSITORY-NAME>` accordingly)
 
     NOTE: If you like, feel free to replace `public` with `origin`, or a remote name of your choosing.
 
-    ```console
-    $ git remote add public https://github.com/<YOUR-GITHUB-NAME>/<YOUR-REPOSITORY-NAME>.git
+    ```shell
+    git remote add public https://github.com/<YOUR-GITHUB-NAME>/<YOUR-REPOSITORY-NAME>.git
     ```
 
 - Push it:
 
-    ```console
-    $ git push public master
+    ```shell
+    git push public master
     ```
 
 ## GitHub Releases

--- a/docs/guides/hosting/gitlab.md
+++ b/docs/guides/hosting/gitlab.md
@@ -2,28 +2,28 @@
 
 - Add and commit everything:
 
-    ```console
-    $ git add -A && git commit -am "shard complete"
+    ```shell
+    git add -A && git commit -am "shard complete"
     ```
 
 - Create a GitLab project with the same `name` and `description` as specified in your `shard.yml`.
 
 - Add the remote: (Be sure to replace `<YOUR-GITLAB-USERNAME>` and `<YOUR-REPOSITORY-NAME>` accordingly)
 
-    ```console
-    $ git remote add origin https://gitlab.com/<YOUR-GITLAB-USERNAME>/<YOUR-REPOSITORY-NAME>.git
+    ```shell
+    git remote add origin https://gitlab.com/<YOUR-GITLAB-USERNAME>/<YOUR-REPOSITORY-NAME>.git
     ```
 
     or if you use SSH
 
-    ```console
-    $ git remote add origin git@gitlab.com:<YOUR-GITLAB-USERNAME>/<YOUR-REPOSITORY-NAME>.git
+    ```shell
+    git remote add origin git@gitlab.com:<YOUR-GITLAB-USERNAME>/<YOUR-REPOSITORY-NAME>.git
     ```
 
 - Push it:
 
-    ```console
-    $ git push origin master
+    ```shell
+    git push origin master
     ```
 
 ## Pipelines
@@ -70,8 +70,8 @@ The `before_script` and `cache` keys in the file are for running the same script
 
 If you commit the above file to your project and push, you'll trigger your first run of the new pipeline.
 
-```console
-$ git add -A && git commit -am 'Add .gitlab-ci.yml' && git push origin master
+```shell
+git add -A && git commit -am 'Add .gitlab-ci.yml' && git push origin master
 ```
 
 ### Some Badges
@@ -103,14 +103,14 @@ As you'll see from the [releases docs](https://docs.gitlab.com/ee/workflow/relea
 
 or you can create the tag from the command line like so:
 
-```console
-$ git tag -a v0.1.0 -m "Release v0.1.0"
+```shell
+git tag -a v0.1.0 -m "Release v0.1.0"
 ```
 
 push it up
 
-```console
-$ git push origin master --follow-tags
+```shell
+git push origin master --follow-tags
 ```
 
 and then use the UI to add/edit the release note and attach files.

--- a/docs/man/crystal/README.md
+++ b/docs/man/crystal/README.md
@@ -28,8 +28,8 @@ Hello World!
 
 By default, the generated executables are not fully optimized. The `--release` flag can be used to enable optimizations.
 
-```console
-$ crystal build hello_world.cr --release
+```shell
+crystal build hello_world.cr --release
 ```
 
 Compiling without release mode is much faster and the resulting binaries still offer pretty good performance.
@@ -43,8 +43,8 @@ To reduce the binary size for distributable files, the `--no-debug` flag can be 
 
 The `--static` flag can be used to build a statically-linked executable:
 
-```console
-$ crystal build hello_world.cr --release --static
+```shell
+crystal build hello_world.cr --release --static
 ```
 
 NOTE: Building fully statically linked executables is currently only supported on Alpine Linux.


### PR DESCRIPTION
Most of the time, the `console` tag was used incorrectly instead of `shell`.