### PR TITLE
Fix correctly describe argument matching in lib calls

### DIFF
--- a/docs/syntax_and_semantics/autocasting.md
+++ b/docs/syntax_and_semantics/autocasting.md
@@ -57,6 +57,9 @@ end
 Foo.new.set_x 1 # Error: "at line 5: instance variable '@x' of Foo must be Int64, not Int32"
 ```
 
+Arguments in lib calls have implicit [matching and conversion rules](../syntax_and_semantics/c_bindings/fun.md#argument-matching-and-conversions),
+with similar effects to autocasting. They can even be more extensive.
+
 ## Symbol autocasting
 
 Symbols are autocasted as enum members, therefore enabling to write them more succinctly:

--- a/docs/syntax_and_semantics/c_bindings/fun.md
+++ b/docs/syntax_and_semantics/c_bindings/fun.md
@@ -45,7 +45,22 @@ end
 X.variadic(1, 2, 3, 4)
 ```
 
-Note that there are no implicit conversions (except `to_unsafe`, which is explained later) when invoking a C function: you must pass the exact type that is expected. For integers and floats you can use the various `to_...` methods.
+## Argument matching and conversions
+
+There are some special rules about matching argument types for lib types,
+as well as some implicit conversions.
+
+- `Nil` matches any pointer or proc type.
+- Any proc type matches the same proc type with `Nil` output type.
+- Any pointer type matches a void pointer type.
+- Number literals autocast to any primitive number type.
+- Primitive number types automatically converts to any other primitive number
+  type if a respective `#to_#{kind}!` method exists (such as `Float64#to_i64!`).
+  In contrast to [number autocasting](../autocasting.md), these implicit
+  conversions are unsafe and can lose significant information.
+- Any type that implements [`#to_unsafe`](./to_unsafe.md) automatically converts
+  to the return value of that method. The above mentioned matching rules apply to
+  the result.
 
 ## Function names
 


### PR DESCRIPTION
The previous description is incorrect. Numeric types autoconvert between each other, covering even more conversions than autocasting does.

I'm a bit surprised about this behaviour as it's dangerously unsafe and risks losing relevant information without a huge benefit (as far as I am aware).